### PR TITLE
always fetch latest sheldon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.3
+install:
+  - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+  - bundle update sheldon
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Always fetches the latest sheldon gem in the travis build. This way we don't need to issue PRs in threes when Sheldon updates.