### PR TITLE
Update locales-zh-CN.xml

### DIFF
--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -38,7 +38,7 @@
     <term name="cited">见引于</term>
     <term name="edition">版本</term>
     <term name="edition" form="short">本</term>
-    <term name="et-al">等.</term>
+    <term name="et-al">等</term>
     <term name="forthcoming">即将出版</term>
     <term name="from">从</term>
     <term name="ibid">同上</term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -25,20 +25,20 @@
     <date-part name="day" form="numeric-leading-zeros" prefix="/"/>
   </date>
   <terms>
-    <term name="accessed">见於</term>
+    <term name="accessed">见于</term>
     <term name="and">和</term>
     <term name="and others">及其他</term>
     <term name="anonymous">作者不详</term>
     <term name="anonymous" form="short">无名氏</term>
-    <term name="at">於</term>
-    <term name="available at">载於</term>
+    <term name="at">于</term>
+    <term name="available at">载于</term>
     <term name="by">著</term>
     <term name="circa">介于</term>
     <term name="circa" form="short">约</term>
-    <term name="cited">见引於</term>
+    <term name="cited">见引于</term>
     <term name="edition">版本</term>
     <term name="edition" form="short">本</term>
-    <term name="et-al">等</term>
+    <term name="et-al">等.</term>
     <term name="forthcoming">即将出版</term>
     <term name="from">从</term>
     <term name="ibid">同上</term>
@@ -50,7 +50,7 @@
     <term name="no date">日期不详</term>
     <term name="no date" form="short">不详</term>
     <term name="online">在线</term>
-    <term name="presented at">发表於</term>
+    <term name="presented at">发表于</term>
     <term name="reference">参考</term>
     <term name="reference" form="short">参</term>
     <term name="retrieved">取读于</term>


### PR DESCRIPTION
1. The "于" is used to instead of the "於" in Simplified Chinese.
2. Added a period after the "等".
