### PR TITLE
Update locales-it-IT.xml (terms translation, gender)

### DIFF
--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -43,7 +43,7 @@
     <term name="forthcoming">futuro</term>
     <term name="from">da</term>
     <term name="ibid">ibid.</term>
-    <term name="ibid" form="long">ibidem</term>
+    <term name="ibid">ibidem</term>
     <term name="ibid" form="short">ibid.</term>
     <term name="in">in</term>
     <term name="in press">in stampa</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -85,7 +85,7 @@
     <term name="long-ordinal-01" gender-form="masculine">primo</term>
     <term name="long-ordinal-01" gender-form="feminine">prima</term>
     <term name="long-ordinal-02">seconda</term>
-    <term name="long-ordinal-02" gender-form="masculine>secondo</term>
+    <term name="long-ordinal-02" gender-form="masculine">secondo</term>
     <term name="long-ordinal-02" gender-form="feminine">seconda</term>
     <term name="long-ordinal-03">terza</term>
     <term name="long-ordinal-03" gender-form="masculine">terzo</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -117,7 +117,7 @@
       <single>libro</single>
       <multiple>libri</multiple>
     </term>
-    <term name="chapter" gender="masculine">
+    <term name="chapter">
       <single>capitolo</single>
       <multiple>capitoli</multiple>
     </term>
@@ -133,7 +133,7 @@
       <single>foglio</single>
       <multiple>fogli</multiple>
     </term>
-    <term name="issue" gender="masculine">
+    <term name="issue">
       <single>numero</single>
       <multiple>numeri</multiple>
     </term>
@@ -177,7 +177,7 @@
       <single>verso</single>
       <multiple>versi</multiple>
     </term>
-    <term name="volume" gender="masculine">
+    <term name="volume">
       <single>volume</single>
       <multiple>volumi</multiple>
     </term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -43,6 +43,8 @@
     <term name="forthcoming">futuro</term>
     <term name="from">da</term>
     <term name="ibid">ibid.</term>
+    <term name="ibid" form="long">ibidem</term>
+    <term name="ibid" form="short">ibid.</term>
     <term name="in">in</term>
     <term name="in press">in stampa</term>
     <term name="internet">internet</term>
@@ -133,7 +135,7 @@
       <single>foglio</single>
       <multiple>fogli</multiple>
     </term>
-    <term name="issue">
+    <term name="issue" gender="masculine">
       <single>numero</single>
       <multiple>numeri</multiple>
     </term>
@@ -177,14 +179,17 @@
       <single>verso</single>
       <multiple>versi</multiple>
     </term>
-    <term name="volume">
+    <term name="volume" gender="masculine">
       <single>volume</single>
       <multiple>volumi</multiple>
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
     <term name="book" form="short">lib.</term>
-    <term name="chapter" form="short">cap.</term>
+    <term name="chapter" form="short">
+      <single>cap.</single>
+      <multiple>capp.</multiple>
+    </term>
     <term name="column" form="short">col.</term>
     <term name="figure" form="short">fig.</term>
     <term name="folio" form="short">fgl.</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -5,7 +5,7 @@
       <name>FI App Development</name>
     </translator>
     <translator>
-      <name>monykat</name>
+      <name>Monica Thuegaz</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
@@ -46,8 +46,8 @@
     <term name="in">in</term>
     <term name="in press">in stampa</term>
     <term name="internet">internet</term>
-    <term name="interview" gender="feminine">intervista</term>
-    <term name="letter" gender="feminine">lettera</term>
+    <term name="interview">intervista</term>
+    <term name="letter">lettera</term>
     <term name="no date">senza data</term>
     <term name="no date" form="short">s.d.</term>
     <term name="online">online</term>
@@ -62,7 +62,7 @@
     </term>
     <term name="retrieved">recuperato</term>
     <term name="scale">scala</term>
-    <term name="version" gender="feminine">versione</term>
+    <term name="version">versione</term>
 
     <!-- ANNO DOMINI; BEFORE CHRIST -->
     <term name="ad">d.C.</term>
@@ -82,22 +82,42 @@
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">prima</term>
+    <term name="long-ordinal-01" gender-form="masculine">primo</term>
+    <term name="long-ordinal-01" gender-form="feminine">prima</term>
     <term name="long-ordinal-02">seconda</term>
+    <term name="long-ordinal-02" gender-form="masculine>secondo</term>
+    <term name="long-ordinal-02" gender-form="feminine">seconda</term>
     <term name="long-ordinal-03">terza</term>
