### PR TITLE
Add translators from git log to the locale files.

### DIFF
--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -7,7 +7,7 @@
   <style-options punctuation-in-quote="false"/>
   <date form="text">
     <date-part name="day" suffix=" "/>
-    <date-part name="month" suffix=", "/>
+    <date-part name="month" suffix="، "/>
     <date-part name="year"/>
   </date>
   <date form="numeric">
@@ -54,8 +54,8 @@
       <multiple>مراجع</multiple>
     </term>
     <term name="retrieved">استرجع في</term>
-    <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="scale">السلم الموسيقي</term>
+    <term name="version">نسخة</term>
 
     <!-- ANNO DOMINI; BEFORE CHRIST -->
     <term name="ad">ب.م.</term>
@@ -160,16 +160,16 @@
     <term name="figure" form="short">رسم توضيحي</term>
     <term name="folio" form="short">مطوية</term>
     <term name="issue" form="short">عدد</term>
-    <term name="line" form="short">l.</term>
-    <term name="note" form="short">n.</term>
+    <term name="line" form="short">سـ</term>
+    <term name="note" form="short">نكتة</term>
     <term name="opus" form="short">نوتة موسيقية</term>
     <term name="page" form="short">
-      <single>ص</single>
-      <multiple>ص.ص.</multiple>
+      <single>ص.</single>
+      <multiple>ص.</multiple>
     </term>
     <term name="number-of-pages" form="short">
-      <single>ص</single>
-      <multiple>ص.ص.</multiple>
+      <single>ص.</single>
+      <multiple>ص.</multiple>
     </term>
     <term name="paragraph" form="short">فقرة</term>
     <term name="part" form="short">ج.</term>
@@ -198,77 +198,29 @@
     </term>
 
     <!-- LONG ROLE FORMS -->
-    <term name="director">
-      <single>مدور</single>
-      <multiple>مدورين</multiple>
-    </term>
-    <term name="editor">
-      <single>محرر</single>
-      <multiple>محررين</multiple>
-    </term>
-    <term name="editorial-director">
-      <single>رئيس التحرير</single>
-      <multiple>رؤساء التحرير</multiple>
-    </term>
-    <term name="illustrator">
-      <single>illustrator</single>
-      <multiple>illustrators</multiple>
-    </term>
-    <term name="translator">
-      <single>مترجم</single>
-      <multiple>مترجمين</multiple>
-    </term>
-    <term name="editortranslator">
-      <single>مترجم ومحرر</single>
-      <multiple>مترجمين ومحررين</multiple>
-    </term>
+    <term name="director">ادارة</term>
+    <term name="editor">تحقيق</term>
+    <term name="editorial-director">قيادة التحرير</term>
+    <term name="illustrator">رسوم</term>
+    <term name="translator">ترجمة</term>
+    <term name="editortranslator">ترجمة وتحقيق</term>
 
     <!-- SHORT ROLE FORMS -->
-    <term name="director" form="short">
-      <single>dir.</single>
-      <multiple>dirs.</multiple>
-    </term>
-    <term name="editor" form="short">
-      <single>محرر</single>
-      <multiple>محررين</multiple>
-    </term>
-    <term name="editorial-director" form="short">
-      <single>مشرف على الطبعة</single>
-      <multiple>مشرفين على الطبعة</multiple>
-    </term>
-    <term name="illustrator" form="short">
-      <single>ill.</single>
-      <multiple>ills.</multiple>
-    </term>
-    <term name="translator" form="short">
-      <single>مترجم</single>
-      <multiple>مترجمين</multiple>
-    </term>
-    <term name="editortranslator" form="short">
-      <single>مترجم ومشرف على الطباعه</single>
-      <multiple>مترجمين ومشرفين على الطباعه</multiple>
-    </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb"></term>
-    <term name="director" form="verb">directed by</term>
-    <term name="editor" form="verb">تحرير</term>
+    <term name="container-author" form="verb">انشاء</term>
+    <term name="director" form="verb">اشراف</term>
+    <term name="editor" form="verb">تحقيق</term>
     <term name="editorial-director" form="verb">اعداد</term>
-    <term name="illustrator" form="verb">illustrated by</term>
+    <term name="illustrator" form="verb">رسوم</term>
     <term name="interviewer" form="verb">مقابلة بواسطة</term>
     <term name="recipient" form="verb">مرسل الى</term>
