### PR TITLE
Period after Übers. added

### DIFF
--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -272,7 +272,7 @@
     </term>
     <term name="editortranslator" form="short">
       <single>Hrsg.&#160;&amp; Übers.</single>
-      <multiple>Hrsg.&#160;&amp; Übers</multiple>
+      <multiple>Hrsg.&#160;&amp; Übers.</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -258,7 +258,7 @@
     </term>
     <term name="editortranslator" form="short">
       <single>Hrsg.&#160;&amp; Übers.</single>
-      <multiple>Hrsg.&#160;&amp; Übers</multiple>
+      <multiple>Hrsg.&#160;&amp; Übers.</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -269,7 +269,7 @@
     </term>
     <term name="editortranslator" form="short">
       <single>Hrsg.&#160;&amp; Übers.</single>
-      <multiple>Hrsg.&#160;&amp; Übers</multiple>
+      <multiple>Hrsg.&#160;&amp; Übers.</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->


### PR DESCRIPTION
Even in multiple, there should be a period for the short 
editortranslator Übers. [Übersetzer]? The shortened form
of translator (Übers) needs a period suffixed.

just a small typo.