### PR TITLE
Update locales-nl-NL.xml

### DIFF
--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -20,7 +20,7 @@
     <date-part name="year"/>
   </date>
   <terms>
-    <term name="accessed">geraadpleegd</term>
+    <term name="accessed">geraadpleegd op</term>
     <term name="and">en</term>
     <term name="and others">en anderen</term>
     <term name="anonymous">anoniem</term>
@@ -57,7 +57,7 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
-    <term name="retrieved">geraadpleegd</term>
+    <term name="retrieved">geraadpleegd op</term>
     <term name="scale">schaal</term>
     <term name="version">versie</term>
 


### PR DESCRIPTION
Changed "geraadpleegd" to "geraadpleegd op".

The phrase "Retrieved Year, Month Day, from URL" is in Dutch APA-guidelines often translated as "Geraadpleegd op dag maand jaar, op URL", e.g. in http://itswww.uvt.nl/lis/es/apa/apa-handleiding.pdf. Therefore, I'd like to propose to change "geraadpleegd" to "geraadpleegd op".