### PR TITLE
Move container-author from verb-short to verb.

### DIFF
--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">onder redaksie van</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">red</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">تحرير</term>
     <term name="editorial-director" form="verb">اعداد</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">اعداد وترجمة</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">تحرير</term>
     <term name="editorial-director" form="verb-short">اشرف على الطبعة</term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -69,7 +69,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"/>
+    <term name="ordinal"></term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">الاول</term>
@@ -250,7 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">تحرير</term>
     <term name="editorial-director" form="verb">اعداد</term>

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">редактиран от</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ред</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">per</term>
     <term name="director" form="verb">dirigit per</term>
     <term name="editor" form="verb">editat per</term>
     <term name="editorial-director" form="verb">editat per</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">editat i traduït per</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">per</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -251,6 +251,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">řídil</term>
     <term name="editor" form="verb">editoval</term>
     <term name="editorial-director" form="verb">editoval</term>
@@ -262,7 +263,6 @@
     <term name="editortranslator" form="verb">editoval a přeložil</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"></term>
     <term name="director" form="verb-short">řed.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -251,7 +251,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">řídil</term>
     <term name="editor" form="verb">editoval</term>
     <term name="editorial-director" form="verb">editoval</term>

--- a/locales-cy-GB.xml
+++ b/locales-cy-GB.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">gan</term>
     <term name="director" form="verb">cyfarwyddwyd gan</term>
     <term name="editor" form="verb">golygwyd gan</term>
     <term name="editorial-director" form="verb">cyfarwyddwyd a golygwyd gan</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">golygwyd a chyfieithwyd gan</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">gan</term>
     <term name="director" form="verb-short">cyf. gan</term>
     <term name="editor" form="verb-short">gol. gan</term>
     <term name="editorial-director" form="verb-short">cyf.-gol. gan</term>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">af</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">redigeret af</term>
     <term name="editorial-director" form="verb">redigeret af</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">redigeret &amp; oversat af</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">af</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">von</term>
     <term name="director" form="verb">Regie von</term>
     <term name="editor" form="verb">herausgegeben von</term>
     <term name="editorial-director" form="verb">herausgegeben von</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">herausgegeben und übersetzt von</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">von</term>
     <term name="director" form="verb-short">Reg.</term>
     <term name="editor" form="verb-short">hg. von</term>
     <term name="editorial-director" form="verb-short">hg. von</term>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">von</term>
     <term name="director" form="verb">Regie von</term>
     <term name="editor" form="verb">herausgegeben von</term>
     <term name="editorial-director" form="verb">herausgegeben von</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">herausgegeben und übersetzt von</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">von</term>
     <term name="director" form="verb-short">Reg.</term>
     <term name="editor" form="verb-short">hg. von</term>
     <term name="editorial-director" form="verb-short">hg. von</term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -258,6 +258,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">von</term>
     <term name="director" form="verb">Regie von</term>
     <term name="editor" form="verb">herausgegeben von</term>
     <term name="collection-editor" form="verb">herausgegeben von</term>
@@ -270,7 +271,6 @@
     <term name="editortranslator" form="verb">herausgegeben und übersetzt von</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">von</term>
     <term name="director" form="verb-short">Reg.</term>
     <term name="editor" form="verb-short">hg. von</term>
     <term name="collection-editor" form="verb-short">hg. von</term>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -252,6 +252,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">στον συλλ. τόμο</term>
     <term name="director" form="verb">διεύθυνση</term>
     <term name="editor" form="verb">επιμέλεια</term>
     <term name="editorial-director" form="verb">διεύθυνση σειράς</term>
@@ -263,7 +264,6 @@
     <term name="editortranslator" form="verb">μετάφραση και επιμέλεια</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">στον συλλ. τόμο</term>
     <term name="director" form="verb-short">διευθ.</term>
     <term name="editor" form="verb-short">επιμέλ.</term>
     <term name="editorial-director" form="verb-short">δ/νση σειράς</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -292,6 +292,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -303,7 +304,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editorial-director" form="verb-short">ed. by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -292,6 +292,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -303,7 +304,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editorial-director" form="verb-short">ed. by</term>

