### PR TITLE
Update locales-he-IL.xml

### DIFF
--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -1,313 +1,304 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="he-IL">
-  <info>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2012-07-04T23:31:02+00:00</updated>
-  </info>
-  <style-options punctuation-in-quote="false"/>
-  <date form="text">
-    <date-part name="day" suffix=" "/>
-    <date-part name="month" suffix=" "/>
-    <date-part name="year"/>
-  </date>
-  <date form="numeric">
-    <date-part name="day" form="numeric-leading-zeros" suffix="/"/>
-    <date-part name="month" form="numeric-leading-zeros" suffix="/"/>
-    <date-part name="year"/>
-  </date>
-  <terms>
-    <term name="accessed">נבדק לאחרונה</term>
-    <term name="and">ו</term>
-    <term name="and others">ואחרים</term>
-    <term name="anonymous">אלמוני</term>
-    <term name="anonymous" form="short"></term>
-    <term name="at">-ב</term>
-    <term name="available at">זמין ב</term>
-    <term name="by">על-ידי</term>
-    <term name="circa">לערך</term>
-    <term name="circa" form="short">~</term>
-    <term name="cited">מצוטט ב</term>
-    <term name="edition">
-      <single>מהדורה</single>
-      <multiple>מהדורות</multiple>
-    </term>
-    <term name="edition" form="short">מהדורה</term>
-    <term name="et-al">ואחרים</term>
-    <term name="forthcoming">צפוי</term>
-    <term name="from">מתוך</term>
-    <term name="ibid">שם</term>
-    <term name="in">בתוך</term>
-    <term name="in press">בדפוס</term>
-    <term name="internet">אתר</term>
-    <term name="interview">ראיון</term>
-    <term name="letter">מכתב</term>
-    <term name="no date">לא ידוע/term>
-    <term name="no date" form="short"></term>
-    <term name="online">מקוון</term>
-    <term name="presented at">הוצג ב</term>
-    <term name="reference">
-      <single>הפניה</single>
-      <multiple>הפניות</multiple>
-    </term>
-    <term name="retrieved">אוחזר</term>
-    <term name="scale">scale</term>
-    <term name="version">גירסה</term>
-    <!-- ANNO DOMINI; BEFORE CHRIST -->
-    <term name="ad">לספירה</term>
-    <term name="bc">לפני הספירה</term>
+	<info>
+		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+		<updated>2012-07-04T23:31:02+00:00</updated>
+	</info>
+	<style-options punctuation-in-quote="false"/>
+	<date form="text">
+		<date-part name="day" suffix=" "/>
+		<date-part name="month" suffix=" "/>
+		<date-part name="year"/>
+	</date>
+	<date form="numeric">
+		<date-part name="day" form="numeric-leading-zeros" suffix="/"/>
+		<date-part name="month" form="numeric-leading-zeros" suffix="/"/>
+		<date-part name="year"/>
+		</date>
+	<terms>
+		<term name="accessed">נבדק לאחרונה</term>
+		<term name="and">ו</term>
+		<term name="and others">ואחרים</term>
+		<term name="anonymous">אלמוני</term>
+		<term name="anonymous" form="short"> </term>
+		<term name="at">-ב</term>
+		<term name="available at">זמין ב</term>
+		<term name="by">על-ידי</term>
+		<term name="circa">לערך</term>
+		<term name="circa" form="short">~</term>
+		<term name="cited">מצוטט ב</term>
+		<term name="edition">
+			<single>מהדורה</single>
+			<multiple>מהדורות</multiple>
+		</term>
+		<term name="edition" form="short">מהדורה</term>
+		<term name="et-al">ואחרים</term>
+		<term name="forthcoming">צפוי</term>
+		<term name="from">מתוך</term>
+		<term name="ibid">שם</term>
+		<term name="in">בתוך</term>
+		<term name="in press">בדפוס</term>
+		<term name="internet">אתר</term>
+		<term name="interview">ראיון</term>
+		<term name="letter">מכתב</term>
+		<term name="no date">לא ידוע</term>
+		<term name="no date" form="short"> </term>
+		<term name="online">מקוון</term>
+		<term name="presented at">הוצג ב</term>
+		<term name="reference">
+			<single>הפניה</single>
+			<multiple>הפניות</multiple>
+		</term>
+		<term name="retrieved">אוחזר</term>
+		<term name="scale">קנ"מ</term>
+		<term name="version">גירסה</term>
+		<!-- ANNO DOMINI; BEFORE CHRIST -->
+		<term name="ad">לספירה</term>
+		<term name="bc">לפני הספירה</term>
+	
+		<!-- PUNCTUATION -->
+		<term name="open-quote">"</term>
+		<term name="close-quote">"</term>
+		<term name="open-inner-quote">'</term>
+		<term name="close-inner-quote">'</term>
+		<term name="page-range-delimiter">-</term>
 
