### PR TITLE
Update locales-sv-SE.xml

### DIFF
--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -288,18 +288,18 @@
     <term name="month-12">december</term>
 
     <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">jan</term>
-    <term name="month-02" form="short">feb</term>
-    <term name="month-03" form="short">mar</term>
-    <term name="month-04" form="short">apr</term>
+    <term name="month-01" form="short">jan.</term>
+    <term name="month-02" form="short">feb.</term>
+    <term name="month-03" form="short">mar.</term>
+    <term name="month-04" form="short">apr.</term>
     <term name="month-05" form="short">maj</term>
-    <term name="month-06" form="short">jun</term>
-    <term name="month-07" form="short">jul</term>
-    <term name="month-08" form="short">aug</term>
-    <term name="month-09" form="short">sep</term>
-    <term name="month-10" form="short">okt</term>
-    <term name="month-11" form="short">nov</term>
-    <term name="month-12" form="short">dec</term>
+    <term name="month-06" form="short">juni</term>
+    <term name="month-07" form="short">juli</term>
+    <term name="month-08" form="short">aug.</term>
+    <term name="month-09" form="short">sep.</term>
+    <term name="month-10" form="short">okt.</term>
+    <term name="month-11" form="short">nov.</term>
+    <term name="month-12" form="short">dec.</term>
 
     <!-- SEASONS -->
     <term name="season-01">vår</term>


### PR DESCRIPTION
Changes shorts for swedish months. May, June and July are normally not abbreviated, equivalent to the german de-DE locale.