--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -254,6 +254,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">de</term>
     <term name="director" form="verb">dirigido por</term>
     <term name="editor" form="verb">editado por</term>
     <term name="editorial-director" form="verb">coordinado por</term>
@@ -265,7 +266,6 @@
     <term name="editortranslator" form="verb">editado y traducido por</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">de</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">coord.</term>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">de</term>
     <term name="director" form="verb">dirigido por</term>
     <term name="editor" form="verb">editado por</term>
     <term name="editorial-director" form="verb">editado por</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">editado y traducido por</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">de</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -295,6 +295,7 @@
     </term>
     
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">de</term>
     <term name="director" form="verb">dirigido por</term>
     <term name="editor" form="verb">editado por</term>
     <term name="editorial-director" form="verb">coordinado por</term>
@@ -306,7 +307,6 @@
     <term name="editortranslator" form="verb">editado y traducido por</term>
     
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">de</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">coord.</term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -21,9 +21,9 @@
     <term name="and others">ja teised</term>
     <term name="anonymous">anonüümne</term>
     <term name="anonymous" form="short">anon</term>
-    <term name="at"/>
+    <term name="at"></term>
     <term name="available at">available at</term>
-    <term name="by"/>
+    <term name="by"></term>
     <term name="circa">umbes</term>
     <term name="circa" form="short">u</term>
     <term name="cited">tsiteeritud</term>
@@ -34,9 +34,9 @@
     <term name="edition" form="short">tr</term>
     <term name="et-al">et al.</term>
     <term name="forthcoming">ilmumisel</term>
-    <term name="from"/>
+    <term name="from"></term>
     <term name="ibid">ibid.</term>
-    <term name="in"/>
+    <term name="in"></term>
     <term name="in press">trükis</term>
     <term name="internet">internet</term>
     <term name="interview">intervjuu</term>
@@ -250,13 +250,13 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">toimetanud</term>
     <term name="editorial-director" form="verb">toimetanud</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">intervjueerinud</term>
-    <term name="recipient" form="verb"/>
+    <term name="recipient" form="verb"></term>
     <term name="reviewed-author" form="verb">by</term>
     <term name="translator" form="verb">tõlkinud</term>
     <term name="editortranslator" form="verb">toimetanud &amp; tõlkinud</term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">toimetanud</term>
     <term name="editorial-director" form="verb">toimetanud</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">toimetanud &amp; tõlkinud</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">toim</term>
     <term name="editorial-director" form="verb-short">toim</term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -250,7 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">-(e)k argitaratua</term>
     <term name="editorial-director" form="verb">-(e)k argitaratua</term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">-(e)k argitaratua</term>
     <term name="editorial-director" form="verb">-(e)k argitaratua</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">-(e)k argitaratu eta itzulia</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">arg.</term>
     <term name="editorial-director" form="verb-short">arg.</term>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">توسط</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
     <term name="editorial-director" form="verb">ویراسته‌ی</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">ترجمه و ویراسته‌ی</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">توسط</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ویراسته‌ی</term>
     <term name="editorial-director" form="verb-short">ویراسته‌ی</term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">ohjannut</term>
     <term name="editor" form="verb">toimittanut</term>
     <term name="editorial-director" form="verb">toimittanut</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">toimittanut ja kääntänyt</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">ohj.</term>
     <term name="editor" form="verb-short">toim.</term>
     <term name="editorial-director" form="verb-short">toim.</term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -250,14 +250,14 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">ohjannut</term>
     <term name="editor" form="verb">toimittanut</term>
     <term name="editorial-director" form="verb">toimittanut</term>
     <term name="illustrator" form="verb">kuvittanut</term>
     <term name="interviewer" form="verb">haastatellut</term>
     <term name="recipient" form="verb">vastaanottaja</term>
-    <term name="reviewed-author" form="verb"/>
+    <term name="reviewed-author" form="verb"></term>
     <term name="translator" form="verb">kääntänyt</term>
     <term name="editortranslator" form="verb">toimittanut ja kääntänyt</term>
 

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -261,6 +261,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">par</term>
     <term name="director" form="verb">réalisé par</term>
     <term name="editor" form="verb">édité par</term>
     <term name="editorial-director" form="verb">sous la direction de</term>
