### PR TITLE
update locales-ar for grammar and completeness

### DIFF
--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -54,8 +54,8 @@
       <multiple>مراجع</multiple>
     </term>
     <term name="retrieved">استرجع في</term>
-    <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="scale">السلم الموسيقي</term>
+    <term name="version">نسخة</term>
 
     <!-- ANNO DOMINI; BEFORE CHRIST -->
     <term name="ad">ب.م.</term>
@@ -161,18 +161,18 @@
     <term name="folio" form="short">مطوية</term>
     <term name="issue" form="short">عدد</term>
     <term name="line" form="short">سـ</term>
-    <term name="note" form="short">n.</term>
+    <term name="note" form="short">نكتة</term>
     <term name="opus" form="short">نوتة موسيقية</term>
     <term name="page" form="short">
-      <single>صـ</single>
-      <multiple>صـ</multiple>
+      <single>ص.</single>
+      <multiple>ص.</multiple>
     </term>
     <term name="number-of-pages" form="short">
-      <single>صـ</single>
-      <multiple>صـ</multiple>
+      <single>ص.</single>
+      <multiple>ص.</multiple>
     </term>
     <term name="paragraph" form="short">فقرة</term>
-    <term name="part" form="short">جـ.</term>
+    <term name="part" form="short">ج.</term>
     <term name="section" form="short">قسم</term>
     <term name="sub verbo" form="short">
       <single>تفسير فرعي</single>
@@ -183,8 +183,8 @@
       <multiple>أبيات شعر</multiple>
     </term>
     <term name="volume" form="short">
-      <single>مجـ.</single>
-      <multiple>مجـ.</multiple>
+      <single>مج.</single>
+      <multiple>مج.</multiple>
     </term>
 
     <!-- SYMBOL LOCATOR FORMS -->
@@ -198,77 +198,29 @@
     </term>
 
     <!-- LONG ROLE FORMS -->
-    <term name="director">
-      <single>مدور</single>
-      <multiple>مدورين</multiple>
-    </term>
-    <term name="editor">
-      <single>محرر</single>
-      <multiple>محررون</multiple>
-    </term>
-    <term name="editorial-director">
-      <single>رئيس التحرير</single>
-      <multiple>رؤساء التحرير</multiple>
-    </term>
-    <term name="illustrator">
-      <single>مرسم</single>
-      <multiple>مرسمون</multiple>
-    </term>
-    <term name="translator">
-      <single>مترجم</single>
-      <multiple>مترجمون</multiple>
-    </term>
-    <term name="editortranslator">
-      <single>مترجم ومحرر</single>
-      <multiple>مترجمون ومحررون</multiple>
-    </term>
+    <term name="director">ادارة</term>
+    <term name="editor">تحقيق</term>
+    <term name="editorial-director">قيادة التحرير</term>
+    <term name="illustrator">رسوم</term>
+    <term name="translator">ترجمة</term>
+    <term name="editortranslator">ترجمة وتحقيق</term>
 
     <!-- SHORT ROLE FORMS -->
-    <term name="director" form="short">
-      <single>مدور</single>
-      <multiple>مدورون</multiple>
-    </term>
-    <term name="editor" form="short">
-      <single>محرر</single>
-      <multiple>محررون</multiple>
-    </term>
-    <term name="editorial-director" form="short">
-      <single>مشرف على الطبعة</single>
-      <multiple>مشرفون على الطبعة</multiple>
-    </term>
-    <term name="illustrator" form="short">
-      <single>مرسم</single>
-      <multiple>مرسمون</multiple>
-    </term>
-    <term name="translator" form="short">
-      <single>مترجم</single>
-      <multiple>مترجمون</multiple>
-    </term>
-    <term name="editortranslator" form="short">
-      <single>مترجم ومشرف على الطباعه</single>
-      <multiple>مترجمون ومشرفون على الطباعه</multiple>
-    </term>
 
     <!-- VERB ROLE FORMS -->
     <term name="container-author" form="verb">انشاء</term>
     <term name="director" form="verb">اشراف</term>
-    <term name="editor" form="verb">تحرير</term>
+    <term name="editor" form="verb">تحقيق</term>
     <term name="editorial-director" form="verb">اعداد</term>
-    <term name="illustrator" form="verb">ترسيم</term>
+    <term name="illustrator" form="verb">رسوم</term>
     <term name="interviewer" form="verb">مقابلة بواسطة</term>
     <term name="recipient" form="verb">مرسل الى</term>
     <term name="reviewed-author" form="verb">مراجعة</term>
     <term name="translator" form="verb">ترجمة</term>
-    <term name="editortranslator" form="verb">اعداد وترجمة</term>
+    <term name="editortranslator" form="verb">تحقيق وترجمة</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="director" form="verb-short">اشراف</term>
-    <term name="editor" form="verb-short">تحرير</term>
-    <term name="editorial-director" form="verb-short">اشرف على الطبعة</term>
-    <term name="illustrator" form="verb-short">ترسيم.</term>
-    <term name="translator" form="verb-short">ترجمة</term>
-    <term name="editortranslator" form="verb-short">الترجمة والإشراف على الطباعة لـ</term>
-
+ 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">يناير</term>
     <term name="month-02">فبراير</term>
@@ -284,18 +236,7 @@
     <term name="month-12">ديسمبر</term>
 
     <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">يناير</term>
-    <term name="month-02" form="short">فبراير</term>
-    <term name="month-03" form="short">مارس</term>
-    <term name="month-04" form="short">ابريل</term>
-    <term name="month-05" form="short">مايو</term>
-    <term name="month-06" form="short">يونيو</term>
-    <term name="month-07" form="short">يوليو</term>
-    <term name="month-08" form="short">اغسطس</term>
-    <term name="month-09" form="short">سبتمبر</term>
-    <term name="month-10" form="short">اكتوبر</term>
-    <term name="month-11" form="short">نوفمبر</term>
-    <term name="month-12" form="short">ديسمبر</term>
+
 
     <!-- SEASONS -->
     <term name="season-01">الربيع</term>


### PR DESCRIPTION
Changed delimiter in dates from Latin comma (,) to Arabic comma (،)
Changed tense of roles from modified to _marfu'_ (The form they were previously in - ending in ين- is used when that word has been modified by another word or is the object of a verb. The ون form is what it would take if it has been unmodified or at the beginning of a sentence - which is what the use case would be here.)
Added _kashida_ to short forms which have been abbreviated. 
Changed pages (single and multiple) to صـ (I don't think ص.ص. might be appropriate though it is analogous to pp.)
Completed a few entries. (They might not be totally in agreement with what is commonly used, but they can be modified in individual styles according to local tastes or changed here. But I think minimizing the mixing of LTR and RTL characters is very important...it can lead to serious confusion!)