### PR TITLE
locales-el-GR-translations.xml

### DIFF
--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -27,7 +27,7 @@
     <term name="circa">περίπου</term>
     <term name="circa" form="short">περ.</term>
     <term name="cited">παρατίθεται</term>
-    <term name="edition">
+    <term name="edition"  gender="feminine">
       <single>έκδοση</single>
       <multiple>εκδόσεις</multiple>
     </term>
@@ -69,7 +69,9 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">ος</term>
+    <term name="ordinal">ο</term>
+    <term name="ordinal-01" gender-form="feminine" match="whole-number">η</term>
+    <term name="ordinal-01" gender-form="masculine" match="whole-number">ος</term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">πρώτος</term>
@@ -92,15 +94,15 @@
       <single>κεφάλαιο</single>
       <multiple>κεφάλαια</multiple>
     </term>
-    <term name="column">
+    <term name="column" gender="feminine">
       <single>στήλη</single>
       <multiple>στήλες</multiple>
     </term>
-    <term name="figure">
+    <term name="figure" gender="feminine">
       <single>εικόνα</single>
       <multiple>εικόνες</multiple>
     </term>
-    <term name="folio">
+    <term name="folio" gender="masculine">
       <single>φάκελος</single>
       <multiple>φάκελοι</multiple>
     </term>
@@ -108,7 +110,7 @@
       <single>τεύχος</single>
       <multiple>τεύχη</multiple>
     </term>
-    <term name="line">
+    <term name="line" gender="feminine">
       <single>σειρά</single>
       <multiple>σειρές</multiple>
     </term>
@@ -120,7 +122,7 @@
       <single>έργο</single>
       <multiple>έργα</multiple>
     </term>
-    <term name="page">
+    <term name="page" gender="feminine">
       <single>σελίδα</single>
       <multiple>σελίδες</multiple>
     </term>
@@ -128,7 +130,7 @@
       <single>σελίδα</single>
       <multiple>σελίδες</multiple>
     </term>
-    <term name="paragraph">
+    <term name="paragraph" gender="feminine">
       <single>παράγραφος</single>
       <multiple>παράγραφοι</multiple>
     </term>
@@ -144,11 +146,11 @@
       <single>λήμμα</single>
       <multiple>λήμματα</multiple>
     </term>
-    <term name="verse">
+    <term name="verse" gender="masculine">
       <single>στίχος</single>
       <multiple>στίχοι</multiple>
     </term>
-    <term name="volume">
+    <term name="volume" gender="masculine">
       <single>τόμος</single>
       <multiple>τόμοι</multiple>
     </term>
@@ -256,7 +258,7 @@
     <term name="illustrator" form="verb">εικονογράφηση by</term>
     <term name="interviewer" form="verb">συνέντευξη</term>
     <term name="recipient" form="verb">παραλήπτης</term>
-    <term name="reviewed-author" form="verb">by</term>
+    <term name="reviewed-author" form="verb">συγγραφέας:</term>
     <term name="translator" form="verb">μετάφραση</term>
     <term name="editortranslator" form="verb">μετάφραση και επιμέλεια</term>
 


### PR DESCRIPTION
Corrected the Greek locale mostly in issues of gender references:
-edition (έκδοση) defined as feminine, volume (τόμος) defined as masculine, and some others
-defined genders for masculine, feminine and neuter ordinals
-translated reviewed-author term. This is a bit tricky because we need a translation that is correct to use with the nominative declension of the reviewed author's name, which is the way authors are normally entered in the database. E.g., a translation of "by" with "του/της" would require the genitive form of the author's name, which would mean that an entirely new field would need to be created, i.e. the reviewed author's name in the genitive form.