### PR TITLE
Create locales-es-CL.xml

### DIFF
--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="es-CL">
   <info>
-  	<translator>
-		  <name>Scott Sadowsky</name>
-		  <uri>http://sadowsky.cl/</uri>
+    <translator>
+      <name>Scott Sadowsky</name>
+      <uri>http://sadowsky.cl/</uri>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2013-10-28T13:25:11-04:00</updated>
+    <updated>2013-10-28T13:57:31-04:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">


### PR DESCRIPTION
A slightly modified version of locales-es-ES.xml. Main differences are (1) American Spanish quotation marks instead of European Spanish chevrons, (2) removal of the period in ordinals (Nº instead of N.º), (3) "editorial director" is translated as "coordinador" instead of "editor" (which is actually "editor").