-    <!-- PUNCTUATION -->
-    <term name="open-quote">"</term>
-    <term name="close-quote">"</term>
-    <term name="open-inner-quote">'</term>
-    <term name="close-inner-quote">'</term>
-    <term name="page-range-delimiter">-</term>
+		<!-- ORDINALS -->
+		<term name="ordinal-01">1</term>
+		<term name="ordinal-02">2</term>
+		<term name="ordinal-03">3</term>
+		<term name="ordinal-04">4</term>
+		<term name="ordinal-05">5</term>
+		<term name="ordinal-06">6</term>
+		<term name="ordinal-07">7</term>
+		<term name="ordinal-08">8</term>
+		<term name="ordinal-09">9</term>
+		<term name="ordinal-10">10</term>
+	 
+		<!-- LONG ORDINALS -->
+		<term name="long-ordinal-01">ראשון</term>
+		<term name="long-ordinal-02">שני</term>
+		<term name="long-ordinal-03">שלישי</term>
+		<term name="long-ordinal-04">רביעי</term>
+		<term name="long-ordinal-05">חמישי</term>
+		<term name="long-ordinal-06">שישי</term>
+		<term name="long-ordinal-07">שביעי</term>
+		<term name="long-ordinal-08">שמיני</term>
+		<term name="long-ordinal-09">תשיעי</term>
+		<term name="long-ordinal-10">עשירי</term>
 
