### PR TITLE
 Update Japanese (ja-JP) Localization [fix for #245]

### DIFF
--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -3,6 +3,8 @@
   <info>
     <translator>
       <name>Shoji Takahashi</name>
+    </translator>
+    <translator>
       <name>cmplstofB</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -3,9 +3,15 @@
   <info>
     <translator>
       <name>Shoji Takahashi</name>
+      <name>cmplstofB</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2012-07-04T23:31:02+00:00</updated>
+    <updated>2022-01-01T14:17:55+09:00</updated>
+    <!--
+日本語化にあたって参考にした文献
+* SIST 02:2007「参照文献の書き方」
+* JIS X 0807:1999「電子文献の引用法」
+    -->
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -20,16 +26,16 @@
   </date>
   <terms>
     <term name="accessed">参照</term>
-    <term name="and">と</term>
-    <term name="and others">and others</term>
-    <term name="anonymous">anonymous</term>
-    <term name="anonymous" form="short">anon</term>
-    <term name="at">at</term>
-    <term name="available at">available at</term>
-    <term name="by">by</term>
-    <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term>
-    <term name="cited">cited</term>
+    <term name="and">および</term>
+    <term name="and others">ほか</term>
+    <term name="anonymous">匿名</term>
+    <term name="anonymous" form="short">匿名</term>
+    <term name="at">にて</term>
+    <term name="available at">入手先</term>
+    <term name="by">による</term>
+    <term name="circa">およそ</term>
+    <term name="circa" form="short">およそ</term>
+    <term name="cited">引用</term>
     <term name="edition">
       <single>版</single>
       <multiple>版</multiple>
@@ -39,30 +45,30 @@
     <term name="forthcoming">近刊</term>
     <term name="from">から</term>
     <term name="ibid">前掲</term>
-    <term name="in"></term>
-    <term name="in press">in press</term>
-    <term name="internet">internet</term>
-    <term name="interview">interview</term>
-    <term name="letter">letter</term>
-    <term name="no date">no date</term>
+    <term name="in">中</term>
+    <term name="in press">近刊</term>
+    <term name="internet">インターネット</term>
+    <term name="interview">面接</term>
+    <term name="letter">手紙</term>
+    <term name="no date">日付なし</term>
     <term name="no date" form="short">日付なし</term>
-    <term name="online">online</term>
-    <term name="presented at">presented at the</term>
+    <term name="online">オンライン</term>
+    <term name="presented at">表示場所</term>
     <term name="reference">
-      <single>reference</single>
-      <multiple>references</multiple>
+      <single>参照</single>
+      <multiple>参照</multiple>
     </term>
     <term name="reference" form="short">
-      <single>ref.</single>
-      <multiple>refs.</multiple>
+      <single>参照</single>
+      <multiple>参照</multiple>
     </term>
-    <term name="retrieved">読み込み</term>
-    <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="retrieved">入手先</term>
+    <term name="scale">位</term>
+    <term name="version">版</term>
 
     <!-- ANNO DOMINI; BEFORE CHRIST -->
-    <term name="ad">AD</term>
-    <term name="bc">BC</term>
+    <term name="ad">紀元前</term>
+    <term name="bc">紀元後</term>
 
     <!-- PUNCTUATION -->
     <term name="open-quote">「</term>
@@ -72,62 +78,62 @@
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
-    <term name="ordinal">th</term>
-    <term name="ordinal-01">st</term>
-    <term name="ordinal-02">nd</term>
-    <term name="ordinal-03">rd</term>
-    <term name="ordinal-11">th</term>
-    <term name="ordinal-12">th</term>
-    <term name="ordinal-13">th</term>
+    <term name="ordinal">番目</term>
+    <term name="ordinal-01">番目</term>
+    <term name="ordinal-02">番目</term>
+    <term name="ordinal-03">番目</term>
+    <term name="ordinal-11">番目</term>
+    <term name="ordinal-12">番目</term>
+    <term name="ordinal-13">番目</term>
 
     <!-- LONG ORDINALS -->
-    <term name="long-ordinal-01">first</term>
-    <term name="long-ordinal-02">second</term>
-    <term name="long-ordinal-03">third</term>
-    <term name="long-ordinal-04">fourth</term>
-    <term name="long-ordinal-05">fifth</term>
-    <term name="long-ordinal-06">sixth</term>
-    <term name="long-ordinal-07">seventh</term>
-    <term name="long-ordinal-08">eighth</term>
-    <term name="long-ordinal-09">ninth</term>
-    <term name="long-ordinal-10">tenth</term>
+    <term name="long-ordinal-01">1番目</term>
+    <term name="long-ordinal-02">2番目</term>
+    <term name="long-ordinal-03">3番目</term>
+    <term name="long-ordinal-04">4番目</term>
+    <term name="long-ordinal-05">5番目</term>
+    <term name="long-ordinal-06">6番目</term>
+    <term name="long-ordinal-07">7番目</term>
+    <term name="long-ordinal-08">8番目</term>
+    <term name="long-ordinal-09">9番目</term>
+    <term name="long-ordinal-10">10番目</term>
 
     <!-- LONG LOCATOR FORMS -->
     <term name="book">
-      <single>book</single>
-      <multiple>books</multiple>
+      <single>書籍</single>
+      <multiple>書籍</multiple>
     </term>
     <term name="chapter">
-      <single>chapter</single>
-      <multiple>chapters</multiple>
+      <single>章</single>
+      <multiple>章</multiple>
     </term>
     <term name="column">
-      <single>column</single>
-      <multiple>columns</multiple>
+      <single>欄</single>
+      <multiple>欄</multiple>
     </term>
     <term name="figure">
-      <single>figure</single>
-      <multiple>figures</multiple>
+      <single>図</single>
+      <multiple>図</multiple>
     </term>
     <term name="folio">
-      <single>folio</single>
-      <multiple>folios</multiple>
+      <single>面</single>
+      <multiple>面</multiple>
     </term>
     <term name="issue">
-      <single>number</single>
-      <multiple>numbers</multiple>
+      <single>号</single>
+      <multiple>号</multiple>
     </term>
     <term name="line">
       <single>行</single>
       <multiple>行</multiple>
     </term>
     <term name="note">
-      <single>note</single>
-      <multiple>notes</multiple>
+      <single>註</single>
+      <multiple>註</multiple>
     </term>
     <term name="opus">
-      <single>opus</single>
-      <multiple>opera</multiple>
+      <single>作品</single>
+      <multiple>作品</multiple>
     </term>
     <term name="page">
       <single>ページ</single>
@@ -142,24 +148,28 @@
       <multiple>段落</multiple>
     </term>
     <term name="part">
-      <single>part</single>
-      <multiple>parts</multiple>
+      <single>部</single>
+      <multiple>部</multiple>
     </term>
     <term name="section">
-      <single>section</single>
-      <multiple>sections</multiple>
+      <single>節</single>
+      <multiple>節</multiple>
     </term>
     <term name="sub verbo">
-      <single>sub verbo</single>
-      <multiple>sub verbis</multiple>
+      <single>における</single>
+<!--
+『辞書』における「単語」
+        ^^^^^^^^
+-->
+      <multiple>における</multiple>
     </term>
     <term name="verse">
-      <single>verse</single>
-      <multiple>verses</multiple>
+      <single>詩歌</single>
+      <multiple>詩歌</multiple>
     </term>
     <term name="volume">
-      <single>volume</single>
-      <multiple>volumes</multiple>
+      <single>巻</single>
+      <multiple>巻</multiple>
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
@@ -208,75 +218,75 @@
 
     <!-- LONG ROLE FORMS -->
     <term name="director">
-      <single>director</single>
-      <multiple>directors</multiple>
+      <single>指導者</single>
+      <multiple>指導者</multiple>
     </term>
     <term name="editor">
-      <single>編</single>
-      <multiple>編</multiple>
+      <single>編集者</single>
+      <multiple>編集者</multiple>
     </term>
     <term name="editorial-director">
-      <single>editor</single>
-      <multiple>editors</multiple>
+      <single>編集者</single>
+      <multiple>編集者</multiple>
     </term>
     <term name="illustrator">
-      <single>illustrator</single>
-      <multiple>illustrators</multiple>
+      <single>図解者</single>
+      <multiple>図解者</multiple>
     </term>
     <term name="translator">
       <single>翻訳者</single>
       <multiple>翻訳者</multiple>
     </term>
     <term name="editortranslator">
-      <single>editor &amp; translator</single>
-      <multiple>editors &amp; translators</multiple>
+      <single>編集・翻訳者</single>
+      <multiple>編集・翻訳者</multiple>
     </term>
 
     <!-- SHORT ROLE FORMS -->
     <term name="director" form="short">
-      <single>dir.</single>
-      <multiple>dirs.</multiple>
+      <single>指導</single>
+      <multiple>指導</multiple>
     </term>
     <term name="editor" form="short">
       <single>編</single>
       <multiple>編</multiple>
     </term>
     <term name="editorial-director" form="short">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
+      <single>編</single>
+      <multiple>編</multiple>
     </term>
     <term name="illustrator" form="short">
-      <single>ill.</single>
-      <multiple>ills.</multiple>
+      <single>図</single>
+      <multiple>図</multiple>
     </term>
     <term name="translator" form="short">
-      <single>翻訳者</single>
-      <multiple>翻訳者</multiple>
+      <single>訳</single>
+      <multiple>訳</multiple>
     </term>
     <term name="editortranslator" form="short">
-      <single>ed. &amp; tran.</single>
-      <multiple>eds. &amp; trans.</multiple>
+      <single>編・訳</single>
+      <multiple>編・訳</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="container-author" form="verb">by</term>
-    <term name="director" form="verb">directed by</term>
-    <term name="editor" form="verb">編集者：</term>
-    <term name="editorial-director" form="verb">edited by</term>
-    <term name="illustrator" form="verb">illustrated by</term>
-    <term name="interviewer" form="verb">interview by</term>
-    <term name="recipient" form="verb">to</term>
-    <term name="reviewed-author" form="verb">by</term>
-    <term name="translator" form="verb">翻訳者：</term>
-    <term name="editortranslator" form="verb">edited &amp; translated by</term>
+    <term name="container-author" form="verb">作者: </term>
+    <term name="director" form="verb">指導者: </term>
+    <term name="editor" form="verb">編集者: </term>
+    <term name="editorial-director" form="verb">編集者: </term>
+    <term name="illustrator" form="verb">図解者: </term>
+    <term name="interviewer" form="verb">面接者: </term>
+    <term name="recipient" form="verb">受領者: </term>
+    <term name="reviewed-author" form="verb">査読者: </term>
+    <term name="translator" form="verb">翻訳者: </term>
+    <term name="editortranslator" form="verb">編集・翻訳者: </term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="director" form="verb-short">dir.</term>
-    <term name="editor" form="verb-short">編集者：</term>
-    <term name="editorial-director" form="verb-short">ed.</term>
-    <term name="illustrator" form="verb-short">illus.</term>
-    <term name="translator" form="verb-short">翻訳者：</term>
-    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="director" form="verb-short">指導: </term>
+    <term name="editor" form="verb-short">編: </term>
+    <term name="editorial-director" form="verb-short">編: </term>
+    <term name="illustrator" form="verb-short">図: </term>
+    <term name="translator" form="verb-short">訳: </term>
+    <term name="editortranslator" form="verb-short">編・訳: </term>
 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">1月</term>
@@ -307,9 +317,9 @@
     <term name="month-12" form="short">12月</term>
 
     <!-- SEASONS -->
-    <term name="season-01">Spring</term>
-    <term name="season-02">Summer</term>
-    <term name="season-03">Autumn</term>
-    <term name="season-04">Winter</term>
+    <term name="season-01">春季</term>
+    <term name="season-02">夏季</term>
+    <term name="season-03">秋季</term>
+    <term name="season-04">冬季</term>
   </terms>
 </locale>


### PR DESCRIPTION
The following documents were used as references for the Japanese translation.

* SIST 02:2007「参照文献の書き方」
* JIS X 0807:1999「電子文献の引用法」

As a result, the existing translation has been slightly modified.
For example, "retrieved" should be translated as "入手元" (cf: JIS X 0807:1999, §6.12).

Some words (e.g. `pp.` the short form for the page ranges) are still in English, but they have been translated keeping their form, not untranslated.

---

This issue is fix for #245