### PR TITLE
Add number-of-pages to locale by copying pages

### DIFF
--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -130,6 +130,10 @@
       <single>bladsy</single>
       <multiple>bladsye</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>bladsy</single>
+      <multiple>bladsye</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraaf</single>
       <multiple>paragrawe</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>bl</single>
+      <multiple>bll</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>bl</single>
       <multiple>bll</multiple>
     </term>

--- a/locales-ar-AR.xml
+++ b/locales-ar-AR.xml
@@ -124,6 +124,10 @@
       <single>صفحة</single>
       <multiple>صفحات</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>صفحة</single>
+      <multiple>صفحات</multiple>
+    </term>
     <term name="paragraph">
       <single>فقرة</single>
       <multiple>فقرات</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">نوتة موسيقية</term>
     <term name="page" form="short">
+      <single>ص</single>
+      <multiple>ص.ص.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>ص</single>
       <multiple>ص.ص.</multiple>
     </term>

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -130,6 +130,10 @@
       <single>страница</single>
       <multiple>страници</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>страница</single>
+      <multiple>страници</multiple>
+    </term>
     <term name="paragraph">
       <single>параграф</single>
       <multiple>параграфи</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">оп</term>
     <term name="page" form="short">
+      <single>с</single>
+      <multiple>с-ци</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>с</single>
       <multiple>с-ци</multiple>
     </term>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -124,6 +124,10 @@
       <single>pàgina</single>
       <multiple>pàgines</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>pàgina</single>
+      <multiple>pàgines</multiple>
+    </term>
     <term name="paragraph">
       <single>paràgraf</single>
       <multiple>paràgrafs</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>p.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
     </term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -125,6 +125,10 @@
       <single>strana</single>
       <multiple>strany</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>strana</single>
+      <multiple>strany</multiple>
+    </term>
     <term name="paragraph">
       <single>odstavec</single>
       <multiple>odstavce</multiple>
@@ -161,6 +165,10 @@
     <term name="note" form="short">pozn.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>s.</single>
+      <multiple>s.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -124,6 +124,10 @@
       <single>side</single>
       <multiple>sider</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>side</single>
+      <multiple>sider</multiple>
+    </term>
     <term name="paragraph">
       <single>afsnit</single>
       <multiple>afsnit</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>s.</single>
+      <multiple>s.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -124,6 +124,10 @@
       <single>Seite</single>
       <multiple>Seiten</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>Seite</single>
+      <multiple>Seiten</multiple>
+    </term>
     <term name="paragraph">
       <single>Absatz</single>
       <multiple>Absätze</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>S.</single>
+      <multiple>S.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>S.</single>
       <multiple>S.</multiple>
     </term>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -124,6 +124,10 @@
       <single>Seite</single>
       <multiple>Seiten</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>Seite</single>
+      <multiple>Seiten</multiple>
+    </term>
     <term name="paragraph">
       <single>Absatz</single>
       <multiple>Absätze</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>S.</single>
+      <multiple>S.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>S.</single>
       <multiple>S.</multiple>
     </term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -124,6 +124,10 @@
       <single>Seite</single>
       <multiple>Seiten</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>Seite</single>
+      <multiple>Seiten</multiple>
+    </term>
     <term name="paragraph">
       <single>Absatz</single>
       <multiple>Absätze</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>S.</single>
+      <multiple>S.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>S.</single>
       <multiple>S.</multiple>
     </term>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -124,6 +124,10 @@
       <single>σελίδα</single>
       <multiple>σελίδες</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>σελίδα</single>
+      <multiple>σελίδες</multiple>
+    </term>
     <term name="paragraph">
       <single>παράγραφος</single>
       <multiple>παράγραφοι</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">έργ.</term>
     <term name="page" form="short">
+      <single>σ</single>
+      <multiple>σσ</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>σ</single>
       <multiple>σσ</multiple>
     </term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -130,6 +130,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraph</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -130,6 +130,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraph</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -124,6 +124,10 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>página</single>
