### PR TITLE
Rename "figure" and "sub verbo" for 1.0.2

### DIFF
--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -102,7 +102,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">bk</term>
     <term name="chapter" form="short">chap</term>
     <term name="column" form="short">col</term>
-    <term name="figure" form="short">fig</term>
+    <term name="figure-locator" form="short">fig</term>
     <term name="folio" form="short">f</term>
     <term name="issue" form="short">no</term>
     <term name="line" form="short">l.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">sec</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -102,7 +102,7 @@
       <single>عمود</single>
       <multiple>أعمدة</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>رسم توضيحي</single>
       <multiple>رسوم توضيحية</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>قسم</single>
       <multiple>أقسام</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>تفسير فرعي</single>
       <multiple>تفسيرات فرعية</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">كتاب</term>
     <term name="chapter" form="short">فصل</term>
     <term name="column" form="short">عمود</term>
-    <term name="figure" form="short">رسم توضيحي</term>
+    <term name="figure-locator" form="short">رسم توضيحي</term>
     <term name="folio" form="short">مطوية</term>
     <term name="issue" form="short">عدد</term>
     <term name="line" form="short">سـ</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">فقرة</term>
     <term name="part" form="short">ج</term>
     <term name="section" form="short">قسم</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>تفسير فرعي</single>
       <multiple>تفسيرات فرعية</multiple>
     </term>

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -141,7 +141,7 @@
       <single>колона</single>
       <multiple>колони</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>фигура</single>
       <multiple>фигури</multiple>
     </term>
@@ -182,7 +182,7 @@
       <single>раздел</single>
       <multiple>раздели</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>под раздел</single>
       <multiple>под раздели</multiple>
     </term>
@@ -199,7 +199,7 @@
     <term name="book" form="short">кн.</term>
     <term name="chapter" form="short">гл.</term>
     <term name="column" form="short">кол.</term>
-    <term name="figure" form="short">фиг.</term>
+    <term name="figure-locator" form="short">фиг.</term>
     <term name="folio" form="short">фол.</term>
     <term name="issue" form="short">бр.</term>
     <term name="line" form="short">р.</term>
@@ -210,7 +210,7 @@
     <term name="paragraph" form="short">абз.</term>
     <term name="part" form="short">ч.</term>
     <term name="section" form="short">разд.</term>
-    <term name="sub verbo" form="short">подразд.</term>
+    <term name="sub-verbo" form="short">подразд.</term>
     <term name="verse" form="short">ст.</term>
     <term name="volume" form="short">
       <single>том</single>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -102,7 +102,7 @@
       <single>columna</single>
       <multiple>columnes</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figures</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>secció</single>
       <multiple>seccions</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub voce</single>
       <multiple>sub vocibus</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">llib.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">núm.</term>
     <term name="line" form="short">l.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
     </term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -109,7 +109,7 @@
       <single>sloupec</single>
       <multiple>sloupce</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>obrázek</single>
       <multiple>obrázky</multiple>
     </term>
@@ -153,7 +153,7 @@
       <single>sekce</single>
       <multiple>sekce</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>pod heslem</single>
       <multiple>pod hesly</multiple>
     </term>
@@ -170,7 +170,7 @@
     <term name="book" form="short">k.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">sl.</term>
-    <term name="figure" form="short">obr.</term>
+    <term name="figure-locator" form="short">obr.</term>
     <term name="folio" form="short">l.</term>
     <term name="issue" form="short">č.</term>
     <term name="line" form="short">ř.</term>
@@ -187,7 +187,7 @@
     <term name="paragraph" form="short">odst.</term>
     <term name="part" form="short">č.</term>
     <term name="section" form="short">sek.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
     </term>

--- a/locales-cy-GB.xml
+++ b/locales-cy-GB.xml
@@ -102,7 +102,7 @@
       <single>colofn</single>
       <multiple>colofnau</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>ffigwr</single>
       <multiple>ffigyrau</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>adran</single>
       <multiple>adrannau</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">llyfr.</term>
     <term name="chapter" form="short">pen.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">ffig.</term>
+    <term name="figure-locator" form="short">ffig.</term>
     <term name="folio" form="short">ff.</term>
     <term name="issue" form="short">rhif.</term>
     <term name="line" form="short">ll.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">rhan.</term>
     <term name="section" form="short">adr.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -105,7 +105,7 @@
       <single>kolonne</single>
       <multiple>kolonner</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figur</single>
       <multiple>figurer</multiple>
     </term>
@@ -149,7 +149,7 @@
       <single>paragraf</single>
       <multiple>paragraffer</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub voce</single>
       <multiple>sub voce</multiple>
     </term>
