### PR TITLE
Ibid and quote changes for sl-SI

### DIFF
--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -68,7 +68,7 @@
     <term name="et-al">idr.</term>
     <term name="forthcoming">pred izidom</term>
     <term name="from">s</term>
-    <term name="ibid">isto</term>
+    <term name="ibid">prav tam</term>
     <term name="in">v</term>
     <term name="in press">v tisku</term>
     <term name="internet">internet</term>
@@ -161,8 +161,8 @@
     <term name="ce">CE</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">„</term>
-    <term name="close-quote">“</term>
+    <term name="open-quote">»</term>
+    <term name="close-quote">«</term>
     <term name="open-inner-quote">‚</term>
     <term name="close-inner-quote">‘</term>
     <term name="page-range-delimiter">–</term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -7,6 +7,9 @@
     <translator>
       <name>ratek1</name>
     </translator>
+    <translator>
+      <name>mknurs</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-11-06T09:41:02+00:00</updated>
   </info>


### PR DESCRIPTION
## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

My change corrects two glaring incorrections or rather inaccuracies.

The official Slovenski pravopis recommends primarily using »«

> Dvodelni narekovaj, npr. dvojni srednji (» «), enojni srednji (› ‹), dvojni spodaj-zgoraj („ “), enojni spodaj-zgoraj (, ‘) ali dvojni zgornji (" ") (see Toporišič, *Slovenski pravopis*, § 461

See also: [https://svetovalnica.zrc-sazu.si/topic/4826/narekovaji](https://svetovalnica.zrc-sazu.si/topic/4826/narekovaji )

The other change (isto -> prav tam) is not yet officially confirmed, but it is the most used translation and is officially »being considered«. See: [https://fran.si/135/epravopis-slovenski-pravopis/4414197/ibid](https://fran.si/135/epravopis-slovenski-pravopis/4414197/ibid)


### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
