### PR TITLE
Fix month to numeric in numeric date form in fi-FI

### DIFF
--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -12,7 +12,7 @@
   </date>
   <date form="numeric">
     <date-part name="day" suffix="."/>
-    <date-part name="month" suffix="."/>
+    <date-part name="month" form="numeric" suffix="."/>
     <date-part name="year"/>
   </date>
   <terms>


### PR DESCRIPTION
In fi-Fi the date form="numeric" had month in a text form. This will fix it to numeric. The Finnish date format is: d.m.yyyy.