-    <!-- ORDINALS -->
-    <term name="ordinal-01">1</term>
-    <term name="ordinal-02">2</term>
-    <term name="ordinal-03">3</term>
-    <term name="ordinal-04">4</term>
-    <term name="ordinal-05">5</term>
-    <term name="ordinal-06">6</term>
-    <term name="ordinal-07">7</term>
-    <term name="ordinal-08">8</term>
-    <term name="ordinal-09">9</term>
-    <term name="ordinal-10">10</term>
- 
-    <!-- LONG ORDINALS -->
-    <term name="long-ordinal-01">ראשון</term>
-    <term name="long-ordinal-02">שני</term>
-    <term name="long-ordinal-03">שלישי</term>
-    <term name="long-ordinal-04">רביעי</term>
-    <term name="long-ordinal-05">חמישי</term>
-    <term name="long-ordinal-06">שישי</term>
-    <term name="long-ordinal-07">שביעי</term>
-    <term name="long-ordinal-08">שמיני</term>
-    <term name="long-ordinal-09">תשיעי</term>
-    <term name="long-ordinal-10">עשירי</term>
-
-    <!-- LONG LOCATOR FORMS -->
-    <term name="book">
-      <single>ספר</single>
-      <multiple>ספרים</multiple>
-    </term>
-    <term name="chapter">
-      <single>פרק</single>
-      <multiple>פרקים</multiple>
-    </term>
-    <term name="column">
-      <single>טור</single>
-      <multiple>טורים</multiple>
-    </term>
-    <term name="figure">
-      <single>איור</single>
-      <multiple>איורים</multiple>
-    </term>
-    <term name="folio">
-      <single>פוליו</single>
-      <multiple>פוליו</multiple>
-    </term>
-    <term name="issue">
-      <single>מספר</single>
-      <multiple>מספרים</multiple>
-    </term>
-    <term name="line">
-      <single>שורה</single>
-      <multiple>שורות</multiple>
-    </term>
-    <term name="note">
-      <single>הערה</single>
-      <multiple>הערות</multiple>
-    </term>
-    <term name="opus">
-      <single>אופוס</single>
-      <multiple>אופרה</multiple>
-    </term>
-    <term name="page">
-      <single>עמוד</single>
-      <multiple>עמודים</multiple>
-    </term>
-    <term name="number-of-pages">
-      <single>עמוד</single>
-      <multiple>עמודים</multiple>
-    </term>
-    <term name="paragraph">
-      <single>פיסקה</single>
-      <multiple>פיסקאות</multiple>
-    </term>
-    <term name="part">
-      <single>חלק</single>
-      <multiple>חלקים</multiple>
-    </term>
-    <term name="section">
-      <single>סעיף</single>
-      <multiple>סעיפים</multiple>
-    </term>
-    <term name="sub verbo">
-      <single>sub verbo</single>
-      <multiple>sub verbis</multiple>
-    </term>
-    <term name="verse">
-      <single>פסוק</single>
-      <multiple>פסוקים</multiple>
-    </term>
-    <term name="volume">
-      <single>כרך</single>
-      <multiple>כרכים</multiple>
-    </term>
-
-    <!-- SHORT LOCATOR FORMS -->
-    <term name="book" form="short"></term>
-    <term name="chapter" form="short">פ'</term>
-    <term name="column" form="short">עמודה</term>
-    <term name="figure" form="short">א.</term>
-    <term name="folio" form="short">פול'</term>
-    <term name="issue" form="short">מס'</term>
-    <term name="line" form="short">ש'</term>
-    <term name="note" form="short">הע'</term>
-    <term name="opus" form="short">אופ'</term>
-    <term name="page" form="short">
-    <term name="paragraph" form="short">
-      <single>פ.</single>
-      <multiple>פ.</multiple>
-    </term>
-      <single>'עמ</single>
-      <multiple>'עמ</multiple>
-    </term>
-    <term name="number-of-pages" form="short">
-      <single>'עמ</single>
-      <multiple>'עמ</multiple>
-    </term>
-    <term name="part" form="short">חלק</term>
-    <term name="section" form="short">סע'</term>
-    <term name="sub verbo" form="short">
-      <single>s.v.</single>
-      <multiple>s.vv.</multiple>
-    </term>
-    <term name="verse" form="short">
-      <single>פס'</single>
-      <multiple>פס'</multiple>
-    </term>
-    <term name="volume" form="short">
-      <single>כרך</single>
-      <multiple>כרכים</multiple>
-    </term>
-
-    <!-- SYMBOL LOCATOR FORMS -->
-    <term name="paragraph" form="symbol">
-      <single>¶</single>
-      <multiple>¶¶</multiple>
-    </term>
-    <term name="section" form="symbol">
-      <single>§</single>
-      <multiple>§§</multiple>
-    </term>
-
-    <!-- LONG ROLE FORMS -->
-    <term name="director">
-      <single>במאי</single>
-      <multiple>במאים</multiple>
-    </term>
-    <term name="editor">
-      <single>עורך</single>
-      <multiple>עורכים</multiple>
-    </term>
-    <term name="editorial-director">
-      <single>עורך ראשי</single>
-      <multiple>עורכים ראשיים</multiple>
-    </term>
-    <term name="illustrator">
-      <single>איור</single>
-      <multiple>איור</multiple>
-    </term>
-    <term name="translator">
-      <single>תרגום</single>
-      <multiple>תרגום</multiple>
-    </term>
-    <term name="editortranslator">
-      <single>בתרגום ועריכת/single>
-      <multiple>בתרגום ועריכת:</multiple>
-    </term>
-
-    <!-- SHORT ROLE FORMS -->
-    <term name="director" form="short">
-      <single>בימוי</single>
-      <multiple>בימוי:</multiple>
-    </term>
-    <term name="editor" form="short">
-      <single>בעריכת</single>
-      <multiple>בעריכת:</multiple>
-    </term>
-    <term name="editorial-director" form="short">
-      <single>ע.ר.</single>
-      <multiple>עריכה ראשית:</multiple>
-    </term>
-    <term name="illustrator" form="short">
-      <single>איור</single>
-      <multiple>איור:</multiple>
-    </term>
-    <term name="translator" form="short">
-      <single>בתרגום</single>
-      <multiple>בתרגום:</multiple>
-    </term>
-    <term name="editortranslator" form="short">
-      <single>עריכה ותרגום</single>
-      <multiple>עריכה ותרגום:</multiple>
-    </term>
-
-    <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb">על ידי</term>
-    <term name="director" form="verb">בוים ע"י</term>
-    <term name="editor" form="verb">נערך ע"י</term>
-    <term name="editorial-director" form="verb">בוים ע"י</term>
-    <term name="illustrator" form="verb">אויר ע"י</term>
-    <term name="interviewer" form="verb">רואיין ע"י</term>
-    <term name="recipient" form="verb">אל</term>
-    <term name="reviewed-author" form="verb">ע"י</term>
-    <term name="translator" form="verb">תורגם ע"י</term>
-    <term name="editortranslator" form="verb">תורגם ונכרך על ידי:</term>
-
-    <!-- SHORT VERB ROLE FORMS -->
-    <term name="director" form="verb-short">בימוי</term>
-    <term name="editor" form="verb-short">עריכה:</term>
-    <term name="editorial-director" form="verb-short">עריכה ראשית:</term>
-    <term name="illustrator" form="verb-short">מאיירים:</term>
-    <term name="translator" form="verb-short">תרגום: </term>
-    <term name="editortranslator" form="verb-short">עריכה ותרגום:</term>
-
-    <!-- LONG MONTH FORMS -->
-    <term name="month-01">ינואר</term>
-    <term name="month-02">פברואר</term>
-    <term name="month-03">מרץ</term>
-    <term name="month-04">אפריל</term>
-    <term name="month-05">מאי</term>
-    <term name="month-06">יוני</term>
-    <term name="month-07">יולי</term>
-    <term name="month-08">אוגוסט</term>
-    <term name="month-09">ספטמבר</term>
-    <term name="month-10">אוקטובר</term>
-    <term name="month-11">נובמבר</term>
-    <term name="month-12">דצמבר</term>
-
-    <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">ינו'</term>
-    <term name="month-02" form="short">פב'</term>
-    <term name="month-03" form="short">מרץ</term>
-    <term name="month-04" form="short">אפר'</term>
-    <term name="month-05" form="short">מאי</term>
-    <term name="month-06" form="short">יונ'</term>
-    <term name="month-07" form="short">יול'</term>
-    <term name="month-08" form="short">אוג'</term>
-    <term name="month-09" form="short">ספט'</term>
-    <term name="month-10" form="short">אוק'</term>
-    <term name="month-11" form="short">נוב'</term>
-    <term name="month-12" form="short">דצמ'</term>
-
-    <!-- SEASONS -->
-    <term name="season-01">אביב</term>
-    <term name="season-02">קיץ</term>
-    <term name="season-03">סתיו</term>
-    <term name="season-04">חורף</term>
-  </terms>
+		<!-- LONG LOCATOR FORMS -->
+		<term name="book">
+			<single>ספר</single>
+			<multiple>ספרים</multiple>
+		</term>
+		<term name="chapter">
+			<single>פרק</single>
+			<multiple>פרקים</multiple>
+		</term>
+		<term name="column">
+			<single>טור</single>
+			<multiple>טורים</multiple>
+		</term>
+		<term name="figure">
+			<single>איור</single>
+			<multiple>איורים</multiple>
+		</term>
+		<term name="folio">
+			<single>פוליו</single>
+			<multiple>פוליו</multiple>
+		</term>
+		<term name="issue">
+			<single>מספר</single>
+			<multiple>מספרים</multiple>
+		</term>
+		<term name="line">
+			<single>שורה</single>
+			<multiple>שורות</multiple>
+		</term>
+		<term name="note">
+			<single>הערה</single>
+			<multiple>הערות</multiple>
+		</term>
+		<term name="opus">
+			<single>אופוס</single>
+			<multiple>אופרה</multiple>
+		</term>
+		<term name="page">
+			<single>עמוד</single>
+			<multiple>עמודים</multiple>
+		</term>
+		<term name="number-of-pages">
+			<single>עמוד</single>
+			<multiple>עמודים</multiple>
+		</term>
+		<term name="paragraph">
+			<single>פיסקה</single>
+			<multiple>פיסקאות</multiple>
+		</term>
+		<term name="part">
+			<single>חלק</single>
+			<multiple>חלקים</multiple>
+		</term>
+		<term name="section">
+			<single>סעיף</single>
+			<multiple>סעיפים</multiple>
+		</term>
+		<term name="sub verbo">
+			<single>sub verbo</single>
+			<multiple>sub verbis</multiple>
+		</term>
+		<term name="verse">
+			<single>פסוק</single>
+			<multiple>פסוקים</multiple>
+		</term>
+		<term name="volume">
+			<single>כרך</single>
+			<multiple>כרכים</multiple>
+		</term>
+		<!-- SHORT LOCATOR FORMS -->
+		<term name="book" form="short"> </term>
+		<term name="chapter" form="short">פ'</term>
+		<term name="column" form="short">ט'</term>
+		<term name="figure" form="short">א.</term>
+		<term name="folio" form="short">פול'</term>
+		<term name="issue" form="short">מס'</term>
+		<term name="line" form="short">ש'</term>
+		<term name="note" form="short">הע'</term>
+		<term name="opus" form="short">אופ'</term>
+		<term name="page" form="short">
+			<single>'עמ</single>
+			<multiple>'עמ</multiple>
+		</term>
+		<term name="paragraph" form="short">
+			<single>פ.</single>
+			<multiple>פ.</multiple>
+		</term>
+		<term name="number-of-pages" form="short">
+			<single>'עמ</single>
+			<multiple>'עמ</multiple>
+		</term>
+		<term name="part" form="short">חלק</term>
+		<term name="section" form="short">סע'</term>
+		<term name="sub verbo" form="short">
+			<single>s.v.</single>
+			<multiple>s.vv.</multiple>
+		</term>
+		<term name="verse" form="short">
+			<single>פס'</single>
+			<multiple>פס'</multiple>
+		</term>
+		<term name="volume" form="short">
+			<single>כרך</single>
+			<multiple>כרכים</multiple>
+		</term>
+		<!-- SYMBOL LOCATOR FORMS -->
+		<term name="paragraph" form="symbol">
+			<single>¶</single>
+			<multiple>¶¶</multiple>
+		</term>
+		<term name="section" form="symbol">
+			<single>§</single>
+			<multiple>§§</multiple>
+		</term>
+		<!-- LONG ROLE FORMS -->
+		<term name="director">
+			<single>במאי</single>
+			<multiple>במאים</multiple>
+		</term>
+		<term name="editor">
+			<single>עורך</single>
+			<multiple>עורכים</multiple>
+		</term>
+		<term name="editorial-director">
+			<single>עורך ראשי</single>
+			<multiple>עורכים ראשיים</multiple>
+		</term>
+		<term name="illustrator">
+			<single>איור</single>
+			<multiple>איור</multiple>
+		</term>
+		<term name="translator">
+			<single>תרגום</single>
+			<multiple>תרגום</multiple>
+		</term>
+		<term name="editortranslator">
+			<single>בתרגום ועריכת</single>
+			<multiple>בתרגום ועריכת:</multiple>
+		</term>
+		<!-- SHORT ROLE FORMS -->
+		<term name="director" form="short">
+			<single>בימוי</single>
+			<multiple>בימוי:</multiple>
+		</term>
+		<term name="editor" form="short">
+			<single>בעריכת</single>
+			<multiple>בעריכת:</multiple>
+		</term>
+		<term name="editorial-director" form="short">
+			<single>ע.ר.</single>
+			<multiple>עריכה ראשית:</multiple>
+		</term>
+		<term name="illustrator" form="short">
+			<single>איור</single>
+			<multiple>איור:</multiple>
+		</term>
+		<term name="translator" form="short">
+			<single>בתרגום</single>
+			<multiple>בתרגום:</multiple>
+		</term>
+		<term name="editortranslator" form="short">
+			<single>עריכה ותרגום</single>
+			<multiple>עריכה ותרגום:</multiple>
+		</term>
+		<!-- VERB ROLE FORMS -->
+		<term name="container-author" form="verb">על ידי</term>
+		<term name="director" form="verb">בוים ע"י</term>
+		<term name="editor" form="verb">נערך ע"י</term>
+		<term name="editorial-director" form="verb">בוים ע"י</term>
+		<term name="illustrator" form="verb">אויר ע"י</term>
+		<term name="interviewer" form="verb">רואיין ע"י</term>
+		<term name="recipient" form="verb">אל</term>
+		<term name="reviewed-author" form="verb">ע"י</term>
+		<term name="translator" form="verb">תורגם ע"י</term>
+		<term name="editortranslator" form="verb">תורגם ונכרך על ידי:</term>
+		<!-- SHORT VERB ROLE FORMS -->
+		<term name="director" form="verb-short">בימוי</term>
+		<term name="editor" form="verb-short">עריכה:</term>
+		<term name="editorial-director" form="verb-short">עריכה ראשית:</term>
+		<term name="illustrator" form="verb-short">מאיירים:</term>
+		<term name="translator" form="verb-short">תרגום: </term>
+		<term name="editortranslator" form="verb-short">עריכה ותרגום:</term>
+		<!-- LONG MONTH FORMS -->
+		<term name="month-01">ינואר</term>
+		<term name="month-02">פברואר</term>
+		<term name="month-03">מרץ</term>
+		<term name="month-04">אפריל</term>
+		<term name="month-05">מאי</term>
+		<term name="month-06">יוני</term>
+		<term name="month-07">יולי</term>
+		<term name="month-08">אוגוסט</term>
+		<term name="month-09">ספטמבר</term>
+		<term name="month-10">אוקטובר</term>
+		<term name="month-11">נובמבר</term>
+		<term name="month-12">דצמבר</term>
+		<!-- SHORT MONTH FORMS -->
+		<term name="month-01" form="short">ינו'</term>
+		<term name="month-02" form="short">פב'</term>
+		<term name="month-03" form="short">מרץ</term>
+		<term name="month-04" form="short">אפר'</term>
+		<term name="month-05" form="short">מאי</term>
+		<term name="month-06" form="short">יונ'</term>
+		<term name="month-07" form="short">יול'</term>
+		<term name="month-08" form="short">אוג'</term>
+		<term name="month-09" form="short">ספט'</term>
+		<term name="month-10" form="short">אוק'</term>
+		<term name="month-11" form="short">נוב'</term>
+		<term name="month-12" form="short">דצמ'</term>
+		<!-- SEASONS -->
+		<term name="season-01">אביב</term>
+		<term name="season-02">קיץ</term>
+		<term name="season-03">סתיו</term>
+		<term name="season-04">חורף</term>
+	</terms>
 </locale>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -20,63 +20,61 @@
     <term name="and">ו</term>
     <term name="and others">ואחרים</term>
     <term name="anonymous">אלמוני</term>
