### PR TITLE
change date suffix comma to arabic comma

### DIFF
--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -7,7 +7,7 @@
   <style-options punctuation-in-quote="false"/>
   <date form="text">
     <date-part name="day" suffix=" "/>
-    <date-part name="month" suffix=", "/>
+    <date-part name="month" suffix="، "/>
     <date-part name="year"/>
   </date>
   <date form="numeric">


### PR DESCRIPTION
Is the latin comma necessary for dates? I feel the Arabic comma would be more homogenous.