### PR TITLE
Fix markdown lint error "[no-literal-urls] Don’t use literal URLs without angle brackets"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## CSL Locales Pull Request Template
 
 You're about to create a pull request to the CSL locales repository.
-If you haven't done so already, see http://docs.citationstyles.org/en/stable/translating-locale-files.html for instructions on how to translate CSL locale files, and https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md on how to submit your changes.
+If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
 In addition, please fill out the pull request template below.
 
 ### Description


### PR DESCRIPTION
In JabRef, [we run Codacy](https://devdocs.jabref.org/code-quality) to ensure quote qualty. It uses [remark lint](https://github.com/remarkjs/remark-lint) to lint markdown. Since we include the citation styles in JabRef, it also [complains](https://app.codacy.com/gh/JabRef/jabref/file/42498231068/issues/source?bid=16663292&fileBranchId=16663292#l4) about errors there. One rule is 

    [no-literal-urls] Don’t use literal URLs without angle brackets

![grafik](https://user-images.githubusercontent.com/1366654/75413853-045cab00-5927-11ea-8260-08570eb1b7fd.png)

This PR fixes it.

Side comment: Is also complains about two other issues, but I disabled that rules as a) GitHub requires `_` in this filename and b) [markdown-lint](https://github.com/DavidAnson/markdownlint)'s rule is that bulleted lists start at the beginning of a line. I personally like markdownlint more, but it is [not installed at codacy](https://twitter.com/JabRef_org/status/1232752601709633536).