+      <multiple>páginas</multiple>
+    </term>
     <term name="paragraph">
       <single>párrafo</single>
       <multiple>párrafos</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -124,6 +124,10 @@
       <single>lehekülg</single>
       <multiple>leheküljed</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>lehekülg</single>
+      <multiple>leheküljed</multiple>
+    </term>
     <term name="paragraph">
       <single>lõik</single>
       <multiple>lõigud</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>lk</single>
+      <multiple>lk</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>lk</single>
       <multiple>lk</multiple>
     </term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -124,6 +124,10 @@
       <single>orrialdea</single>
       <multiple>orrialdeak</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>orrialdea</single>
+      <multiple>orrialdeak</multiple>
+    </term>
     <term name="paragraph">
       <single>paragrafoa</single>
       <multiple>paragrafoak</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>or.</single>
+      <multiple>or.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>or.</single>
       <multiple>or.</multiple>
     </term>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -130,6 +130,10 @@
       <single>صفحه</single>
       <multiple>صفحات</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>صفحه</single>
+      <multiple>صفحات</multiple>
+    </term>
     <term name="paragraph">
       <single>پاراگراف</single>
       <multiple>پاراگراف‌های</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">قطعه</term>
     <term name="page" form="short">
+      <single>ص</single>
+      <multiple>صص</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>ص</single>
       <multiple>صص</multiple>
     </term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -124,6 +124,10 @@
       <single>sivu</single>
       <multiple>sivut</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>sivu</single>
+      <multiple>sivut</multiple>
+    </term>
     <term name="paragraph">
       <single>kappale</single>
       <multiple>kappaleet</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>s.</single>
+      <multiple>ss.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>ss.</multiple>
     </term>

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -129,6 +129,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraphe</single>
       <multiple>paragraphes</multiple>
@@ -171,6 +175,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>p.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
     </term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -129,6 +129,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraphe</single>
       <multiple>paragraphes</multiple>
@@ -171,6 +175,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>p.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
     </term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -130,6 +130,10 @@
       <single>עמוד</single>
       <multiple>עמודים</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>עמוד</single>
+      <multiple>עמודים</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>פיסקה</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>'עמ</single>
+      <multiple>'עמ</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>'עמ</single>
       <multiple>'עמ</multiple>
     </term>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -130,6 +130,10 @@
       <single>stranica</single>
       <multiple>stranice</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>stranica</single>
+      <multiple>stranice</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraf</single>
       <multiple>paragrafi</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>str.</single>
+      <multiple>str.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>str.</single>
       <multiple>str.</multiple>
     </term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -130,6 +130,10 @@
       <single>oldal</single>
       <multiple>oldal</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>oldal</single>
+      <multiple>oldal</multiple>
+    </term>
     <term name="paragraph">
       <single>bekezdés</single>
       <multiple>bekezdés</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>o</single>
+      <multiple>o</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>o</single>
       <multiple>o</multiple>
     </term>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -124,6 +124,10 @@
       <single>blaðsíða</single>
       <multiple>blaðsíður</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>blaðsíða</single>
+      <multiple>blaðsíður</multiple>
+    </term>
     <term name="paragraph">
       <single>málsgrein</single>
       <multiple>málsgreinar</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">tónv.</term>
     <term name="page" form="short">
+      <single>bls.</single>
+      <multiple>bls.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>bls.</single>
       <multiple>bls.</multiple>
     </term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -124,6 +124,10 @@
       <single>pagina</single>
       <multiple>pagine</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>pagina</single>
+      <multiple>pagine</multiple>
+    </term>
     <term name="paragraph">
       <single>capoverso</single>
       <multiple>capoversi</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>pag.</single>
+      <multiple>pagg.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>pag.</single>
       <multiple>pagg.</multiple>
     </term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -130,6 +130,10 @@
       <single>ページ</single>
       <multiple>ページ</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>ページ</single>