@@ -272,7 +273,6 @@
     <term name="editortranslator" form="verb">édité et traduit par</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">par</term>
     <term name="director" form="verb-short">réal. par</term>
     <term name="editor" form="verb-short">éd. par</term>
     <term name="editorial-director" form="verb-short">ss la dir. de</term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -261,6 +261,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">par</term>
     <term name="director" form="verb">réalisé par</term>
     <term name="editor" form="verb">édité par</term>
     <term name="editorial-director" form="verb">sous la direction de</term>
@@ -272,7 +273,6 @@
     <term name="editortranslator" form="verb">édité et traduit par</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">par</term>
     <term name="director" form="verb-short">réal. par</term>
     <term name="editor" form="verb-short">éd. par</term>
     <term name="editorial-director" form="verb-short">ss la dir. de</term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">בוים ע"י</term>
     <term name="editor" form="verb">נערך ע"י</term>
     <term name="editorial-director" form="verb">בוים ע"י</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">priredio</term>
     <term name="editorial-director" form="verb">priredio</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">priredio &amp; preveo by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">prir.</term>
     <term name="editorial-director" form="verb-short">prir.</term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -21,7 +21,7 @@
     <term name="and others">és mások</term>
     <term name="anonymous">szerző nélkül</term>
     <term name="anonymous" form="short">sz. n.</term>
-    <term name="at"/>
+    <term name="at"></term>
     <term name="available at">elérhető</term>
     <term name="by">by</term>
     <term name="circa">körülbelül</term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -254,6 +254,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">szerkesztette</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -265,7 +266,6 @@
     <term name="editortranslator" form="verb">szerkesztette &amp; fordította</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">ig.</term>
     <term name="editor" form="verb-short">szerk.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -69,13 +69,13 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"></term>
-    <term name="ordinal-01"></term>
-    <term name="ordinal-02"></term>
-    <term name="ordinal-03"></term>
-    <term name="ordinal-11"></term>
-    <term name="ordinal-12"></term>
-    <term name="ordinal-13"></term>
+    <term name="ordinal"/>
+    <term name="ordinal-01"/>
+    <term name="ordinal-02"/>
+    <term name="ordinal-03"/>
+    <term name="ordinal-11"/>
+    <term name="ordinal-12"/>
+    <term name="ordinal-13"/>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">pertama</term>
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">oleh</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">diedit oleh</term>
     <term name="editorial-director" form="verb">diedit oleh</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">disunting &amp; diterjemahkan oleh</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">oleh</term>
     <term name="director" form="verb-short">dir. oleh</term>
     <term name="editor" form="verb-short">ed. oleh</term>
     <term name="editorial-director" form="verb-short">ed. oleh</term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -69,13 +69,13 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"/>
-    <term name="ordinal-01"/>
-    <term name="ordinal-02"/>
-    <term name="ordinal-03"/>
-    <term name="ordinal-11"/>
-    <term name="ordinal-12"/>
-    <term name="ordinal-13"/>
+    <term name="ordinal"></term>
+    <term name="ordinal-01"></term>
+    <term name="ordinal-02"></term>
+    <term name="ordinal-03"></term>
+    <term name="ordinal-11"></term>
+    <term name="ordinal-12"></term>
+    <term name="ordinal-13"></term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">pertama</term>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">eftir</term>
     <term name="director" form="verb">leikstýrt af</term>
     <term name="editor" form="verb">ritstýrt af</term>
     <term name="editorial-director" form="verb">ritstýrt af</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">ritstýrt og þýtt af</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">eftir</term>
     <term name="director" form="verb-short">leikstj.</term>
     <term name="editor" form="verb-short">ritstj.</term>
     <term name="editorial-director" form="verb-short">ritstj.</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">di</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">a cura di</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">a cura di e tradotto da</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">di</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">a c. di</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">編集者：</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">編集者：</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -36,7 +36,7 @@
     <term name="forthcoming">近刊</term>
     <term name="from">から</term>
     <term name="ibid">前掲</term>