-    <term name="reviewed-author" form="verb">بـ</term>
+    <term name="reviewed-author" form="verb">مراجعة</term>
     <term name="translator" form="verb">ترجمة</term>
-    <term name="editortranslator" form="verb">اعداد وترجمة</term>
+    <term name="editortranslator" form="verb">تحقيق وترجمة</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="director" form="verb-short">dir.</term>
-    <term name="editor" form="verb-short">تحرير</term>
-    <term name="editorial-director" form="verb-short">اشرف على الطبعة</term>
-    <term name="illustrator" form="verb-short">illus.</term>
-    <term name="translator" form="verb-short">ترجمة</term>
-    <term name="editortranslator" form="verb-short">ترجمه واشرف على الطباعه</term>
-
+ 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">يناير</term>
     <term name="month-02">فبراير</term>
@@ -284,18 +236,7 @@
     <term name="month-12">ديسمبر</term>
 
     <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">يناير</term>
-    <term name="month-02" form="short">فبراير</term>
-    <term name="month-03" form="short">مارس</term>
-    <term name="month-04" form="short">ابريل</term>
-    <term name="month-05" form="short">مايو</term>
-    <term name="month-06" form="short">يونيو</term>
-    <term name="month-07" form="short">يوليو</term>
-    <term name="month-08" form="short">اغسطس</term>
-    <term name="month-09" form="short">سبتمبر</term>
-    <term name="month-10" form="short">اكتوبر</term>
-    <term name="month-11" form="short">نوفمبر</term>
-    <term name="month-12" form="short">ديسمبر</term>
+
 
     <!-- SEASONS -->
     <term name="season-01">الربيع</term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="ar">
   <info>
+    <translator>
+      <name>abdealikhurrum</name>
+      <email>abdealikhurrum@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>abdealikhurrum</name>
-      <email>abdealikhurrum@gmail.com</email>
     </translator>
     <translator>
       <name>Dr. Ayman Saleh</name>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -5,6 +5,9 @@
       <name>abdealikhurrum</name>
       <email>abdealikhurrum@gmail.com</email>
     </translator>
+    <translator>
+      <name>Dr. Ayman Saleh</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>anidal</name>
-      <email>avidalgomez@gmail.com</email>
     </translator>
     <translator>
       <name>javimat</name>
-      <email>xaviermatoses@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="ca-AD">
   <info>
+    <translator>
+      <name>anidal</name>
+      <email>avidalgomez@gmail.com</email>
+    </translator>
+    <translator>
+      <name>javimat</name>
+      <email>xaviermatoses@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="cs-CZ">
   <info>
+    <translator>
+      <name>nosaal</name>
+      <email>nosaal@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Andrew Dunning</name>
+      <email>andunning@gmail.com</email>
+    </translator>
+    <translator>
+      <name>libora</name>
+      <email>libor.ansorge@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Michal Hoftich</name>
+      <email>michal.h21@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -3,19 +3,15 @@
   <info>
     <translator>
       <name>nosaal</name>
-      <email>nosaal@gmail.com</email>
     </translator>
     <translator>
       <name>Andrew Dunning</name>
-      <email>andunning@gmail.com</email>
     </translator>
     <translator>
       <name>libora</name>
-      <email>libor.ansorge@gmail.com</email>
     </translator>
     <translator>
       <name>Michal Hoftich</name>
-      <email>michal.h21@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>Niels Erik Wille</name>
-      <email>newinfo@tdcadsl.dk</email>
     </translator>
     <translator>
       <name>Jonas Nyrup</name>
-      <email>jnyrup@users.noreply.github.com</email>
     </translator>
     <translator>
       <name>hafnius</name>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="da-DK">
   <info>
+    <translator>
+      <name>Niels Erik Wille</name>
+      <email>newinfo@tdcadsl.dk</email>
+    </translator>
+    <translator>
+      <name>Jonas Nyrup</name>
+      <email>jnyrup@users.noreply.github.com</email>
+    </translator>
+    <translator>
+      <name>hafnius</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -1,6 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="de-AT">
   <info>
