### PR TITLE
Update locales-ar.xml

### DIFF
--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -199,12 +199,12 @@
 
     <!-- LONG ROLE FORMS -->
     <term name="director">
-      <single>مدور</single>
-      <multiple>مدورين</multiple>
+      <single>مدير</single>
+      <multiple>مديرون</multiple>
     </term>
     <term name="editor">
-      <single>محرر</single>
-      <multiple>محررين</multiple>
+      <single>محقق</single>
+      <multiple>محققون</multiple>
     </term>
     <term name="editorial-director">
       <single>رئيس التحرير</single>
@@ -229,8 +229,8 @@
       <multiple>dirs.</multiple>
     </term>
     <term name="editor" form="short">
-      <single>محرر</single>
-      <multiple>محررين</multiple>
+      <single>محقق</single>
+      <multiple>محققون</multiple>
     </term>
     <term name="editorial-director" form="short">
       <single>مشرف على الطبعة</single>
@@ -252,7 +252,7 @@
     <!-- VERB ROLE FORMS -->
     <term name="container-author" form="verb"></term>
     <term name="director" form="verb">directed by</term>
-    <term name="editor" form="verb">تحرير</term>
+    <term name="editor" form="verb">تحقيق</term>
     <term name="editorial-director" form="verb">اعداد</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">مقابلة بواسطة</term>
@@ -263,7 +263,7 @@
 
     <!-- SHORT VERB ROLE FORMS -->
     <term name="director" form="verb-short">dir.</term>
-    <term name="editor" form="verb-short">تحرير</term>
+    <term name="editor" form="verb-short">تحقيق</term>
     <term name="editorial-director" form="verb-short">اشرف على الطبعة</term>
     <term name="illustrator" form="verb-short">illus.</term>
     <term name="translator" form="verb-short">ترجمة</term>


### PR DESCRIPTION
in editing Books, we Arabs use the word "تحقيق"  not "تحرير" 
you almost can find this word "تحقيق" at the top page of every edited book.
thank you.