### PR TITLE
Add short reviewed-author verb role form to English, French.

### DIFF
--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -2,7 +2,7 @@
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-GB">
   <info>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2015-10-10T23:31:02+00:00</updated>
+    <updated>2015-10-11T23:31:02+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -308,6 +308,7 @@
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editorial-director" form="verb-short">ed. by</term>
     <term name="illustrator" form="verb-short">illus. by</term>
+    <term name="reviewed-author" form="verb-short">by</term>
     <term name="translator" form="verb-short">trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
 

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -2,7 +2,7 @@
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
   <info>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2015-10-10T23:31:02+00:00</updated>
+    <updated>2015-10-11T23:31:02+00:00</updated>
   </info>
   <style-options punctuation-in-quote="true"/>
   <date form="text">
@@ -308,6 +308,7 @@
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editorial-director" form="verb-short">ed. by</term>
     <term name="illustrator" form="verb-short">illus. by</term>
+    <term name="reviewed-author" form="verb-short">by</term>
     <term name="translator" form="verb-short">trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
 

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -5,7 +5,7 @@
       <name>Grégoire Colly</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2012-07-04T23:31:02+00:00</updated>
+    <updated>2015-10-11T23:31:02+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false" limit-day-ordinals-to-day-1="true"/>
   <date form="text">
@@ -277,6 +277,7 @@
     <term name="editor" form="verb-short">éd. par</term>
     <term name="editorial-director" form="verb-short">ss la dir. de</term>
     <term name="illustrator" form="verb-short">ill. par</term>
+    <term name="reviewed-author" form="verb-short">par</term>
     <term name="translator" form="verb-short">trad. par</term>
     <term name="editortranslator" form="verb-short">éd. et trad. par</term>
 

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -5,7 +5,7 @@
       <name>Grégoire Colly</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2012-07-04T23:31:02+00:00</updated>
+    <updated>2015-10-11T23:31:02+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false" limit-day-ordinals-to-day-1="true"/>
   <date form="text">
@@ -277,6 +277,7 @@
     <term name="editor" form="verb-short">éd. par</term>
     <term name="editorial-director" form="verb-short">ss la dir. de</term>
     <term name="illustrator" form="verb-short">ill. par</term>
+    <term name="reviewed-author" form="verb-short">par</term>
     <term name="translator" form="verb-short">trad. par</term>
     <term name="editortranslator" form="verb-short">éd. et trad. par</term>
 


### PR DESCRIPTION
There are over a dozen styles that call for this, which causes problems
for pandoc-citeproc; it is more straightforward to add it here than to
track down each occurrence.