@@ -166,7 +166,7 @@
     <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">kol.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">l.</term>
@@ -183,7 +183,7 @@
     <term name="paragraph" form="short">afs.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">par.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
     </term>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -114,7 +114,7 @@
       <single>Spalte</single>
       <multiple>Spalten</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>Abbildung</single>
       <multiple>Abbildungen</multiple>
     </term>
@@ -158,7 +158,7 @@
       <single>Abschnitt</single>
       <multiple>Abschnitte</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -175,7 +175,7 @@
     <term name="book" form="short">B.</term>
     <term name="chapter" form="short">Kap.</term>
     <term name="column" form="short">Sp.</term>
-    <term name="figure" form="short">Abb.</term>
+    <term name="figure-locator" form="short">Abb.</term>
     <term name="folio" form="short">Fol.</term>
     <term name="issue" form="short">Nr.</term>
     <term name="line" form="short">l.</term>
@@ -192,7 +192,7 @@
     <term name="paragraph" form="short">Abs.</term>
     <term name="part" form="short">Teil</term>
     <term name="section" form="short">Abschn.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -108,7 +108,7 @@
       <single>Spalte</single>
       <multiple>Spalten</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>Abbildung</single>
       <multiple>Abbildungen</multiple>
     </term>
@@ -152,7 +152,7 @@
       <single>Abschnitt</single>
       <multiple>Abschnitte</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -169,7 +169,7 @@
     <term name="book" form="short">B.</term>
     <term name="chapter" form="short">Kap.</term>
     <term name="column" form="short">Sp.</term>
-    <term name="figure" form="short">Abb.</term>
+    <term name="figure-locator" form="short">Abb.</term>
     <term name="folio" form="short">Fol.</term>
     <term name="issue" form="short">Nr.</term>
     <term name="line" form="short">l.</term>
@@ -186,7 +186,7 @@
     <term name="paragraph" form="short">Abs.</term>
     <term name="part" form="short">Teil</term>
     <term name="section" form="short">Abschn.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -111,7 +111,7 @@
       <single>Spalte</single>
       <multiple>Spalten</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>Abbildung</single>
       <multiple>Abbildungen</multiple>
     </term>
@@ -155,7 +155,7 @@
       <single>Abschnitt</single>
       <multiple>Abschnitte</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -172,7 +172,7 @@
     <term name="book" form="short">B.</term>
     <term name="chapter" form="short">Kap.</term>
     <term name="column" form="short">Sp.</term>
-    <term name="figure" form="short">Abb.</term>
+    <term name="figure-locator" form="short">Abb.</term>
     <term name="folio" form="short">Fol.</term>
     <term name="issue" form="short">Nr.</term>
     <term name="line" form="short">Z.</term>
@@ -189,7 +189,7 @@
     <term name="paragraph" form="short">Abs.</term>
     <term name="part" form="short">Teil</term>
     <term name="section" form="short">Abschn.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -104,7 +104,7 @@
       <single>στήλη</single>
       <multiple>στήλες</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>εικόνα</single>
       <multiple>εικόνες</multiple>
     </term>
@@ -148,7 +148,7 @@
       <single>τμήμα</single>
       <multiple>τμήματα</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>λήμμα</single>
       <multiple>λήμματα</multiple>
     </term>
@@ -165,7 +165,7 @@
     <term name="book" form="short">βιβ.</term>
     <term name="chapter" form="short">κεφ.</term>
     <term name="column" form="short">στ.</term>
-    <term name="figure" form="short">εικ.</term>
+    <term name="figure-locator" form="short">εικ.</term>
     <term name="folio" form="short">φάκ</term>
     <term name="issue" form="short">τχ.</term>
     <term name="line" form="short">γρ.</term>
@@ -182,7 +182,7 @@
     <term name="paragraph" form="short">παρ.</term>
     <term name="part" form="short">μέρ.</term>
     <term name="section" form="short">τμ.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>λήμ.</single>
       <multiple>λήμ.</multiple>
     </term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -111,7 +111,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -155,7 +155,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -181,7 +181,7 @@
       <single>col.</single>
       <multiple>cols</multiple>
     </term>
-    <term name="figure" form="short">
+    <term name="figure-locator" form="short">
       <single>fig.</single>
       <multiple>figs</multiple>
     </term>
@@ -225,7 +225,7 @@
       <single>sec.</single>
       <multiple>secs</multiple>
     </term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -111,7 +111,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -155,7 +155,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -181,7 +181,7 @@
       <single>col.</single>
       <multiple>cols.</multiple>
     </term>
