### PR TITLE
Use non-breaking hyphen U+2011 for page-range-delimiter in French locales

### DIFF
--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -66,7 +66,7 @@
     <term name="close-quote">&#160;»</term>
     <term name="open-inner-quote">“</term>
     <term name="close-inner-quote">”</term>
-    <term name="page-range-delimiter">–</term>
+    <term name="page-range-delimiter">‑</term>
 
     <!-- ORDINALS -->
     <term name="ordinal">ᵉ</term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -66,7 +66,7 @@
     <term name="close-quote">&#160;»</term>
     <term name="open-inner-quote">“</term>
     <term name="close-inner-quote">”</term>
-    <term name="page-range-delimiter">–</term>
+    <term name="page-range-delimiter">‑</term>
 
     <!-- ORDINALS -->
     <term name="ordinal">ᵉ</term>


### PR DESCRIPTION
From a thread recovered by Rintze, it looks like I set up citeproc-js to use a hyphen for page range delimiters back in February. Reviewing the thread, it looks like U+2011 is the more correct value. Now that we've made the jump to CSL 1.0.1, here it is.