+    <translator>
+      <name>Till A. Heilmann</name>
+      <email>mail@tillheilmann.info</email>
+    </translator>
+    <translator>
+      <name>Georg Duffner</name>
+      <email>g.duffner@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Sebastian Karcher</name>
+      <email>karcher@u.northwestern.edu</email>
+    </translator>
+    <translator>
+      <name>Sylvester Keil</name>
+      <email>sylvester@keil.or.at</email>
+    </translator>
+    <translator>
+      <name>jakov</name>
+      <email>jakov@gmx.at</email>
+    </translator>
+    <translator>
+      <name>adamsmith</name>
+    </translator>
+    <translator>
+      <name>Frank Bennett</name>
+      <email>biercenator@gmail.com</email>
+    </translator>
+
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -17,9 +17,6 @@
       <name>jakov</name>
     </translator>
     <translator>
-      <name>Sebastian Karcher</name>
-    </translator>
-    <translator>
       <name>Frank Bennett</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -3,30 +3,24 @@
   <info>
     <translator>
       <name>Till A. Heilmann</name>
-      <email>mail@tillheilmann.info</email>
     </translator>
     <translator>
       <name>Georg Duffner</name>
-      <email>g.duffner@gmail.com</email>
     </translator>
     <translator>
       <name>Sebastian Karcher</name>
-      <email>karcher@u.northwestern.edu</email>
     </translator>
     <translator>
       <name>Sylvester Keil</name>
-      <email>sylvester@keil.or.at</email>
     </translator>
     <translator>
       <name>jakov</name>
-      <email>jakov@gmx.at</email>
     </translator>
     <translator>
       <name>adamsmith</name>
     </translator>
     <translator>
       <name>Frank Bennett</name>
-      <email>biercenator@gmail.com</email>
     </translator>
 
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -3,15 +3,12 @@
   <info>
     <translator>
       <name>Till A. Heilmann</name>
-      <email>mail@tillheilmann.info</email>
     </translator>
     <translator>
       <name>Sylvester Keil</name>
-      <email>sylvester@keil.or.at</email>
     </translator>
     <translator>
       <name>jakov</name>
-      <email>jakov@gmx.at</email>
     </translator>
     <translator>
       <name>adamsmith</name>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="de-CH">
   <info>
+    <translator>
+      <name>Till A. Heilmann</name>
+      <email>mail@tillheilmann.info</email>
+    </translator>
+    <translator>
+      <name>Sylvester Keil</name>
+      <email>sylvester@keil.or.at</email>
+    </translator>
+    <translator>
+      <name>jakov</name>
+      <email>jakov@gmx.at</email>
+    </translator>
+    <translator>
+      <name>adamsmith</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -3,22 +3,18 @@
   <info>
     <translator>
       <name>Till A. Heilmann</name>
-      <email>mail@tillheilmann.info</email>
     </translator>
     <translator>
       <name>Ulrich</name>
     </translator>
     <translator>
       <name>Rintze M. Zelle</name>
-      <email>rintze.zelle@gmail.com</email>
     </translator>
     <translator>
       <name>Sebastian Karcher</name>
-      <email>karcher@u.northwestern.edu</email>
     </translator>
     <translator>
       <name>jakov</name>
-      <email>jakov@gmx.at</email>
     </translator>
     <translator>
       <name>adamsmith</name>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="de-DE">
   <info>
+    <translator>
+      <name>Till A. Heilmann</name>
+      <email>mail@tillheilmann.info</email>
+    </translator>
+    <translator>
+      <name>Ulrich</name>
+    </translator>
+    <translator>
+      <name>Rintze M. Zelle</name>
+      <email>rintze.zelle@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Sebastian Karcher</name>
+      <email>karcher@u.northwestern.edu</email>
+    </translator>
+    <translator>
+      <name>jakov</name>
+      <email>jakov@gmx.at</email>
+    </translator>
+    <translator>
+      <name>adamsmith</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="el-GR">
   <info>
+    <translator>
+      <name>thanasis57</name>
+      <email>thab57@yahoo.com</email>
+    </translator>
+    <translator>
+      <name>dimtamb</name>
+      <email>dimtamb@users.noreply.github.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2013-11-08T20:31:02+00:00</updated>
   </info>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>thanasis57</name>
-      <email>thab57@yahoo.com</email>
     </translator>
     <translator>
       <name>dimtamb</name>
-      <email>dimtamb@users.noreply.github.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2013-11-08T20:31:02+00:00</updated>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -3,15 +3,12 @@
   <info>
     <translator>
       <name>Andrew Dunning</name>
-      <email>andunning@gmail.com</email>
     </translator>
     <translator>
       <name>adam3smith</name>