-    <term name="figure" form="short">
+    <term name="figure-locator" form="short">
       <single>fig.</single>
       <multiple>figs.</multiple>
     </term>
@@ -225,7 +225,7 @@
       <single>sec.</single>
       <multiple>secs.</multiple>
     </term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -100,7 +100,7 @@
       <single>columna</single>
       <multiple>columnas</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figuras</multiple>
     </term>
@@ -144,7 +144,7 @@
       <single>sección</single>
       <multiple>secciones</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub voce</single>
       <multiple>sub vocibus</multiple>
     </term>
@@ -161,7 +161,7 @@
     <term name="book" form="short">lib.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">nº</term>
     <term name="line" form="short">l.</term>
@@ -178,7 +178,7 @@
     <term name="paragraph" form="short">párr.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -99,7 +99,7 @@
       <single>columna</single>
       <multiple>columnas</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figuras</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>sección</single>
       <multiple>secciones</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub voce</single>
       <multiple>sub vocibus</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">lib.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">n.º</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">párr.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -105,7 +105,7 @@
       <single>columna</single>
       <multiple>columnas</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figuras</multiple>
     </term>
@@ -149,7 +149,7 @@
       <single>sección</single>
       <multiple>secciones</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub voce</single>
       <multiple>sub vocibus</multiple>
     </term>
@@ -175,7 +175,7 @@
       <single>col.</single>
       <multiple>cols.</multiple>
     </term>
-    <term name="figure" form="short">
+    <term name="figure-locator" form="short">
       <single>fig.</single>
       <multiple>figs.</multiple>
     </term>
@@ -219,7 +219,7 @@
       <single>sec.</single>
       <multiple>secs.</multiple>
     </term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -99,7 +99,7 @@
       <single>veerg</single>
       <multiple>veerud</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>joonis</single>
       <multiple>joonised</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>alajaotis</single>
       <multiple>alajaotised</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">rmt</term>
     <term name="chapter" form="short">ptk</term>
     <term name="column" form="short">v</term>
-    <term name="figure" form="short">joon</term>
+    <term name="figure-locator" form="short">joon</term>
     <term name="folio" form="short">f</term>
     <term name="issue" form="short">nr</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">lõik</term>
     <term name="part" form="short">osa</term>
     <term name="section" form="short">alajaot.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -99,7 +99,7 @@
       <single>zutabea</single>
       <multiple>zutabeak</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>irudia</single>
       <multiple>irudiak</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>atala</single>
       <multiple>atalak</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub voce</single>
       <multiple>sub vocem</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">lib.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">zut.</term>
-    <term name="figure" form="short">iru.</term>
+    <term name="figure-locator" form="short">iru.</term>
     <term name="folio" form="short">or.</term>
     <term name="issue" form="short">zenb.</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">zt.</term>
     <term name="section" form="short">atal.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
     </term>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -102,7 +102,7 @@
       <single>ستون</single>
       <multiple>ستون‌های</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>تصویر</single>
       <multiple>تصاویر</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>قسمت</single>
       <multiple>قسمت‌های</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>در ذیلِ واژه</single>
       <multiple>در ذیلِ واژه‌های</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">کتاب</term>
     <term name="chapter" form="short">فصل</term>
     <term name="column" form="short">ستون</term>
-    <term name="figure" form="short">تصویر</term>
+    <term name="figure-locator" form="short">تصویر</term>
     <term name="folio" form="short">برگ</term>
     <term name="issue" form="short">ش</term>
     <term name="line" form="short">خط</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">پاراگراف</term>
     <term name="part" form="short">بخش</term>
     <term name="section" form="short">قسمت</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v</single>
       <multiple>s.vv</multiple>
     </term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -108,7 +108,7 @@
       <single>palsta</single>
       <multiple>palstat</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>kuvio</single>
       <multiple>kuviot</multiple>
     </term>
@@ -152,7 +152,7 @@
       <single>osa</single>
       <multiple>osat</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -169,7 +169,7 @@
     <term name="book" form="short">kirja</term>
     <term name="chapter" form="short">luku</term>
     <term name="column" form="short">palsta</term>
-    <term name="figure" form="short">kuv.</term>
+    <term name="figure-locator" form="short">kuv.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nro</term>
     <term name="line" form="short">r.</term>
@@ -186,7 +186,7 @@
     <term name="paragraph" form="short">kappale</term>
     <term name="part" form="short">osa</term>
     <term name="section" form="short">osa</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -101,7 +101,7 @@
       <single>colonne</single>
       <multiple>colonnes</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -145,7 +145,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -162,7 +162,7 @@
     <term name="book" form="short">liv.</term>
     <term name="chapter" form="short">chap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">
       <single>fᵒ</single>
       <multiple>fᵒˢ</multiple>