-    <term name="in"/>
+    <term name="in"></term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
     <term name="interview">interview</term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -213,7 +213,7 @@
       <multiple>editors</multiple>
     </term>
     <term name="editorial-director">
-      <single/>
+      <single></single>
       <multiple>editors</multiple>
     </term>
     <term name="illustrator">

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">편집자：</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -28,9 +28,9 @@
     <term name="and others">ir kt.</term>
     <term name="anonymous">anonimas</term>
     <term name="anonymous" form="short">anon.</term>
-    <term name="at"/>
+    <term name="at"></term>
     <term name="available at">available at</term>
-    <term name="by"/>
+    <term name="by"></term>
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">cituojama pagal</term>
@@ -41,9 +41,9 @@
     <term name="edition" form="short">leid.</term>
     <term name="et-al">et al.</term>
     <term name="forthcoming">ruošiamas</term>
-    <term name="from"/>
+    <term name="from"></term>
     <term name="ibid">ibid.</term>
-    <term name="in"/>
+    <term name="in"></term>
     <term name="in press">spaudoje</term>
     <term name="internet">prieiga per internetą</term>
     <term name="interview">interviu</term>
@@ -257,7 +257,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">sudarė</term>
     <term name="editorial-director" form="verb">parengė</term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -257,6 +257,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">sudarė</term>
     <term name="editorial-director" form="verb">parengė</term>
@@ -268,7 +269,6 @@
     <term name="editortranslator" form="verb">sudarė ir vertė</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">sud.</term>
     <term name="editorial-director" form="verb-short">pareng.</term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -305,6 +305,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="composer" form="verb">sastādīja</term>
     <term name="director" form="verb">vadīja</term>
     <term name="editor" form="verb">sagatavoja</term>
@@ -316,7 +317,6 @@
     <term name="translator" form="verb">tulkoja</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">sast.</term>
     <term name="editor" form="verb-short">sag.</term>
     <term name="editorial-director" form="verb-short">sag.</term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -27,10 +27,10 @@
     <term name="and others">un citi</term>
     <term name="anonymous">anonīms</term>
     <term name="anonymous" form="short">anon.</term>
-    <term name="at"/>
+    <term name="at"></term>
     <term name="available at">pieejams</term>
     <term name="bc">p.m.ē.</term>
-    <term name="by"/>
+    <term name="by"></term>
     <term name="circa">apmēram</term>
     <term name="circa" form="short">apm.</term>
     <term name="cited">citēts</term>
@@ -305,7 +305,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="composer" form="verb">sastādīja</term>
     <term name="director" form="verb">vadīja</term>
     <term name="editor" form="verb">sagatavoja</term>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">av</term>
     <term name="director" form="verb">regissert av</term>
     <term name="editor" form="verb">redigert av</term>
     <term name="editorial-director" form="verb">redigert av</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">redigert &amp; oversatt av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">av</term>
     <term name="director" form="verb-short">regi</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -272,6 +272,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">door</term>
     <term name="director" form="verb">geregisseerd door</term>
     <term name="editor" form="verb">bewerkt door</term>
     <term name="editorial-director" form="verb">bewerkt door</term>
@@ -283,7 +284,6 @@
     <term name="editortranslator" form="verb">bewerkt &amp; vertaald door</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">door</term>
     <term name="director" form="verb-short">geregisseerd door</term>
     <term name="editor" form="verb-short">bewerkt door</term>
     <term name="editorial-director" form="verb-short">bewerkt door</term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">av</term>
     <term name="director" form="verb">regissert av</term>
     <term name="editor" form="verb">redigert av</term>
     <term name="editorial-director" form="verb">redigert av</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">redigert &amp; omsett av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">av</term>
     <term name="director" form="verb-short">regi</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">przez</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">zredagowane przez</term>
     <term name="editorial-director" form="verb">zredagowane przez</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">zredagowane i przetłumaczone przez</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">przez</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">por</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">organizado por</term>
     <term name="editorial-director" form="verb">editado por</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">editado &amp; traduzido por</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">por</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">org.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -264,6 +264,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">por</term>
     <term name="director" form="verb">dirigido por</term>
     <term name="editor" form="verb">editado por</term>
     <term name="editorial-director" form="verb">editorial de</term>