+    <term name="long-ordinal-03" gender-form="masculine">terzo</term>
+    <term name="long-ordinal-03" gender-form="feminine">terza</term>
     <term name="long-ordinal-04">quarta</term>
+    <term name="long-ordinal-04" gender-form="masculine">quarto</term>
+    <term name="long-ordinal-04" gender-form="feminine">quarta</term>
     <term name="long-ordinal-05">quinta</term>
+    <term name="long-ordinal-05" gender-form="masculine">quinto</term>
+    <term name="long-ordinal-05" gender-form="feminine">quinta</term>
     <term name="long-ordinal-06">sesta</term>
+    <term name="long-ordinal-06" gender-form="masculine">sesto</term>
+    <term name="long-ordinal-06" gender-form="feminine">sesta</term>
     <term name="long-ordinal-07">settima</term>
+    <term name="long-ordinal-07" gender-form="masculine">settimo</term>
+    <term name="long-ordinal-07" gender-form="feminine">settima</term>
     <term name="long-ordinal-08">ottava</term>
+    <term name="long-ordinal-08" gender-form="masculine">ottavo</term>
+    <term name="long-ordinal-08" gender-form="feminine">ottava</term>
     <term name="long-ordinal-09">nona</term>
+    <term name="long-ordinal-09" gender-form="masculine">nono</term>
+    <term name="long-ordinal-09" gender-form="feminine">nona</term>
     <term name="long-ordinal-10">decima</term>
+    <term name="long-ordinal-10" gender-form="masculine">decimo</term>
+    <term name="long-ordinal-10" gender-form="feminine">decima</term>
 
     <!-- LONG LOCATOR FORMS -->
     <term name="book">
       <single>libro</single>
       <multiple>libri</multiple>
     </term>
-    <term name="chapter">
+    <term name="chapter" gender="masculine">
       <single>capitolo</single>
       <multiple>capitoli</multiple>
     </term>
@@ -113,7 +133,7 @@
       <single>foglio</single>
       <multiple>fogli</multiple>
     </term>
-    <term name="issue">
+    <term name="issue" gender="masculine">
       <single>numero</single>
       <multiple>numeri</multiple>
     </term>
@@ -157,7 +177,7 @@
       <single>verso</single>
       <multiple>versi</multiple>
     </term>
-    <term name="volume">
+    <term name="volume" gender="masculine">
       <single>volume</single>
       <multiple>volumi</multiple>
     </term>
@@ -279,18 +299,18 @@
     <term name="editortranslator" form="verb-short">a c. di e trad. da</term>
 
     <!-- LONG MONTH FORMS -->
-    <term name="month-01">gennaio</term>
-    <term name="month-02">febbraio</term>
-    <term name="month-03">marzo</term>
-    <term name="month-04">aprile</term>
-    <term name="month-05">maggio</term>
-    <term name="month-06">giugno</term>
-    <term name="month-07">luglio</term>
-    <term name="month-08">agosto</term>
-    <term name="month-09">settembre</term>
-    <term name="month-10">ottobre</term>
-    <term name="month-11">novembre</term>
-    <term name="month-12">dicembre</term>
+    <term name="month-01" gender="masculine">gennaio</term>
+    <term name="month-02" gender="masculine">febbraio</term>
+    <term name="month-03" gender="masculine">marzo</term>
+    <term name="month-04" gender="masculine">aprile</term>
+    <term name="month-05" gender="masculine">maggio</term>
+    <term name="month-06" gender="masculine">giugno</term>
+    <term name="month-07" gender="masculine">luglio</term>
+    <term name="month-08" gender="masculine">agosto</term>
+    <term name="month-09" gender="masculine">settembre</term>
+    <term name="month-10" gender="masculine">ottobre</term>
+    <term name="month-11" gender="masculine">novembre</term>
+    <term name="month-12" gender="masculine">dicembre</term>
 
     <!-- SHORT MONTH FORMS -->
     <term name="month-01" form="short">gen.</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -4,6 +4,9 @@
     <translator>
       <name>FI App Development</name>
     </translator>
+    <translator>
+      <name>monykat</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>
@@ -25,12 +28,13 @@
     <term name="anonymous">anonimo</term>
     <term name="anonymous" form="short">anon.</term>
     <term name="at">a</term>
-    <term name="available at">available at</term>
+    <term name="available at">disponibile su</term>
+    <term name="available at" form="short">su</term>
     <term name="by">di</term>
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citato</term>
-    <term name="edition">
+    <term name="edition" gender="feminine">
       <single>edizione</single>
       <multiple>edizioni</multiple>
     </term>