@@ -185,7 +185,7 @@
     <term name="paragraph" form="short">paragr.</term>
     <term name="part" form="short">part.</term>
     <term name="section" form="short">sect.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -101,7 +101,7 @@
       <single>colonne</single>
       <multiple>colonnes</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -145,7 +145,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -162,7 +162,7 @@
     <term name="book" form="short">liv.</term>
     <term name="chapter" form="short">chap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">
       <single>fᵒ</single>
       <multiple>fᵒˢ</multiple>
@@ -185,7 +185,7 @@
     <term name="paragraph" form="short">paragr.</term>
     <term name="part" form="short">part.</term>
     <term name="section" form="short">sect.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
     </term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -105,7 +105,7 @@
       <single>טור</single>
       <multiple>טורים</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -149,7 +149,7 @@
       <single>סעיף</single>
       <multiple>סעיפים</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -166,7 +166,7 @@
     <term name="book" form="short">bk</term>
     <term name="chapter" form="short">chap</term>
     <term name="column" form="short">col</term>
-    <term name="figure" form="short">fig</term>
+    <term name="figure-locator" form="short">fig</term>
     <term name="folio" form="short">f</term>
     <term name="issue" form="short">no</term>
     <term name="line" form="short">l.</term>
@@ -183,7 +183,7 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">ס'</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-hi-IN.xml
+++ b/locales-hi-IN.xml
@@ -115,7 +115,7 @@
       <single>कॉलम</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>चित्र</single>
       <multiple>चित्रों</multiple>
     </term>
@@ -159,7 +159,7 @@
       <single>अनुभाग</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -185,7 +185,7 @@
       <single>col.</single>
       <multiple>cols.</multiple>
     </term>
-    <term name="figure" form="short">
+    <term name="figure-locator" form="short">
       <single>fig.</single>
       <multiple>figs.</multiple>
     </term>
@@ -229,7 +229,7 @@
       <single>sec.</single>
       <multiple>secs.</multiple>
     </term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -99,7 +99,7 @@
       <single>stupac</single>
       <multiple>stupci</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>crtež</single>
       <multiple>crteži</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>odjeljak</single>
       <multiple>odjeljci</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">knj.</term>
     <term name="chapter" form="short">pogl.</term>
     <term name="column" form="short">stup.</term>
-    <term name="figure" form="short">crt.</term>
+    <term name="figure-locator" form="short">crt.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">izd.</term>
     <term name="line" form="short">red</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">dio</term>
     <term name="section" form="short">od.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -103,7 +103,7 @@
       <single>oszlop</single>
       <multiple>oszlop</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>ábra</single>
       <multiple>ábra</multiple>
     </term>
@@ -147,7 +147,7 @@
       <single>szakasz</single>
       <multiple>szakasz</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -164,7 +164,7 @@
     <term name="book" form="short">könyv</term>
     <term name="chapter" form="short">fej.</term>
     <term name="column" form="short">oszl.</term>
-    <term name="figure" form="short">ábr.</term>
+    <term name="figure-locator" form="short">ábr.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">sz.</term>
     <term name="line" form="short">s.</term>
@@ -181,7 +181,7 @@
     <term name="paragraph" form="short">bek.</term>
     <term name="part" form="short">rész</term>
     <term name="section" form="short">szak.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s. v.</single>
       <multiple>s. vv.</multiple>
     </term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -111,7 +111,7 @@
       <single>kolom</single>
       <multiple>kolom</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>gambar</single>
       <multiple>gambar</multiple>
     </term>
@@ -155,7 +155,7 @@
       <single>bagian</single>
       <multiple>bagian</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -172,7 +172,7 @@
     <term name="book" form="short">bk.</term>
     <term name="chapter" form="short">bb.</term>
     <term name="column" form="short">kol.</term>
-    <term name="figure" form="short">gbr.</term>
+    <term name="figure-locator" form="short">gbr.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">no.</term>
     <term name="line" form="short">brs.</term>
@@ -189,7 +189,7 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">bag.</term>
     <term name="section" form="short">bag.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -102,7 +102,7 @@
       <single>dálkur</single>
       <multiple>dálkar</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>mynd</single>
       <multiple>myndir</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>hluti</single>
       <multiple>hlutar</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">bók</term>
     <term name="chapter" form="short">k.</term>
     <term name="column" form="short">d.</term>
