### PR TITLE
Update locales-cs-CZ.xml

### DIFF
--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -54,7 +54,7 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
-    <term name="retrieved">dostupné</term>
+    <term name="retrieved">získáno</term>
     <term name="scale">měřítko</term>
     <term name="version">verze</term>
 


### PR DESCRIPTION
Termín retrieved je přeložen chybně jako dostupné, správný překlad je získáno.
The term "retrieved" is wrongly translated as "dostupné" which means available. The correct translation is "získáno".