### PR TITLE
Terms for 'collection-editor', 'director' (verb)

### DIFF
--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -206,6 +206,10 @@
       <single>Herausgeber</single>
       <multiple>Herausgeber</multiple>
     </term>
+    <term name="collection-editor">
+      <single>Reihenherausgeber</single>
+      <multiple>Reihenherausgeber</multiple>
+    </term>
     <term name="editorial-director">
       <single>Herausgeber</single>
       <multiple>Herausgeber</multiple>
@@ -226,9 +230,13 @@
     <!-- SHORT ROLE FORMS -->
     <term name="director" form="short">
       <single>Reg.</single>
-      <multiple>Reg..</multiple>
+      <multiple>Reg.</multiple>
     </term>
     <term name="editor" form="short">
+      <single>Hrsg.</single>
+      <multiple>Hrsg.</multiple>
+    </term>
+    <term name="collection-editor" form="short">
       <single>Hrsg.</single>
       <multiple>Hrsg.</multiple>
     </term>
@@ -250,8 +258,9 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="director" form="verb">directed by</term>
+    <term name="director" form="verb">Regie von</term>
     <term name="editor" form="verb">herausgegeben von</term>
+    <term name="collection-editor" form="verb">herausgegeben von</term>
     <term name="editorial-director" form="verb">herausgegeben von</term>
     <term name="illustrator" form="verb">illustriert von</term>
     <term name="interviewer" form="verb">interviewt von</term>
@@ -264,6 +273,7 @@
     <term name="container-author" form="verb-short">von</term>
     <term name="director" form="verb-short">Reg.</term>
     <term name="editor" form="verb-short">hg. von</term>
+    <term name="collection-editor" form="verb-short">hg. von</term>
     <term name="editorial-director" form="verb-short">hg. von</term>
     <term name="illustrator" form="verb-short">illus. von</term>
     <term name="translator" form="verb-short">übers. von</term>


### PR DESCRIPTION
Added terms for 'collection-editor', verb role form for 'director' (was english)