-    <term name="figure" form="short">mynd.</term>
+    <term name="figure-locator" form="short">mynd.</term>
     <term name="folio" form="short">handr.</term>
     <term name="issue" form="short">tbl.</term>
     <term name="line" form="short">l.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">málsgr.</term>
     <term name="part" form="short">hl.</term>
     <term name="section" form="short">hl.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -127,7 +127,7 @@
       <single>colonna</single>
       <multiple>colonne</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figure</multiple>
     </term>
@@ -171,7 +171,7 @@
       <single>paragrafo</single>
       <multiple>paragrafi</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -191,7 +191,7 @@
       <multiple>capp.</multiple>
     </term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">fgl.</term>
     <term name="issue" form="short">n.</term>
     <term name="line" form="short">l.</term>
@@ -208,7 +208,7 @@
     <term name="paragraph" form="short">cpv.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">par.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -105,7 +105,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -149,7 +149,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -166,7 +166,7 @@
     <term name="book" form="short">bk.</term>
     <term name="chapter" form="short">chap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">no.</term>
     <term name="line" form="short">l.</term>
@@ -183,7 +183,7 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -102,7 +102,7 @@
       <single>កាឡោន</single>
       <multiple>កាឡោន</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>តួលេខ</single>
       <multiple>តួលេខ</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>ផ្នែក</single>
       <multiple>ផ្នែក</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">bk.</term>
     <term name="chapter" form="short">chap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">no.</term>
     <term name="line" form="short">l.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -102,7 +102,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">bk</term>
     <term name="chapter" form="short">chap</term>
     <term name="column" form="short">col</term>
-    <term name="figure" form="short">fig</term>
+    <term name="figure-locator" form="short">fig</term>
     <term name="folio" form="short">f</term>
     <term name="issue" form="short">호</term>
     <term name="line" form="short">l.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">sec</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-la.xml
+++ b/locales-la.xml
@@ -99,7 +99,7 @@
       <single>columna</single>
       <multiple>columnae</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figurae</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>paragraphus</single>
       <multiple>paragraphi</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub uerbo</single>
       <multiple>sub uerbis</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">lib.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">n.</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pr.</term>
     <term name="section" form="short">par.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.u.</single>
       <multiple>s.uu.</multiple>
     </term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -118,7 +118,7 @@
       <single>skiltis</single>
       <multiple>skiltys</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>iliustracija</single>
       <multiple>iliustracijos</multiple>
     </term>
@@ -162,7 +162,7 @@
       <single>poskyris</single>
       <multiple>poskyriai</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>žiūrėk</single>
       <multiple>žiūrėk</multiple>
     </term>
@@ -179,7 +179,7 @@
     <term name="book" form="short">kn.</term>
     <term name="chapter" form="short">sk.</term>
     <term name="column" form="short">skilt.</term>
-    <term name="figure" form="short">il.</term>
+    <term name="figure-locator" form="short">il.</term>
     <term name="folio" form="short">l.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">eil.</term>
@@ -196,7 +196,7 @@
     <term name="paragraph" form="short">pastr.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">posk.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>žr.</single>
       <multiple>žr.</multiple>
     </term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -111,7 +111,7 @@
       <single>sleja</single>
       <multiple>slejas</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>ilustrācija</single>
       <multiple>ilustrācijas</multiple>
     </term>
@@ -155,7 +155,7 @@
       <single>apakšnodaļa</single>
       <multiple>apakšnodaļas</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>skatīt</single>
       <multiple>skatīt</multiple>
     </term>
@@ -172,7 +172,7 @@
     <term name="book" form="short">grām.</term>
     <term name="chapter" form="short">nod.</term>
     <term name="column" form="short">sl.</term>
-    <term name="figure" form="short">il.</term>
+    <term name="figure-locator" form="short">il.</term>
     <term name="folio" form="short">fo.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">r.</term>
@@ -189,7 +189,7 @@
     <term name="paragraph" form="short">rindk.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">apakšnod.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>sk.</single>
       <multiple>sk.</multiple>
     </term>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -96,7 +96,7 @@
       <single>багана</single>
       <multiple>баганууд</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -140,7 +140,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -157,7 +157,7 @@
     <term name="book" form="short">bk</term>
     <term name="chapter" form="short">chap</term>
     <term name="column" form="short">col</term>
-    <term name="figure" form="short">fig</term>
+    <term name="figure-locator" form="short">fig</term>
     <term name="folio" form="short">f</term>
     <term name="issue" form="short">no</term>
     <term name="line" form="short">l.</term>
