### PR TITLE
locales-el-GR.xml

### DIFF
--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -27,7 +27,7 @@
     <term name="circa">περίπου</term>
     <term name="circa" form="short">περ.</term>
     <term name="cited">παρατίθεται</term>
-    <term name="edition">
+    <term name="edition" gender="feminine">
       <single>έκδοση</single>
       <multiple>εκδόσεις</multiple>
     </term>
@@ -69,7 +69,9 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">ος</term>
+    <term name="ordinal">ο</term>
+    <term name="ordinal-01" gender-form="feminine" match="whole-number">η</term>
+    <term name="ordinal-01" gender-form="masculine" match="whole-number">ος</term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">πρώτος</term>
@@ -253,10 +255,10 @@
     <term name="director" form="verb">διεύθυνση</term>
     <term name="editor" form="verb">επιμέλεια</term>
     <term name="editorial-director" form="verb">διεύθυνση σειράς</term>
-    <term name="illustrator" form="verb">εικονογράφηση by</term>
+    <term name="illustrator" form="verb">εικονογράφηση:</term>
     <term name="interviewer" form="verb">συνέντευξη</term>
     <term name="recipient" form="verb">παραλήπτης</term>
-    <term name="reviewed-author" form="verb">by</term>
+    <term name="reviewed-author" form="verb">συγγραφέας:</term>
     <term name="translator" form="verb">μετάφραση</term>
     <term name="editortranslator" form="verb">μετάφραση και επιμέλεια</term>
 


### PR DESCRIPTION
Corrected the Greek locale mostly in issues of gender references:
-edition (έκδοση) defined as feminine
-defined genders for masculine, feminine and neuter ordinals
-translated reviewed-author term and corrected illustrator name. This is a bit tricky because we need a translation that is correct to use with the nominative case of the reviewed author's name, which is the way authors are normally entered in the database. E.g., a translation of "by" with "του/της" would require the genitive form of the author's name, which would mean that an entirely new field would need to be created, i.e. the reviewed author's name in the genitive form. The workaround for Greek is to use a colon.