-      <email>karcher@u.northwestern.edu</email>
     </translator>
     <translator>
       <name>rmzelle</name>
-      <email>rintze.zelle@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2015-10-10T23:31:02+00:00</updated>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-GB">
   <info>
+    <translator>
+      <name>Andrew Dunning</name>
+      <email>andunning@gmail.com</email>
+    </translator>
+    <translator>
+      <name>adam3smith</name>
+      <email>karcher@u.northwestern.edu</email>
+    </translator>
+    <translator>
+      <name>rmzelle</name>
+      <email>rintze.zelle@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2015-10-10T23:31:02+00:00</updated>
   </info>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -3,15 +3,12 @@
   <info>
     <translator>
       <name>Andrew Dunning</name>
-      <email>andunning@gmail.com</email>
     </translator>
     <translator>
       <name>adam3smith</name>
-      <email>karcher@u.northwestern.edu</email>
     </translator>
     <translator>
       <name>rmzelle</name>
-      <email>rintze.zelle@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2015-10-10T23:31:02+00:00</updated>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
   <info>
+    <translator>
+      <name>Andrew Dunning</name>
+      <email>andunning@gmail.com</email>
+    </translator>
+    <translator>
+      <name>adam3smith</name>
+      <email>karcher@u.northwestern.edu</email>
+    </translator>
+    <translator>
+      <name>rmzelle</name>
+      <email>rintze.zelle@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2015-10-10T23:31:02+00:00</updated>
   </info>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="es-ES">
   <info>
+    <translator>
+      <name>javimat</name>
+      <email>xaviermatoses@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>javimat</name>
-      <email>xaviermatoses@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>Andrew Dunning</name>
-      <email>andunning@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="et-EE">
   <info>
+    <translator>
+      <name>Andrew Dunning</name>
+      <email>andunning@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="eu">
   <info>
+    <translator>
+      <name>Amaraun</name>
+    </translator>
+
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>Hamed Heydari</name>
-      <email>hamedheydari@live.com</email>
     </translator>
     <translator>
       <name>abdealikhurrum</name>
-      <email>abdealikhurrum@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="fa-IR">
   <info>
+    <translator>
+      <name>Hamed Heydari</name>
+      <email>hamedheydari@live.com</email>
+    </translator>
+    <translator>
+      <name>abdealikhurrum</name>
+      <email>abdealikhurrum@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="fi-FI">
   <info>
+    <translator>
+      <name>Janne Huovari</name>
+      <email>janne.huovari@ptt.fi</email>
+    </translator>
+    <translator>
+      <name>snissine</name>
+      <email>sami.nissinen@aalto.fi</email>
+    </translator>
+    <translator>
+      <name>villelahtinen</name>
+      <email>ville.lahtinen@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Juhana Venäläinen</name>
+      <email>juhana.venalainen@gmail.com</email>
+    </translator>
+
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -3,19 +3,15 @@
   <info>
     <translator>
       <name>Janne Huovari</name>
-      <email>janne.huovari@ptt.fi</email>
     </translator>
     <translator>
       <name>snissine</name>
-      <email>sami.nissinen@aalto.fi</email>
     </translator>
     <translator>
       <name>villelahtinen</name>
-      <email>ville.lahtinen@gmail.com</email>
     </translator>
     <translator>
       <name>Juhana Venäläinen</name>
-      <email>juhana.venalainen@gmail.com</email>
     </translator>
 
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>roypeled1</name>
-      <email>roypeled@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="he-IL">
   <info>
+    <translator>
+      <name>roypeled1</name>
+      <email>roypeled@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="hr-HR">
   <info>
+    <translator>
+      <name>tvrbanec</name>
+      <email>tvrbanec@users.noreply.github.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>tvrbanec</name>
-      <email>tvrbanec@users.noreply.github.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>Miklos Vajna</name>
-      <email>vmiklos@vmiklos.hu</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-06-17T09:56:35+02:00</updated>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="hu-HU">
   <info>
+    <translator>
+      <name>Miklos Vajna</name>
+      <email>vmiklos@vmiklos.hu</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-06-17T09:56:35+02:00</updated>
   </info>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -23,31 +23,31 @@
     <term name="anonymous" form="short">anon.</term>
     <term name="at">pada</term>
     <term name="available at">tersedia pada</term>
-    <term name="by">by</term>
+    <term name="by">oleh</term>
     <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term>