@@ -174,7 +174,7 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">sec</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -99,7 +99,7 @@
       <single>kolonne</single>
       <multiple>kolonner</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figur</single>
       <multiple>figurer</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>paragraf</single>
       <multiple>paragrafer</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">kol.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">avsn.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">pargr.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -118,7 +118,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figuur</single>
       <multiple>figuren</multiple>
     </term>
@@ -162,7 +162,7 @@
       <single>sectie</single>
       <multiple>secties</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -179,7 +179,7 @@
     <term name="book" form="short">bk.</term>
     <term name="chapter" form="short">hfdst.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">l.</term>
@@ -196,7 +196,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">deel</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -99,7 +99,7 @@
       <single>kolonne</single>
       <multiple>kolonner</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figur</single>
       <multiple>figurar</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>paragraf</single>
       <multiple>paragrafar</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">kol.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">avsn.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">par.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -105,7 +105,7 @@
       <single>kolumna</single>
       <multiple>kolumny</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>rycina</single>
       <multiple>ryciny</multiple>
     </term>
@@ -149,7 +149,7 @@
       <single>sekcja</single>
       <multiple>sekcje</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -166,7 +166,7 @@
     <term name="book" form="short">książka</term>
     <term name="chapter" form="short">rozdz.</term>
     <term name="column" form="short">kol.</term>
-    <term name="figure" form="short">ryc.</term>
+    <term name="figure-locator" form="short">ryc.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr</term>
     <term name="line" form="short">l.</term>
@@ -183,7 +183,7 @@
     <term name="paragraph" form="short">akap.</term>
     <term name="part" form="short">cz.</term>
     <term name="section" form="short">sekc.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -114,7 +114,7 @@
       <single>coluna</single>
       <multiple>colunas</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figuras</multiple>
     </term>
@@ -158,7 +158,7 @@
       <single>seção</single>
       <multiple>seções</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -175,7 +175,7 @@
     <term name="book" form="short">liv.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">nº</term>
     <term name="line" form="short">l.</term>
@@ -192,7 +192,7 @@
     <term name="paragraph" form="short">parag.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">seç.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -110,7 +110,7 @@
       <single>coluna</single>
       <multiple>colunas</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figuras</multiple>
     </term>
@@ -154,7 +154,7 @@
       <single>secção</single>
       <multiple>secções</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -171,7 +171,7 @@
     <term name="book" form="short">liv.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">n.</term>
     <term name="line" form="short">l.</term>
@@ -188,7 +188,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -101,7 +101,7 @@
       <single>coloana</single>
       <multiple>coloanele</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figura</single>
       <multiple>figurile</multiple>
     </term>
@@ -145,7 +145,7 @@
       <single>secțiunea</single>
       <multiple>secțiunile</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -162,7 +162,7 @@
     <term name="book" form="short">cart.</term>
     <term name="chapter" form="short">cap.</term>
     <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr.</term>
     <term name="line" form="short">l.</term>
@@ -179,7 +179,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">part.</term>
     <term name="section" form="short">sec.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -125,7 +125,7 @@
       <single>столбец</single>
       <multiple>столбцы</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>рисунок</single>
       <multiple>рисунки</multiple>
     </term>
@@ -170,7 +170,7 @@
       <single>раздел</single>
       <multiple>разделы</multiple>
     </term>
-    <term name="sub verbo">смотри</term>
+    <term name="sub-verbo">смотри</term>
     <term name="verse">
       <single>стих</single>
       <multiple>стихи</multiple>
@@ -185,7 +185,7 @@
     <term name="book" form="short">кн.</term>
     <term name="chapter" form="short">гл.</term>
     <term name="column" form="short">стб.</term>
-    <term name="figure" form="short">рис.</term>
+    <term name="figure-locator" form="short">рис.</term>
     <term name="folio" form="short">
       <single>л.</single>
       <multiple>лл.</multiple>
@@ -211,7 +211,7 @@
       <multiple>чч.</multiple>
     </term>
     <term name="section" form="short">разд.</term>
-    <term name="sub verbo" form="short">см.</term>
+    <term name="sub-verbo" form="short">см.</term>
     <term name="verse" form="short">ст.</term>
     <term name="volume" form="short">
       <single>т.</single>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -108,7 +108,7 @@
       <single>stĺpec</single>
       <multiple>stĺpce</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>obrázok</single>
       <multiple>obrázky</multiple>
     </term>
@@ -152,7 +152,7 @@
       <single>sekcia</single>
       <multiple>sekcie</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -169,7 +169,7 @@
     <term name="book" form="short">k.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">stĺp.</term>