-    <term name="anonymous" form="short">anon</term>
+    <term name="anonymous" form="short"></term>
     <term name="at">-ב</term>
     <term name="available at">זמין ב</term>
     <term name="by">על-ידי</term>
     <term name="circa">לערך</term>
-    <term name="circa" form="short">c.</term>
+    <term name="circa" form="short">~</term>
     <term name="cited">מצוטט ב</term>
     <term name="edition">
       <single>מהדורה</single>
       <multiple>מהדורות</multiple>
     </term>
-    <term name="edition" form="short">ed</term>
+    <term name="edition" form="short">מהדורה</term>
     <term name="et-al">ואחרים</term>
     <term name="forthcoming">צפוי</term>
     <term name="from">מתוך</term>
     <term name="ibid">שם</term>
     <term name="in">בתוך</term>
-    <term name="in press">בהדפסה</term>
-    <term name="internet">אינטרנט</term>
+    <term name="in press">בדפוס</term>
+    <term name="internet">אתר</term>
     <term name="interview">ראיון</term>
     <term name="letter">מכתב</term>
-    <term name="no date">אין נתונים</term>
-    <term name="no date" form="short">nd</term>
+    <term name="no date">לא ידוע/term>
+    <term name="no date" form="short"></term>
     <term name="online">מקוון</term>
     <term name="presented at">הוצג ב</term>
     <term name="reference">
       <single>הפניה</single>
       <multiple>הפניות</multiple>
     </term>