+    <term name="circa" form="short">ca.</term>
     <term name="cited">dikutip</term>
     <term name="edition">
       <single>edisi</single>
       <multiple>edisi</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
-    <term name="et-al">et al.</term>
+    <term name="et-al">dkk.</term>
     <term name="forthcoming">mendatang</term>
     <term name="from">dari</term>
     <term name="ibid">ibid.</term>
-    <term name="in">in</term>
-    <term name="in press">in press</term>
+    <term name="in">dalam</term>
+    <term name="in press">dalam proses cetakan</term>
     <term name="internet">internet</term>
     <term name="interview">wawancara</term>
     <term name="letter">surat</term>
     <term name="no date">tanpa tanggal</term>
-    <term name="no date" form="short">n.d.</term>
+    <term name="no date" form="short">t.t.</term>
     <term name="online">daring</term>
     <term name="presented at">dipresentasikan pada</term>
     <term name="reference">
-      <single>reference</single>
-      <multiple>references</multiple>
+      <single>referensi</single>
+      <multiple>referensi</multiple>
     </term>
     <term name="reference" form="short">
       <single>ref.</single>
@@ -143,8 +143,8 @@
       <multiple>bagian</multiple>
     </term>
     <term name="section">
-      <single>section</single>
-      <multiple>section</multiple>
+      <single>bagian</single>
+      <multiple>bagian</multiple>
     </term>
     <term name="sub verbo">
       <single>sub verbo</single>
@@ -161,25 +161,25 @@
 
     <!-- SHORT LOCATOR FORMS -->
     <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">chap.</term>
-    <term name="column" form="short">col.</term>
-    <term name="figure" form="short">gam.</term>
-    <term name="folio" form="short">f.</term>
+    <term name="chapter" form="short">bb.</term>
+    <term name="column" form="short">kol.</term>
+    <term name="figure" form="short">gbr.</term>
+    <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">no.</term>
-    <term name="line" form="short">l.</term>
-    <term name="note" form="short">n.</term>
+    <term name="line" form="short">brs.</term>
+    <term name="note" form="short">ctt.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
-      <single>hal.</single>
-      <multiple>hal.</multiple>
+      <single>hlm.</single>
+      <multiple>hlm.</multiple>
     </term>
     <term name="number-of-pages" form="short">
-      <single>hal.</single>
-      <multiple>hal.</multiple>
+      <single>hlm.</single>
+      <multiple>hlm.</multiple>
     </term>
     <term name="paragraph" form="short">para.</term>
-    <term name="part" form="short">pt.</term>
-    <term name="section" form="short">sec.</term>
+    <term name="part" form="short">bag.</term>
+    <term name="section" form="short">bag.</term>
     <term name="sub verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -232,7 +232,7 @@
     <!-- SHORT ROLE FORMS -->
     <term name="director" form="short">
       <single>dir.</single>
-      <multiple>dirs.</multiple>
+      <multiple>dir.</multiple>
     </term>
     <term name="editor" form="short">
       <single>ed.</single>
@@ -251,17 +251,17 @@
       <multiple>penerj.</multiple>
     </term>
     <term name="editortranslator" form="short">
-      <single>ed. &amp; tran.</single>
-      <multiple>ed. &amp; tran.</multiple>
+      <single>ed. &amp; penerj.</single>
+      <multiple>ed. &amp; penerj.</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->
     <term name="container-author" form="verb">oleh</term>
     <term name="director" form="verb">diarahkan oleh</term>
-    <term name="editor" form="verb">diedit oleh</term>
-    <term name="editorial-director" form="verb">diedit oleh</term>
+    <term name="editor" form="verb">disunting oleh</term>
+    <term name="editorial-director" form="verb">disunting oleh</term>
     <term name="illustrator" form="verb">diilustrasi oleh</term>
-    <term name="interviewer" form="verb">interview oleh</term>
+    <term name="interviewer" form="verb">diwawancara oleh</term>
     <term name="recipient" form="verb">kepada</term>
     <term name="reviewed-author" form="verb">oleh</term>
     <term name="translator" form="verb">diterjemahkan oleh</term>
@@ -273,7 +273,7 @@
     <term name="editorial-director" form="verb-short">ed. oleh</term>
     <term name="illustrator" form="verb-short">illus. oleh</term>
     <term name="translator" form="verb-short">trans. oleh</term>