-    <term name="figure" form="short">obr.</term>
+    <term name="figure-locator" form="short">obr.</term>
     <term name="folio" form="short">l.</term>
     <term name="issue" form="short">č.</term>
     <term name="line" form="short">l.</term>
@@ -186,7 +186,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">č.</term>
     <term name="section" form="short">sek.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -102,7 +102,7 @@
       <single>stolpec</single>
       <multiple>stolpci</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>slika</single>
       <multiple>slike</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>odsek</single>
       <multiple>odseki</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">knj.</term>
     <term name="chapter" form="short">pogl.</term>
     <term name="column" form="short">stolp.</term>
-    <term name="figure" form="short">sl.</term>
+    <term name="figure-locator" form="short">sl.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">št.</term>
     <term name="line" form="short">vrst.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">odst.</term>
     <term name="part" form="short">del</term>
     <term name="section" form="short">ods.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s. v.</single>
       <multiple>s. v.</multiple>
     </term>

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -102,7 +102,7 @@
       <single>колона</single>
       <multiple>колоне</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>цртеж</single>
       <multiple>цртежи</multiple>
     </term>
@@ -146,7 +146,7 @@
       <single>одељак</single>
       <multiple>одељака</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -163,7 +163,7 @@
     <term name="book" form="short">књига</term>
     <term name="chapter" form="short">Пог.</term>
     <term name="column" form="short">кол.</term>
-    <term name="figure" form="short">црт.</term>
+    <term name="figure-locator" form="short">црт.</term>
     <term name="folio" form="short">фолио</term>
     <term name="issue" form="short">изд.</term>
     <term name="line" form="short">l.</term>
@@ -180,7 +180,7 @@
     <term name="paragraph" form="short">пар.</term>
     <term name="part" form="short">део</term>
     <term name="section" form="short">од.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -112,7 +112,7 @@
       <single>kolumn</single>
       <multiple>kolumner</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figur</single>
       <multiple>figurer</multiple>
     </term>
@@ -156,7 +156,7 @@
       <single>avsnitt</single>
       <multiple>avsnitt</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -173,7 +173,7 @@
     <term name="book" form="short">bok</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">kol.</term>
-    <term name="figure" form="short">fig.</term>
+    <term name="figure-locator" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
     <term name="issue" form="short">nr</term>
     <term name="line" form="short">l.</term>
@@ -190,7 +190,7 @@
     <term name="paragraph" form="short">st.</term>
     <term name="part" form="short">del</term>
     <term name="section" form="short">avs.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -99,7 +99,7 @@
       <single>สดมภ์</single>
       <multiple>สดมภ์</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>รูปภาพ</single>
       <multiple>รูปภาพ</multiple>
     </term>
@@ -143,7 +143,7 @@
       <single>หมวด</single>
       <multiple>หมวด</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>ใต้คำ</single>
       <multiple>ใต้คำ</multiple>
     </term>
@@ -160,7 +160,7 @@
     <term name="book" form="short">หนังสือ</term>
     <term name="chapter" form="short">บทที่</term>
     <term name="column" form="short">สดมภ์</term>
-    <term name="figure" form="short">รูปภาพ</term>
+    <term name="figure-locator" form="short">รูปภาพ</term>
     <term name="folio" form="short">หน้า</term>
     <term name="issue" form="short">ฉบับที่</term>
     <term name="line" form="short">l.</term>
@@ -177,7 +177,7 @@
     <term name="paragraph" form="short">ย่อหน้า</term>
     <term name="part" form="short">ส่วนย่อย</term>
     <term name="section" form="short">หมวด</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>ใต้คำ</single>
       <multiple>ใต้คำ</multiple>
     </term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -109,7 +109,7 @@
       <single>sütun</single>
       <multiple>sütunlar</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>şekil</single>
       <multiple>şekiller</multiple>
     </term>
@@ -153,7 +153,7 @@
       <single>bölüm</single>
       <multiple>bölümler</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>madde</single>
       <multiple>maddeler</multiple>
     </term>
@@ -170,7 +170,7 @@
     <term name="book" form="short">kit.</term>
     <term name="chapter" form="short">böl.</term>
     <term name="column" form="short">süt.</term>
-    <term name="figure" form="short">şek.</term>
+    <term name="figure-locator" form="short">şek.</term>
     <term name="folio" form="short">fl.</term>
     <term name="issue" form="short">sy</term>
     <term name="line" form="short">satır</term>
@@ -187,7 +187,7 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">ksm.</term>
     <term name="section" form="short">blm.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>md.</single>
       <multiple>md.</multiple>
     </term>

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -87,7 +87,7 @@
       <single>графа</single>
       <multiple>графи</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>рисунок</single>
       <multiple>рисунки</multiple>
     </term>