-    <term name="reference" form="short">
-      <single>ref.</single>
-      <multiple>refs.</multiple>
-    </term>
     <term name="retrieved">אוחזר</term>
     <term name="scale">scale</term>
     <term name="version">גירסה</term>
-
     <!-- ANNO DOMINI; BEFORE CHRIST -->
     <term name="ad">לספירה</term>
     <term name="bc">לפני הספירה</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">“</term>
-    <term name="close-quote">”</term>
-    <term name="open-inner-quote">‘</term>
-    <term name="close-inner-quote">’</term>
-    <term name="page-range-delimiter">–</term>
+    <term name="open-quote">"</term>
+    <term name="close-quote">"</term>
+    <term name="open-inner-quote">'</term>
+    <term name="close-inner-quote">'</term>
+    <term name="page-range-delimiter">-</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">th</term>
-    <term name="ordinal-01">st</term>
-    <term name="ordinal-02">nd</term>
-    <term name="ordinal-03">rd</term>
-    <term name="ordinal-11">th</term>
-    <term name="ordinal-12">th</term>
-    <term name="ordinal-13">th</term>
-
+    <term name="ordinal-01">1</term>
+    <term name="ordinal-02">2</term>
+    <term name="ordinal-03">3</term>
+    <term name="ordinal-04">4</term>
+    <term name="ordinal-05">5</term>
+    <term name="ordinal-06">6</term>
+    <term name="ordinal-07">7</term>
+    <term name="ordinal-08">8</term>
+    <term name="ordinal-09">9</term>
+    <term name="ordinal-10">10</term>
+ 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">ראשון</term>
     <term name="long-ordinal-02">שני</term>