-    <term name="editortranslator" form="verb-short">ed. &amp; trans. oleh</term>
+    <term name="editortranslator" form="verb-short">ed. &amp; penerj. oleh</term>
 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">Januari</term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -3,15 +3,12 @@
   <info>
     <translator>
       <name>faizhabibullah</name>
-      <email>33214901+faizhabibullah@users.noreply.github.com</email>
     </translator>
     <translator>
       <name>Deden Habibi</name>
-      <email>dedenhabibi@gmail.com</email>
     </translator>
     <translator>
       <name>xbypass</name>
-      <email>xbypass@users.noreply.github.com</email>
     </translator>
   <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2015-08-05T23:31:02+00:00</updated>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="id-ID">
   <info>
+    <translator>
+      <name>faizhabibullah</name>
+      <email>33214901+faizhabibullah@users.noreply.github.com</email>
+    </translator>
+    <translator>
+      <name>Deden Habibi</name>
+      <email>dedenhabibi@gmail.com</email>
+    </translator>
+    <translator>
+      <name>xbypass</name>
+      <email>xbypass@users.noreply.github.com</email>
+    </translator>
   <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2015-08-05T23:31:02+00:00</updated>
   </info>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>dadamaster</name>
-      <email>hlynur.helgason@gmail.com</email>
     </translator>
     <translator>
       <name>styrmirm</name>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="is-IS">
   <info>
+    <translator>
+      <name>dadamaster</name>
+      <email>hlynur.helgason@gmail.com</email>
+    </translator>
+    <translator>
+      <name>styrmirm</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="it-IT">
   <info>
+    <translator>
+      <name>FI App Development</name>
+      <email>apps@liturgiaetmusica.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>FI App Development</name>
-      <email>apps@liturgiaetmusica.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="ja-JP">
   <info>
+    <translator>
+      <name>Shoji Takahashi</name>
+      <email>s.takahashi@elsevier.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>Shoji Takahashi</name>
-      <email>s.takahashi@elsevier.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="nb-NO">
   <info>
+    <translator>
+      <name>Guttorm Flatabø</name>
+      <email>post@guttormflatabo.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2013-03-01T12:20:00+01:00</updated>
   </info>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>Guttorm Flatabø</name>
-      <email>post@guttormflatabo.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2013-03-01T12:20:00+01:00</updated>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="nn-NO">
   <info>
+    <translator>
+      <name>Guttorm Flatabø</name>
+      <email>post@guttormflatabo.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2013-03-01T12:20:00+01:00</updated>
   </info>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>Guttorm Flatabø</name>
-      <email>post@guttormflatabo.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2013-03-01T12:20:00+01:00</updated>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="pl-PL">
   <info>
+    <translator>
+      <name>pAo</name>
+      <email>pawel.kleka@amu.edu.pl</email>
+    </translator>
+    <translator>
+      <name>Michal</name>
+      <email>msmoczyk@wp.pl</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>pAo</name>
-      <email>pawel.kleka@amu.edu.pl</email>
     </translator>
     <translator>
       <name>Michal</name>
-      <email>msmoczyk@wp.pl</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="pt-BR">
   <info>
+    <translator>
+      <name>José Antonio Meira da Rocha</name>
+      <email>joseantoniorocha@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Meira da Rocha</name>
+    </translator>
+
     <updated>2016-05-16T00:00:00+03:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -7,9 +7,8 @@
     <translator>
       <name>Meira da Rocha</name>
     </translator>
-
-    <updated>2016-05-16T00:00:00+03:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2016-05-16T00:00:00+03:00</updated>
   </info>
   <style-options punctuation-in-quote="false" limit-day-ordinals-to-day-1="true"/>
   <date form="text">

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>José Antonio Meira da Rocha</name>
-      <email>joseantoniorocha@gmail.com</email>
     </translator>
     <translator>
       <name>Meira da Rocha</name>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="sk-SK">
   <info>
+    <translator>
+      <name>Tomáš Ferianc</name>
+      <email>tferianc@gmail.com</email>
+    </translator>
+    <translator>
+      <name>kohafan</name>
+      <email>vilhan@xaver.sk</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-03-09T22:23:31+00:00</updated>
   </info>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>Tomáš Ferianc</name>
-      <email>tferianc@gmail.com</email>
     </translator>
     <translator>
       <name>kohafan</name>