@@ -122,7 +122,7 @@
       <single>розділ</single>
       <multiple>розділи</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -139,7 +139,7 @@
     <term name="book" form="short">кн.</term>
     <term name="chapter" form="short">розд.</term>
     <term name="column" form="short">ряд.</term>
-    <term name="figure" form="short">рис.</term>
+    <term name="figure-locator" form="short">рис.</term>
     <term name="folio" form="short">ф.</term>
     <term name="issue" form="short">вип.</term>
     <term name="line" form="short">л.</term>
@@ -150,7 +150,7 @@
     <term name="paragraph" form="short">пар.</term>
     <term name="part" form="short">ч.</term>
     <term name="section" form="short">сек.</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -105,7 +105,7 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="figure">
+    <term name="figure-locator">
       <single>figure</single>
       <multiple>figures</multiple>
     </term>
@@ -149,7 +149,7 @@
       <single>section</single>
       <multiple>sections</multiple>
     </term>
-    <term name="sub verbo">
+    <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
@@ -166,7 +166,7 @@
     <term name="book" form="short">sách</term>
     <term name="chapter" form="short">ch</term>
     <term name="column" form="short">col</term>
-    <term name="figure" form="short">fig</term>
+    <term name="figure-locator" form="short">fig</term>
     <term name="folio" form="short">f</term>
     <term name="issue" form="short">số p.h</term>
     <term name="line" form="short">d.</term>
@@ -183,7 +183,7 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">ph</term>
     <term name="section" form="short">sec</term>
-    <term name="sub verbo" form="short">
+    <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -87,7 +87,7 @@
     <term name="book">册</term>
     <term name="chapter">章</term>
     <term name="column">栏</term>
-    <term name="figure">图表</term>       
+    <term name="figure-locator">图表</term>       
     <term name="folio">版</term>
     <term name="issue">期</term>
     <term name="line">行</term>
@@ -98,7 +98,7 @@
     <term name="paragraph">段落</term>
     <term name="part">部分</term>     
     <term name="section">节</term>         
-    <term name="sub verbo">另见</term>    
+    <term name="sub-verbo">另见</term>    
     <term name="verse">篇</term>    
     <term name="volume">卷</term>
     
@@ -106,7 +106,7 @@
     <term name="book" form="short">册</term>
     <term name="chapter" form="short">章</term>
     <term name="column" form="short">栏</term>
-    <term name="figure" form="short">图</term>
+    <term name="figure-locator" form="short">图</term>
     <term name="folio" form="short">版</term>
     <term name="issue" form="short">期</term>
     <term name="line" form="short">行</term>
@@ -117,7 +117,7 @@
     <term name="paragraph" form="short">段</term>
     <term name="part" form="short">部</term>
     <term name="section" form="short">节</term>
-    <term name="sub verbo" form="short">另见</term>   
+    <term name="sub-verbo" form="short">另见</term>   
     <term name="verse" form="short">篇</term>      
     <term name="volume" form="short">卷</term>
     

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -81,7 +81,7 @@
     <term name="book">冊</term>
     <term name="chapter">章</term>
     <term name="column">欄</term>
-    <term name="figure">圖表</term>       
+    <term name="figure-locator">圖表</term>       
     <term name="folio">版</term>
     <term name="issue">期</term>
     <term name="line">行</term>
@@ -92,7 +92,7 @@
     <term name="paragraph">段落</term>
     <term name="part">部分</term>     
     <term name="section">節</term>         
-    <term name="sub verbo">另見</term>    
+    <term name="sub-verbo">另見</term>    
     <term name="verse">篇</term>    
     <term name="volume">卷</term>
     
@@ -100,7 +100,7 @@
     <term name="book" form="short">冊</term>
     <term name="chapter" form="short">章</term>
     <term name="column" form="short">欄</term>
-    <term name="figure" form="short">圖</term>
+    <term name="figure-locator" form="short">圖</term>
     <term name="issue" form="short">期</term>
     <term name="line" form="short">行</term>
     <term name="note" form="short">註</term>
@@ -110,7 +110,7 @@
     <term name="paragraph" form="short">段</term>
     <term name="part" form="short">部</term>
     <term name="section" form="short">節</term>
-    <term name="sub verbo" form="short">另見</term>   
+    <term name="sub-verbo" form="short">另見</term>   
     <term name="verse" form="short">篇</term>      
     <term name="volume" form="short">卷</term>
     


### PR DESCRIPTION
Rename these terms. Should be the only change needed for validation on CSL 1.0.2