@@ -275,7 +276,6 @@
     <term name="editortranslator" form="verb">editado &amp; traduzido por</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">por</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -255,6 +255,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">de</term>
     <term name="director" form="verb">coordonat de</term>
     <term name="editor" form="verb">ediție de</term>
     <term name="editorial-director" form="verb">ediție de</term>
@@ -266,7 +267,6 @@
     <term name="editortranslator" form="verb">ediție &amp; traducere de</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">de</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -74,7 +74,7 @@
 
     <!-- ORDINALS -->
     <term name="ordinal">-lea</term>
-    <term name="ordinal-01" match="whole-number"/>
+    <term name="ordinal-01" match="whole-number"></term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">primul</term>

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -27,7 +27,7 @@
     <term name="anonymous" form="short">анон.</term>
     <term name="at">на</term>
     <term name="available at">доступно на</term>
-    <term name="by"/>
+    <term name="by"></term>
     <term name="circa">около</term>
     <term name="circa" form="short">ок.</term>
     <term name="cited">цитируется по</term>
@@ -264,14 +264,14 @@
 
     <!-- VERB ROLE FORMS -->
     <!-- В этом и следующем разделе приведены наиболее широко используемые термины (например, "под редакцией" вместо "отредактировано"). Единственным недостатком является то, что разные термины требует разного падежа для последующих фамилий -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">режиссировано</term>
     <term name="editor" form="verb">под редакцией</term>
     <term name="editorial-director" form="verb">под ответственной редакцией</term>
     <term name="illustrator" form="verb">иллюстрировано</term>
     <term name="interviewer" form="verb">интервью проведено</term>
     <term name="recipient" form="verb">к</term>
-    <term name="reviewed-author" form="verb"/>
+    <term name="reviewed-author" form="verb"></term>
     <term name="translator" form="verb">переведено</term>
     <term name="editortranslator" form="verb">под редакцией и переведено</term>
 

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -264,6 +264,7 @@
 
     <!-- VERB ROLE FORMS -->
     <!-- В этом и следующем разделе приведены наиболее широко используемые термины (например, "под редакцией" вместо "отредактировано"). Единственным недостатком является то, что разные термины требует разного падежа для последующих фамилий -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">режиссировано</term>
     <term name="editor" form="verb">под редакцией</term>
     <term name="editorial-director" form="verb">под ответственной редакцией</term>
@@ -275,7 +276,6 @@
     <term name="editortranslator" form="verb">под редакцией и переведено</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">реж.</term>
     <term name="editor" form="verb-short">под ред.</term>
     <term name="editorial-director" form="verb-short">под отв. ред.</term>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">zostavil</term>
     <term name="editorial-director" form="verb">zostavil</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">zostavil &amp; preložil</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -23,7 +23,7 @@
     <term name="anonymous" form="short">anon.</term>
     <term name="at">pri</term>
     <term name="available at">dostopno</term>
-    <term name="by"></term>
+    <term name="by"/>
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">citirano</term>
@@ -250,18 +250,18 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">režiral</term>
     <term name="editor" form="verb">uredil</term>
     <term name="editorial-director" form="verb">uredil</term>
     <term name="illustrator" form="verb">ilustriral</term>
     <term name="interviewer" form="verb">intervjuval</term>
     <term name="recipient" form="verb">za</term>
-    <term name="reviewed-author" form="verb"></term>
+    <term name="reviewed-author" form="verb"/>
     <term name="translator" form="verb">prevedel</term>
     <term name="editortranslator" form="verb">uredil &amp; prevedel</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"></term>
     <term name="director" form="verb-short">rež.</term>
     <term name="editor" form="verb-short">ured.</term>
     <term name="editorial-director" form="verb-short">ured.</term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -23,7 +23,7 @@
     <term name="anonymous" form="short">anon.</term>
     <term name="at">pri</term>
     <term name="available at">dostopno</term>
