### PR TITLE
Italian: Correct ordinal indicator

### DIFF
--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -72,7 +72,7 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">°</term>
+    <term name="ordinal">º</term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">prima</term>


### PR DESCRIPTION
The ° symbol is a degree sign; º is the correct symbol for an ordinal.