### PR TITLE
el-GR add period to page abbreviations

### DIFF
--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -172,12 +172,12 @@
     <term name="note" form="short">σημ.</term>
     <term name="opus" form="short">έργ.</term>
     <term name="page" form="short">
-      <single>σ</single>
-      <multiple>σσ</multiple>
+      <single>σ.</single>
+      <multiple>σσ.</multiple>
     </term>
     <term name="number-of-pages" form="short">
-      <single>σ</single>
-      <multiple>σσ</multiple>
+      <single>σ.</single>
+      <multiple>σσ.</multiple>
     </term>
     <term name="paragraph" form="short">παρ.</term>
     <term name="part" form="short">μέρ.</term>


### PR DESCRIPTION
Requested here: https://forums.zotero.org/discussion/74178/need-to-add-a-full-stop-after-p-in-citations-that-include-page-number#latest and is in line with all other abbreviations in style. The line in the code is 8+ years old, so no way to tell.