@@ -103,8 +101,8 @@
       <multiple>טורים</multiple>
     </term>
     <term name="figure">
-      <single>figure</single>
-      <multiple>figures</multiple>
+      <single>איור</single>
+      <multiple>איורים</multiple>
     </term>
     <term name="folio">
       <single>פוליו</single>
@@ -151,8 +149,8 @@
       <multiple>sub verbis</multiple>
     </term>
     <term name="verse">
-      <single>בית</single>
-      <multiple>בתים</multiple>
+      <single>פסוק</single>
+      <multiple>פסוקים</multiple>
     </term>
     <term name="volume">
       <single>כרך</single>
@@ -160,16 +158,20 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="book" form="short">bk</term>
-    <term name="chapter" form="short">chap</term>
-    <term name="column" form="short">col</term>
-    <term name="figure" form="short">fig</term>
-    <term name="folio" form="short">f</term>
-    <term name="issue" form="short">no</term>
-    <term name="line" form="short">l.</term>
-    <term name="note" form="short">n.</term>
-    <term name="opus" form="short">op</term>
+    <term name="book" form="short"></term>
+    <term name="chapter" form="short">פ'</term>
+    <term name="column" form="short">עמודה</term>
+    <term name="figure" form="short">א.</term>
+    <term name="folio" form="short">פול'</term>
+    <term name="issue" form="short">מס'</term>
+    <term name="line" form="short">ש'</term>
+    <term name="note" form="short">הע'</term>
+    <term name="opus" form="short">אופ'</term>
     <term name="page" form="short">
