### PR TITLE
Update locales-zh-CN.xml

### DIFF
--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -60,7 +60,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">""</term>
+    <term name="ordinal"></term>
   
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">一</term>


### PR DESCRIPTION
This one is completed based on the recently updated and committed zh-TW locale. 

Specifically for the CN locale,《》and〈〉have been set as inner and outer quotes under punctuation, and the term 公元 is used to translate AD.