-      <email>vilhan@xaver.sk</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-03-09T22:23:31+00:00</updated>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -3,11 +3,9 @@
   <info>
     <translator>
       <name>Kristof Ostir</name>
-      <email>krostir@gmail.com</email>
     </translator>
     <translator>
       <name>ratek1</name>
-      <email>dkopse@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-11-06T09:41:02+00:00</updated>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="sl-SI">
   <info>
+    <translator>
+      <name>Kristof Ostir</name>
+      <email>krostir@gmail.com</email>
+    </translator>
+    <translator>
+      <name>ratek1</name>
+      <email>dkopse@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-11-06T09:41:02+00:00</updated>
   </info>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="sv-SE">
   <info>
+    <translator>
+      <name>torfeur</name>
+      <email>torstenfeurstein@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Sylvester Keil</name>
+      <email>sylvester@keil.or.at</email>
+    </translator>
+    <translator>
+      <name>adam3smith</name>
+      <email>karcher@u.northwestern.edu</email>
+    </translator>
+    <translator>
+      <name>Ulf Harnhammar</name>
+      <email>ulfharn@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -3,19 +3,15 @@
   <info>
     <translator>
       <name>torfeur</name>
-      <email>torstenfeurstein@gmail.com</email>
     </translator>
     <translator>
       <name>Sylvester Keil</name>
-      <email>sylvester@keil.or.at</email>
     </translator>
     <translator>
       <name>adam3smith</name>
-      <email>karcher@u.northwestern.edu</email>
     </translator>
     <translator>
       <name>Ulf Harnhammar</name>
-      <email>ulfharn@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="th-TH">
   <info>
+    <translator>
+      <name>Dusit Laohasinnarong</name>
+      <email>ldusit@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>Dusit Laohasinnarong</name>
-      <email>ldusit@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="tr-TR">
   <info>
+    <translator>
+      <name>ekizyener</name>
+      <email>ekizyener@gmail.com</email>
+    </translator>
+    <translator>
+      <name>Binici</name>
+      <email>binici82@gmail.com</email>
+    </translator>
+    <translator>
+      <name>cengiza</name>
+      <email>caytun@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -3,15 +3,12 @@
   <info>
     <translator>
       <name>ekizyener</name>
-      <email>ekizyener@gmail.com</email>
     </translator>
     <translator>
       <name>Binici</name>
-      <email>binici82@gmail.com</email>
     </translator>
     <translator>
       <name>cengiza</name>
-      <email>caytun@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>dowens76</name>
-      <email>dcowens76@gmail.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="vi-VN">
   <info>
+    <translator>
+      <name>dowens76</name>
+      <email>dcowens76@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="zh-CN">
   <info>
+    <translator>
+      <name>rongls</name>
+      <email>ronglisong@gmail.com</email>
+    </translator>
+    <translator>
+      <name>sati-bodhi</name>
+      <email>sati-bodhi@users.noreply.github.com</email>
+    </translator>
+    <translator>
+      <name>Heromyth</name>
+      <email>bitworld@qq.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-05-15T23:31:02+00:00</updated>
   </info>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -3,15 +3,12 @@
   <info>
     <translator>
       <name>rongls</name>
-      <email>ronglisong@gmail.com</email>
     </translator>
     <translator>
       <name>sati-bodhi</name>
-      <email>sati-bodhi@users.noreply.github.com</email>
     </translator>
     <translator>
       <name>Heromyth</name>
-      <email>bitworld@qq.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-05-15T23:31:02+00:00</updated>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="zh-TW">
   <info>
+    <translator>
+      <name>sati-bodhi</name>
+      <email>sati-bodhi@users.noreply.github.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-05-15T23:31:02+00:00</updated>
   </info>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -3,7 +3,6 @@
   <info>
     <translator>
       <name>sati-bodhi</name>
-      <email>sati-bodhi@users.noreply.github.com</email>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-05-15T23:31:02+00:00</updated>


### PR DESCRIPTION
For all xml files without any `<translator>` tag, the authors of the commits
were extracted from git log, and the ones from technical commits / mass
commits over the whole repo manually removed. The rest were added as
`<translator>`s to the xml files.

Background: issue #151
This still leaves 8 files without any `<translator>`s:
```
locales-af-ZA.xml
locales-bg-BG.xml
locales-cy-GB.xml
locales-km-KH.xml
locales-ko-KR.xml
locales-mn-MN.xml
locales-sr-RS.xml
locales-uk-UA.xml
```