+    <term name="paragraph" form="short">
+      <single>פ.</single>
+      <multiple>פ.</multiple>
+    </term>
       <single>'עמ</single>
       <multiple>'עמ</multiple>
     </term>
@@ -177,20 +179,19 @@
       <single>'עמ</single>
       <multiple>'עמ</multiple>
     </term>
-    <term name="paragraph" form="short">para</term>
-    <term name="part" form="short">pt</term>
-    <term name="section" form="short">ס'</term>
+    <term name="part" form="short">חלק</term>
+    <term name="section" form="short">סע'</term>
     <term name="sub verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>
     <term name="verse" form="short">
-      <single>v</single>
-      <multiple>vv</multiple>
+      <single>פס'</single>
+      <multiple>פס'</multiple>
     </term>
     <term name="volume" form="short">
-      <single>vol</single>
-      <multiple>vols</multiple>
+      <single>כרך</single>
+      <multiple>כרכים</multiple>
     </term>
 
     <!-- SYMBOL LOCATOR FORMS -->
@@ -217,46 +218,46 @@
       <multiple>עורכים ראשיים</multiple>
     </term>
     <term name="illustrator">
-      <single>מאייר</single>
-      <multiple>מאיירים</multiple>
+      <single>איור</single>
+      <multiple>איור</multiple>
     </term>
     <term name="translator">
-      <single>מתרגם</single>
-      <multiple>מתרגמים</multiple>
+      <single>תרגום</single>
+      <multiple>תרגום</multiple>
     </term>
     <term name="editortranslator">
-      <single>editor &amp; translator</single>
-      <multiple>editors &amp; translators</multiple>
+      <single>בתרגום ועריכת/single>
+      <multiple>בתרגום ועריכת:</multiple>
     </term>
 
     <!-- SHORT ROLE FORMS -->
     <term name="director" form="short">
-      <single>dir.</single>
-      <multiple>dirs.</multiple>
+      <single>בימוי</single>
+      <multiple>בימוי:</multiple>
     </term>
     <term name="editor" form="short">