@@ -42,11 +46,11 @@
     <term name="in">in</term>
     <term name="in press">in stampa</term>
     <term name="internet">internet</term>
-    <term name="interview">intervista</term>
-    <term name="letter">lettera</term>
+    <term name="interview" gender="feminine">intervista</term>
+    <term name="letter" gender="feminine">lettera</term>
     <term name="no date">senza data</term>
     <term name="no date" form="short">s.d.</term>
-    <term name="online">in linea</term>
+    <term name="online">online</term>
     <term name="presented at">presentato al</term>
     <term name="reference">
       <single>reference</single>
@@ -57,8 +61,8 @@
       <multiple>refs.</multiple>
     </term>
     <term name="retrieved">recuperato</term>
-    <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="scale">scala</term>
+    <term name="version" gender="feminine">versione</term>
 
     <!-- ANNO DOMINI; BEFORE CHRIST -->
     <term name="ad">d.C.</term>
@@ -73,6 +77,8 @@
 
     <!-- ORDINALS -->
     <term name="ordinal">º</term>
+    <term name="ordinal" gender-form="masculine">º</term>
+    <term name="ordinal" gender-form="feminine">ª</term>
 
     <!-- LONG ORDINALS -->
     <term name="long-ordinal-01">prima</term>
@@ -214,8 +220,8 @@
       <multiple>editors</multiple>
     </term>
     <term name="illustrator">
-      <single>illustrator</single>
-      <multiple>illustrators</multiple>
+      <single>illustratore</single>
+      <multiple>illustratori</multiple>
     </term>
     <term name="translator">
       <single>traduttore</single>
@@ -229,7 +235,7 @@
     <!-- SHORT ROLE FORMS -->
     <term name="director" form="short">
       <single>dir.</single>
-      <multiple>dirs.</multiple>
+      <multiple>dir.</multiple>
     </term>
     <term name="editor" form="short">
       <single>a c. di</single>
@@ -237,11 +243,11 @@
     </term>
     <term name="editorial-director" form="short">
       <single>ed.</single>
-      <multiple>eds.</multiple>
+      <multiple>ed.</multiple>
     </term>
     <term name="illustrator" form="short">
       <single>ill.</single>
-      <multiple>ills.</multiple>
+      <multiple>ill.</multiple>
     </term>
     <term name="translator" form="short">
       <single>trad.</single>
@@ -254,21 +260,21 @@
 
     <!-- VERB ROLE FORMS -->
     <term name="container-author" form="verb">di</term>
-    <term name="director" form="verb">directed by</term>
+    <term name="director" form="verb">diretto da</term>
     <term name="editor" form="verb">a cura di</term>
     <term name="editorial-director" form="verb">edited by</term>
-    <term name="illustrator" form="verb">illustrated by</term>
+    <term name="illustrator" form="verb">illustrato da</term>
     <term name="interviewer" form="verb">intervista di</term>
     <term name="recipient" form="verb">a</term>
-    <term name="reviewed-author" form="verb">by</term>
+    <term name="reviewed-author" form="verb">di</term>
     <term name="translator" form="verb">tradotto da</term>
     <term name="editortranslator" form="verb">a cura di e tradotto da</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="director" form="verb-short">dir.</term>
+    <term name="director" form="verb-short">dir. da</term>
     <term name="editor" form="verb-short">a c. di</term>
     <term name="editorial-director" form="verb-short">ed.</term>
-    <term name="illustrator" form="verb-short">illus.</term>
+    <term name="illustrator" form="verb-short">ill. da</term>
     <term name="translator" form="verb-short">trad. da</term>
     <term name="editortranslator" form="verb-short">a c. di e trad. da</term>
 

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -213,7 +213,7 @@
     </term>
     <term name="volume" form="short">
       <single>vol.</single>
-      <multiple>vol.</multiple>
+      <multiple>voll.</multiple>
     </term>
 
     <!-- SYMBOL LOCATOR FORMS -->


### PR DESCRIPTION
I propose the correct translation of several terms, some of which were still in English. Moreover, here I specified the gender of some others.
I also added feminine (and defined masculine) form of general ordinals. [Such changes are still needed for long ordinals: here I see only feminine forms. Maybe they have been proposed in another pull request]

Here I added what I proposed in pull request #212, also: correcting/adding some abreviation plural forms and adding "ibid." long form, which is optionall allowded by some publishers and still used by some authors.

Please, note: the translation is still not completed.

## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Correct translation of several terms. Gender specification of some others. Correct plural form of some abbreviations. Ibidem long form (and short form specification).

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
NOTE: done in this pull request.