+      <multiple>ページ</multiple>
+    </term>
     <term name="paragraph">
       <single>段落</single>
       <multiple>段落</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>p</single>
+      <multiple>p</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>p</multiple>
     </term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -130,6 +130,10 @@
       <single>ទំព័រ</single>
       <multiple>ទំព័រ</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>ទំព័រ</single>
+      <multiple>ទំព័រ</multiple>
+    </term>
     <term name="paragraph">
       <single>កថាខណ្ឌ</single>
       <multiple>កថាខណ្ឌ</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -130,6 +130,10 @@
       <single>페이지</single>
       <multiple>페이지</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>페이지</single>
+      <multiple>페이지</multiple>
+    </term>
     <term name="paragraph">
       <single>단락</single>
       <multiple>단락</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>p</single>
+      <multiple>pp</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
     </term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -131,6 +131,10 @@
       <single>puslapis</single>
       <multiple>puslapiai</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>puslapis</single>
+      <multiple>puslapiai</multiple>
+    </term>
     <term name="paragraph">
       <single>pastraipa</single>
       <multiple>pastraipos</multiple>
@@ -167,6 +171,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>p.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
     </term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -139,6 +139,10 @@
       <single>lappuse</single>
       <multiple>lappuses</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>lappuse</single>
+      <multiple>lappuses</multiple>
+    </term>
     <term name="paragraph">
       <single>rindkopa</single>
       <multiple>rindkopas</multiple>
@@ -175,6 +179,10 @@
     <term name="note" form="short">piez.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>lpp.</single>
+      <multiple>lpp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>lpp.</single>
       <multiple>lpp.</multiple>
     </term>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -130,6 +130,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraph</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>p</single>
+      <multiple>pp</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
     </term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -124,6 +124,10 @@
       <single>side</single>
       <multiple>sider</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>side</single>
+      <multiple>sider</multiple>
+    </term>
     <term name="paragraph">
       <single>avsnitt</single>
       <multiple>avsnitt</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>s.</single>
+      <multiple>s.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -146,6 +146,10 @@
       <single>pagina</single>
       <multiple>pagina's</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>pagina</single>
+      <multiple>pagina's</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraaf</single>
       <multiple>paragrafen</multiple>
@@ -182,6 +186,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -124,6 +124,10 @@
       <single>side</single>
       <multiple>sider</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>side</single>
+      <multiple>sider</multiple>
+    </term>
     <term name="paragraph">
       <single>avsnitt</single>
       <multiple>avsnitt</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>s.</single>
+      <multiple>s.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -124,6 +124,10 @@
       <single>strona</single>
       <multiple>strony</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>strona</single>
+      <multiple>strony</multiple>
+    </term>
     <term name="paragraph">
       <single>akapit</single>
       <multiple>akapity</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>s.</single>
+      <multiple>ss.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>ss.</multiple>
     </term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -124,6 +124,10 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>página</single>
+      <multiple>páginas</multiple>
+    </term>
     <term name="paragraph">
       <single>parágrafo</single>
       <multiple>parágrafos</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>p.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
     </term>

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -130,6 +130,10 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>página</single>
+      <multiple>páginas</multiple>
+    </term>
     <term name="paragraph">
       <single>parágrafo</single>
       <multiple>parágrafos</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>p</single>
+      <multiple>pp</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
     </term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -129,6 +129,10 @@
       <single>pagina</single>
       <multiple>paginile</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>pagina</single>
+      <multiple>paginile</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraful</single>
       <multiple>paragrafele</multiple>
@@ -165,6 +169,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -129,6 +129,10 @@
       <single>страница</single>
       <multiple>страницы</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>страница</single>
+      <multiple>страницы</multiple>
+    </term>
     <term name="paragraph">
       <single>параграф</single>
       <multiple>параграфы</multiple>
@@ -165,6 +169,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">соч.</term>
     <term name="page" form="short">
