### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "citation-style-language/locales",
+    "description": "Citation Style Language (CSL) Locales",
+    "type": "library",
+    "license": "Creative Commons Attribution-ShareAlike 3.0 License",
+    "homepage": "http://citationstyles.org/",
+    "authors": [
+        {
+            "name": "Citation Style Language (CSL) Team",
+            "homepage": "http://citationstyles.org/about/#Credits"
+        }
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
+    "require": {}
+}


### PR DESCRIPTION
Simplify integration of this repository through Composer.

However, as long as the package is missing on https://packagist.org/, the repository still needs to be added to the `composer.json` file of a project.