-    <term name="by"/>
+    <term name="by"></term>
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">citirano</term>
@@ -250,14 +250,14 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">režiral</term>
     <term name="editor" form="verb">uredil</term>
     <term name="editorial-director" form="verb">uredil</term>
     <term name="illustrator" form="verb">ilustriral</term>
     <term name="interviewer" form="verb">intervjuval</term>
     <term name="recipient" form="verb">za</term>
-    <term name="reviewed-author" form="verb"/>
+    <term name="reviewed-author" form="verb"></term>
     <term name="translator" form="verb">prevedel</term>
     <term name="editortranslator" form="verb">uredil &amp; prevedel</term>
 

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">уредио</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ур.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -254,6 +254,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">av</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">redigerad av</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -265,7 +266,6 @@
     <term name="editortranslator" form="verb">redigerad &amp; översatt av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">av</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">โดย</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">เรียบเรียงโดย</term>
     <term name="editorial-director" form="verb">เรียบเรียงโดย</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">แปลและเรียบเรียงโดย</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">โดย</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">โดย</term>
     <term name="editorial-director" form="verb-short">โดย</term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -69,7 +69,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"/>
+    <term name="ordinal"></term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">หนึ่ง</term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -250,6 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb"/>
     <term name="director" form="verb">direktör</term>
     <term name="editor" form="verb">editör</term>
     <term name="editorial-director" form="verb">düzenleyen</term>
@@ -261,7 +262,6 @@
     <term name="editortranslator" form="verb">düzenleyen &amp; çeviren by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short"/>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -250,7 +250,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"/>
+    <term name="container-author" form="verb"></term>
     <term name="director" form="verb">direktör</term>
     <term name="editor" form="verb">editör</term>
     <term name="editorial-director" form="verb">düzenleyen</term>

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
     <term name="editorial-director" form="verb">edited by</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">by</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed</term>
     <term name="editorial-director" form="verb-short">ed.</term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -256,6 +256,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">bởi</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">biên tập bởi</term>
     <term name="editorial-director" form="verb">biên tập bởi</term>
@@ -267,7 +268,6 @@
     <term name="editortranslator" form="verb">biên tập &amp; biên dịch bởi</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">bởi</term>
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">b.t</term>
     <term name="editorial-director" form="verb-short">b.t</term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -60,7 +60,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"></term>
+    <term name="ordinal"/>
   
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">一</term>
@@ -139,6 +139,7 @@
     <term name="editortranslator" form="short">编译</term>    
 
     <!-- VERB ROLE FORMS -->
+    <term name="container-author" form="verb">著</term>
     <term name="director" form="verb">指导</term>
     <term name="editor" form="verb">编辑</term>
     <term name="editorial-director" form="verb">主编</term>
@@ -150,7 +151,6 @@
     <term name="editortranslator" form="verb">编译</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">著</term>
     <term name="director" form="verb-short">导</term>
     <term name="editor" form="verb-short">编</term>
     <term name="editorial-director" form="verb-short">主编</term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -60,7 +60,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"/>
+    <term name="ordinal"></term>
   
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">一</term>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -60,7 +60,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"></term>
+    <term name="ordinal"/>
   
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">一</term>
@@ -148,6 +148,7 @@
 
     <!-- VERB ROLE FORMS -->
     <term name="author" form="verb">著</term>
+    <term name="container-author" form="verb">著</term>
     <term name="director" form="verb">指導</term>
     <term name="editor" form="verb">編輯</term>
     <term name="collection-editor" form="verb">點校</term>
@@ -160,7 +161,6 @@
     <term name="editortranslator" form="verb">編譯</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="container-author" form="verb-short">著</term>
     <term name="director" form="verb-short">導</term>
     <term name="editor" form="verb-short">編</term>
     <term name="collection-editor" form="verb-short">校</term>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -60,7 +60,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal"/>
+    <term name="ordinal"></term>
   
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">一</term>


### PR DESCRIPTION
As discussed in #121, styles that refer to the term will continue to use this as a fallback. Also replaced empty terms with self-closing tags where this was not already done.

Note that `zh-TW` also includes an `author` term; I believe this is an oversight, but am leaving it there for now.