### PR TITLE
Update locales-cs-CZ.xml

### DIFF
--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -13,7 +13,7 @@
   <date form="numeric">
     <date-part name="day" form="numeric" suffix=". " range-delimiter="-"/>
     <date-part name="month" form="numeric" suffix=". " range-delimiter="-"/>
-    <date-part name="year" form="numeric" range-delimiter="-"/>
+    <date-part name="year" range-delimiter="-"/>
   </date>
   <terms>
     <term name="accessed">přístup</term>


### PR DESCRIPTION
Changed date form Numeric. I the Czech Republic common style is:: 
"day. month. year" e.g. 9. 10. 2013 with space after dot. Form without space is also available.

Form "year-month-day" is not so common, it is usually used in formal correspondence.

Standard delimiter is "-" e.g. 8.-15. 12. 2013
but in this case must be delimiter with space " - ": 8. 6. - 15. 6. 2013
Source: http://prirucka.ujc.cas.cz/?id=810&dotaz=datum (The Institute of the Czech Language of the Academy of Sciences of the Czech Republic, p.r.i.)
