### PR TITLE
Corrected quotation marks in vi-VN locale.

### DIFF
--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -21,15 +21,15 @@
     <term name="and others">and others</term>
     <term name="anonymous">anonymous</term>
     <term name="anonymous" form="short">anon</term>
-    <term name="at">at</term>
+    <term name="at">tại</term>
     <term name="available at">available at</term>
-    <term name="by">by</term>
+    <term name="by">do</term>
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
     <term name="edition">
-      <single>edition</single>
-      <multiple>editions</multiple>
+      <single>ấn bản</single>
+      <multiple>ấn bản</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">và c.s.</term>
@@ -41,7 +41,7 @@
     <term name="internet">internet</term>
     <term name="interview">interview</term>
     <term name="letter">letter</term>
-    <term name="no date">no date</term>
+    <term name="no date">không ngày</term>
     <term name="no date" form="short">không ngày</term>
     <term name="online">online</term>
     <term name="presented at">presented at the</term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -62,10 +62,10 @@
     <term name="bc">BC</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">«</term>
-    <term name="close-quote">»</term>
-    <term name="open-inner-quote">‹</term>
-    <term name="close-inner-quote">›</term>
+    <term name="open-quote">“</term>
+    <term name="close-quote">”</term>
+    <term name="open-inner-quote">‘</term>
+    <term name="close-inner-quote">’</term>
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->


### PR DESCRIPTION
Perhaps in previous generations Vietnamese writers used French quotes
or guillemets, but I am not aware of a publisher in Vietnam today that
uses them. They use quotation marks as in English. As evidence, see a
famous newspaper in Vietnam (http://tuoitre.vn/). If necessary, I can
provide documentation from book publishing.