### PR TITLE
Added pom.xml to distribute the CSL locales via Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.citationstyles</groupId>
+  <artifactId>locales</artifactId>
+  <packaging>jar</packaging>
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <name>Citation Style Language (CSL) locale files</name>
+  <version>1.0.2-SNAPSHOT</version>
+  <description>Citation Style Language (CSL) locale files packaged as a Maven artifact</description>
+  <url>http://citationstyles.org/</url>
+  <licenses>
+    <license>
+      <name>Creative Commons Attribution-ShareAlike 3.0 Unported license</name>
+      <url>http://creativecommons.org/licenses/by-sa/3.0/</url>
+      <distribution>repo</distribution>
+      <comments>
+        All the files in this repository are released under the Creative
+        Commons Attribution-ShareAlike 3.0 Unported license. For attribution,
+        any software using CSL styles from this repository must include a clear
+        mention of the CSL project and a link to CitationStyles.org. When
+        distributing these styles, the listings of authors and contributors in
+        the style metadata must be kept as is.
+      </comments>
+    </license>
+  </licenses>
+  <scm>
+    <url>scm:git:git://github.com/citation-style-language/locales.git</url>
+    <connection>scm:git:git://github.com/citation-style-language/locales.git</connection>
+    <developerConnection>scm:git:git://github.com/citation-style-language/locales.git</developerConnection>
+  </scm>
+  <organization>
+    <name>CitationStyles.org</name>
+    <url>http://citationstyles.org/</url>
+  </organization>
+  <developers>
+    <developer>
+      <id>michel-kraemer</id>
+      <name>Michel Kraemer</name>
+      <email>michel@undercouch.de</email>
+      <url>http://www.michel-kraemer.com</url>
+    </developer>
+  </developers>
+  <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+        <includes>
+          <include>locales-*.xml</include>
+          <include>locales.json</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
+</project>


### PR DESCRIPTION
Hi folks!

I'm currently working on a project called 'citeproc-java' which is a small wrapper around citeproc-js with some additional stuff (such as bibtex conversion). Since I would like to publish citeproc-java via Maven it makes sense to also publish the locales there so they are directly available for Java applications. That's why I'm sending you this pull request.

Please also see my other pull request for more information:
https://github.com/citation-style-language/styles/pull/690

Cheers,
Michel