+      <single>с.</single>
+      <multiple>с.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>с.</single>
       <multiple>с.</multiple>
     </term>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -130,6 +130,10 @@
       <single>strana</single>
       <multiple>strany</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>strana</single>
+      <multiple>strany</multiple>
+    </term>
     <term name="paragraph">
       <single>odstavec</single>
       <multiple>odstavce</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>s</single>
+      <multiple>s</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s</single>
       <multiple>s</multiple>
     </term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -130,6 +130,10 @@
       <single>stran</single>
       <multiple>strani</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>stran</single>
+      <multiple>strani</multiple>
+    </term>
     <term name="paragraph">
       <single>odstavek</single>
       <multiple>odstavki</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>str</single>
+      <multiple>str</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>str</single>
       <multiple>str</multiple>
     </term>

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -130,6 +130,10 @@
       <single>страница</single>
       <multiple>странице</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>страница</single>
+      <multiple>странице</multiple>
+    </term>
     <term name="paragraph">
       <single>параграф</single>
       <multiple>параграфи</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">оп.</term>
     <term name="page" form="short">
+      <single>стр.</single>
+      <multiple>стр.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>стр.</single>
       <multiple>стр.</multiple>
     </term>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -128,6 +128,10 @@
       <single>sida</single>
       <multiple>sidor</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>sida</single>
+      <multiple>sidor</multiple>
+    </term>
     <term name="paragraph">
       <single>stycke</single>
       <multiple>stycken</multiple>
@@ -164,6 +168,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>s</single>
+      <multiple>ss</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s</single>
       <multiple>ss</multiple>
     </term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -124,6 +124,10 @@
       <single>หน้า</single>
       <multiple>หน้า</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>หน้า</single>
+      <multiple>หน้า</multiple>
+    </term>
     <term name="paragraph">
       <single>ย่อหน้า</single>
       <multiple>ย่อหน้า</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">บทประพันธ์</term>
     <term name="page" form="short">
+      <single>น.</single>
+      <multiple>น.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>น.</single>
       <multiple>น.</multiple>
     </term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -124,6 +124,10 @@
       <single>sayfa</single>
       <multiple>sayfalar</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>sayfa</single>
+      <multiple>sayfalar</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraf</single>
       <multiple>paragraflar</multiple>
@@ -160,6 +164,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>s</single>
+      <multiple>ss</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>s</single>
       <multiple>ss</multiple>
     </term>

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -130,6 +130,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraph</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>p</single>
+      <multiple>pp</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
     </term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -130,6 +130,10 @@
       <single>trang</single>
       <multiple>trang</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>trang</single>
+      <multiple>trang</multiple>
+    </term>
     <term name="paragraph">
       <single>đoạn văn</single>
       <multiple>đoạn văn</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>tr</single>
+      <multiple>tr</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>tr</single>
       <multiple>tr</multiple>
     </term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -130,6 +130,10 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraph</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">op</term>
     <term name="page" form="short">
+      <single>p</single>
+      <multiple>pp</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
     </term>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -130,6 +130,10 @@
       <single>頁</single>
       <multiple>頁</multiple>
     </term>
+    <term name="number-of-pages">
+      <single>頁</single>
+      <multiple>頁</multiple>
+    </term>
     <term name="paragraph">
       <single>段落</single>
       <multiple>段落</multiple>
@@ -166,6 +170,10 @@
     <term name="note" form="short">n.</term>
     <term name="opus" form="short">作</term>
     <term name="page" form="short">
+      <single>頁</single>
+      <multiple>頁</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
       <single>頁</single>
       <multiple>頁</multiple>
     </term>


### PR DESCRIPTION
As per @rmzelle's comment on https://bitbucket.org/fbennett/citeproc-js/issue/148/number-of-pages-label-does-not-render

I suppose it's more flexible to have `number-of-pages` defined independently of `page`

Edit: there's also a bit of an issue with how number-of-pages plurality is determined at least in citeproc-js. A single number appears to be interpreted as singular.