-      <single>ed</single>
-      <multiple>eds</multiple>
+      <single>בעריכת</single>
+      <multiple>בעריכת:</multiple>
     </term>
     <term name="editorial-director" form="short">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
+      <single>ע.ר.</single>
+      <multiple>עריכה ראשית:</multiple>
     </term>
     <term name="illustrator" form="short">
-      <single>ill.</single>
-      <multiple>ills.</multiple>
+      <single>איור</single>
+      <multiple>איור:</multiple>
     </term>
     <term name="translator" form="short">
-      <single>tran</single>
-      <multiple>trans</multiple>
+      <single>בתרגום</single>
+      <multiple>בתרגום:</multiple>
     </term>
     <term name="editortranslator" form="short">
-      <single>ed. &amp; tran.</single>
-      <multiple>eds. &amp; trans.</multiple>
+      <single>עריכה ותרגום</single>
+      <multiple>עריכה ותרגום:</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb">by</term>
+    <term name="container-author" form="verb">על ידי</term>
     <term name="director" form="verb">בוים ע"י</term>
     <term name="editor" form="verb">נערך ע"י</term>
     <term name="editorial-director" form="verb">בוים ע"י</term>
@@ -265,15 +266,15 @@
     <term name="recipient" form="verb">אל</term>
     <term name="reviewed-author" form="verb">ע"י</term>
     <term name="translator" form="verb">תורגם ע"י</term>
-    <term name="editortranslator" form="verb">edited &amp; translated by</term>
+    <term name="editortranslator" form="verb">תורגם ונכרך על ידי:</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="director" form="verb-short">dir.</term>
-    <term name="editor" form="verb-short">ed</term>
-    <term name="editorial-director" form="verb-short">ed.</term>
-    <term name="illustrator" form="verb-short">illus.</term>
-    <term name="translator" form="verb-short">trans</term>
-    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="director" form="verb-short">בימוי</term>
+    <term name="editor" form="verb-short">עריכה:</term>
+    <term name="editorial-director" form="verb-short">עריכה ראשית:</term>
+    <term name="illustrator" form="verb-short">מאיירים:</term>
+    <term name="translator" form="verb-short">תרגום: </term>
+    <term name="editortranslator" form="verb-short">עריכה ותרגום:</term>
 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">ינואר</term>
@@ -290,23 +291,23 @@
     <term name="month-12">דצמבר</term>
 
     <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">Jan</term>
-    <term name="month-02" form="short">Feb</term>
-    <term name="month-03" form="short">Mar</term>
-    <term name="month-04" form="short">Apr</term>
-    <term name="month-05" form="short">May</term>
-    <term name="month-06" form="short">Jun</term>
-    <term name="month-07" form="short">Jul</term>
-    <term name="month-08" form="short">Aug</term>
-    <term name="month-09" form="short">Sep</term>
-    <term name="month-10" form="short">Oct</term>
-    <term name="month-11" form="short">Nov</term>
-    <term name="month-12" form="short">Dec</term>
+    <term name="month-01" form="short">ינו'</term>
+    <term name="month-02" form="short">פב'</term>
+    <term name="month-03" form="short">מרץ</term>
+    <term name="month-04" form="short">אפר'</term>
+    <term name="month-05" form="short">מאי</term>
+    <term name="month-06" form="short">יונ'</term>
+    <term name="month-07" form="short">יול'</term>
+    <term name="month-08" form="short">אוג'</term>
+    <term name="month-09" form="short">ספט'</term>
+    <term name="month-10" form="short">אוק'</term>
+    <term name="month-11" form="short">נוב'</term>
+    <term name="month-12" form="short">דצמ'</term>
 
     <!-- SEASONS -->
-    <term name="season-01">Spring</term>
-    <term name="season-02">Summer</term>
-    <term name="season-03">Autumn</term>
-    <term name="season-04">Winter</term>
+    <term name="season-01">אביב</term>
+    <term name="season-02">קיץ</term>
+    <term name="season-03">סתיו</term>
+    <term name="season-04">חורף</term>
   </terms>
 </locale>


### PR DESCRIPTION
added and corrected a few terms in Hebrew.
note that since in Hebrew their is a distinction between feminine and masculine, and there is none in the current format, I changed those terms to a general title, i.e: translator = תרגום instead of מתרגם/ת
