### PR TITLE
Update locales-sl-SI.xml

### DIFF
--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -40,7 +40,7 @@
     <term name="edition" form="short">izd.</term>
     <term name="et-al">idr.</term>
     <term name="forthcoming">pred izidom</term>
-    <term name="from">od</term>
+    <term name="from">s</term>
     <term name="ibid">isto</term>
     <term name="in">v</term>
     <term name="in press">v tisku</term>


### PR DESCRIPTION
### Description

The term `od` should be changed to `s` to fix the incorrect bibliography entries when citing documents with URL.

Fixes issue #200. 
