### PR TITLE
Update of PL "accessed" translation 

### DIFF
--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -25,7 +25,7 @@
     <date-part name="year"/>
   </date>
   <terms>
-    <term name="accessed">dostęp:</term>
+    <term name="accessed">dostęp</term>
     <term name="and">i</term>
     <term name="and others">i inni</term>
     <term name="anonymous">anonim</term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -22,7 +22,7 @@
     <date-part name="year"/>
   </date>
   <terms>
-    <term name="accessed">udostępniono</term>
+    <term name="accessed">dostęp:</term>
     <term name="and">i</term>
     <term name="and others">i inni</term>
     <term name="anonymous">anonim</term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -7,6 +7,9 @@
     <translator>
       <name>Michal</name>
     </translator>
+    <translator>
+      <name>Pendzoncymisio</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>


### PR DESCRIPTION
### Description
Changing the translation of "accessed" to be correct. Currently translation of "accessed" means something like "shared". In update I am proposing translation that is widely used in Polish citations.

### Checklist
- [ X ] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.