### PR TITLE
Update locales-zh-TW.xml

### DIFF
--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -60,7 +60,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">""</term>
+    <term name="ordinal"></term>
   
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">一</term>


### PR DESCRIPTION
I completed the translation and amended a few key terms to render the locale more user-friendly to the native speaker. 

General changes made are: 
1. Removal to the single / multiple differentiation as none exists for the Chinese language. 
2. For ordinals, the Chinese just prefix a 第 to the number. Since ordinals in cs: number are programmed as suffixes, there is no way to project Chinese ordinals in the locale. As such, I attempted a work-around with this: `<term name="ordinal" suffix="第">""</term>`. I wonder if this is legal under the program. 
3. Chinese has three ways to depict numbers. One is the Arabic numeral (1, 2, 3...); one is in Chinese characters (一、二、三...);  another is in "capital format", 大寫 daxie (壹、貳、參...). It would be nice if cs style can provide a way to inter-convert these number format. Meanwhile, I translate the long ordinal to 一、二、三 etc., with reference to the long and short month forms. But I doubt this will work as a work-around. 
4. Many terms in the original translation are never used in a published paper, which defeats the purpose of having a locale in the Chinese language. I render these terms to the more common form so as to conform to the norms in Chinese academia. 
