### PR TITLE
Resolve duplicate terms

### DIFF
--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -66,7 +66,6 @@
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">brief</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>

--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -72,7 +72,6 @@
     <term name="in">في</term>
     <term name="in press">قيد النشر</term>
     <term name="internet">انترنت</term>
-    <term name="interview">مقابلة</term>
     <term name="letter">خطاب</term>
     <term name="no date">دون تاريخ</term>
     <term name="no date" form="short">د.ت</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">مقابلة</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -336,39 +336,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -94,9 +94,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -139,8 +139,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -71,7 +71,6 @@
     <term name="in">в</term>
     <term name="in press">под печат</term>
     <term name="internet">интернет</term>
-    <term name="interview">интервю</term>
     <term name="letter">писмо</term>
     <term name="no date">без дата</term>
     <term name="no date" form="short">б.д.</term>
@@ -109,7 +108,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">интервю</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -72,7 +72,6 @@
     <term name="in">en</term>
     <term name="in press">en impremta</term>
     <term name="internet">internet</term>
-    <term name="interview">entrevista</term>
     <term name="letter">carta</term>
     <term name="no date">sense data</term>
     <term name="no date" form="short">s.d.</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">entrevista</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -102,9 +102,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -147,8 +147,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -79,7 +79,6 @@
     <term name="in">in</term>
     <term name="in press">v tisku</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">dopis</term>
     <term name="no date">nedatováno</term>
     <term name="no date" form="short">b.r.</term>

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -307,39 +307,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-cy-GB.xml
+++ b/locales-cy-GB.xml
@@ -66,7 +66,6 @@
     <term name="in">yn</term>
     <term name="in press">yn y wasg</term>
     <term name="internet">rhyngrwyd</term>
-    <term name="interview">cyfweliad</term>
     <term name="letter">llythyr</term>
     <term name="no date">dim dyddiad</term>
     <term name="no date" form="short">d.d.</term>
@@ -104,7 +103,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">cyfweliad</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-cy-GB.xml
+++ b/locales-cy-GB.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-cy-GB.xml
+++ b/locales-cy-GB.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -75,7 +75,6 @@
     <term name="in">i</term>
     <term name="in press">i trykken</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">brev</term>
     <term name="no date">uden år</term>
     <term name="no date" form="short">u.å.</term>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -98,9 +98,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -143,8 +143,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -303,39 +303,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -84,7 +84,6 @@
     <term name="in">in</term>
     <term name="in press">im Druck</term>
     <term name="internet">Internet</term>
-    <term name="interview">Interview</term>
     <term name="letter">Brief</term>
     <term name="no date">ohne Datum</term>
     <term name="no date" form="short">o.&#160;J.</term>
@@ -122,7 +121,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">Interview</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -312,39 +312,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -107,9 +107,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -152,8 +152,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -306,39 +306,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -78,7 +78,6 @@
     <term name="in">in</term>
     <term name="in press">im Druck</term>
     <term name="internet">Internet</term>
-    <term name="interview">Interview</term>
     <term name="letter">Brief</term>
     <term name="no date">ohne Datum</term>
     <term name="no date" form="short">o.&#160;J.</term>
@@ -116,7 +115,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">Interview</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -101,9 +101,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -146,8 +146,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -104,9 +104,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -149,8 +149,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -309,39 +309,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -81,7 +81,6 @@
     <term name="in">in</term>
     <term name="in press">im Druck</term>
     <term name="internet">Internet</term>
-    <term name="interview">Interview</term>
     <term name="letter">Brief</term>
     <term name="no date">ohne Datum</term>
     <term name="no date" form="short">o.&#160;J.</term>
@@ -119,7 +118,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">Interview</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -302,39 +302,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -72,7 +72,6 @@
     <term name="in">στο</term>
     <term name="in press">υπό έκδοση</term>
     <term name="internet">διαδίκτυο</term>
-    <term name="interview">συνέντευξη</term>
     <term name="letter">επιστολή</term>
     <term name="no date">χωρίς χρονολογία</term>
     <term name="no date" form="short">χ.χ.</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">συνέντευξη</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -75,7 +75,6 @@
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">letter</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -98,9 +98,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -143,8 +143,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -104,9 +104,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -149,8 +149,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -81,7 +81,6 @@
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">letter</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>

--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -93,9 +93,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -138,8 +138,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -298,39 +298,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -70,7 +70,6 @@
     <term name="in">en</term>
     <term name="in press">en imprenta</term>
     <term name="internet">internet</term>
-    <term name="interview">entrevista</term>
     <term name="letter">carta</term>
     <term name="no date">sin fecha</term>
     <term name="no date" form="short">s.&#160;f.</term>
@@ -108,7 +107,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">entrevista</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -69,7 +69,6 @@
     <term name="in">en</term>
     <term name="in press">en imprenta</term>
     <term name="internet">internet</term>
-    <term name="interview">entrevista</term>
     <term name="letter">carta</term>
     <term name="no date">sin fecha</term>
     <term name="no date" form="short">s.&#160;f.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">entrevista</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -73,7 +73,6 @@
     <term name="in">en</term>
     <term name="in press">en imprenta</term>
     <term name="internet">internet</term>
-    <term name="interview">entrevista</term>
     <term name="letter">carta</term>
     <term name="no date">sin fecha</term>
     <term name="no date" form="short">s/f</term>
@@ -111,7 +110,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">entrevista</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -96,9 +96,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -141,8 +141,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -303,39 +303,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -69,7 +69,6 @@
     <term name="in"></term>
     <term name="in press">trükis</term>
     <term name="internet">internet</term>
-    <term name="interview">intervjuu</term>
     <term name="letter">kiri</term>
     <term name="no date">s.a.</term>
     <term name="no date" form="short">s.a.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervjuu</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -69,7 +69,6 @@
     <term name="in">in</term>
     <term name="in press">moldiztegian</term>
     <term name="internet">internet</term>
-    <term name="interview">elkarrizketa</term>
     <term name="letter">gutuna</term>
     <term name="no date">datarik gabe</term>
     <term name="no date" form="short">d. g.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">elkarrizketa</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -72,7 +72,6 @@
     <term name="in">در</term>
     <term name="in press">زیر چاپ</term>
     <term name="internet">اینترنت</term>
-    <term name="interview">مصاحبه</term>
     <term name="letter">نامه</term>
     <term name="no date">بدون تاریخ</term>
     <term name="no date" form="short">بدون تاریخ</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">مصاحبه</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -78,7 +78,6 @@
     <term name="in">teoksessa</term>
     <term name="in press">painossa</term>
     <term name="internet">internet</term>
-    <term name="interview">haastattelu</term>
     <term name="letter">kirje</term>
     <term name="no date">ei päivämäärää</term>
     <term name="no date" form="short">ei pvm.</term>
@@ -116,7 +115,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">haastattelu</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -306,39 +306,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -101,9 +101,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -146,8 +146,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -299,39 +299,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -69,7 +69,6 @@
     <term name="in">dans</term>
     <term name="in press">sous presse</term>
     <term name="internet">Internet</term>
-    <term name="interview">entretien</term>
     <term name="letter">lettre</term>
     <term name="no date">sans date</term>
     <term name="no date" form="short">s.&#160;d.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">entretien</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -72,7 +72,6 @@
     <term name="in">in</term>
     <term name="in press">sous presse</term>
     <term name="internet">Internet</term>
-    <term name="interview">entretien</term>
     <term name="letter">lettre</term>
     <term name="no date">sans date</term>
     <term name="no date" form="short">s.&#160;d.</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">image</term>
     <term name="hearing">audience</term>
-    <term name="interview">interview</term>
+    <term name="interview">entretien</term>
     <term name="legal_case">affaire</term>
     <term name="legislation">acte juridique</term>
     <term name="manuscript">manuscrit</term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -302,39 +302,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">
+    <term name="appendix" form="short">
       <single>append.</single>
       <multiple>append.</multiple>
     </term>
-    <term name="article-locator">
+    <term name="article-locator" form="short">
       <single>art.</single>
       <multiple>art.</multiple>
     </term>
-    <term name="elocation">
+    <term name="elocation" form="short">
       <single>emplact</single>
       <multiple>emplact</multiple>
     </term>
-    <term name="equation">
+    <term name="equation" form="short">
       <single>eq.</single>
       <multiple>eq.</multiple>
     </term>
-    <term name="rule">
+    <term name="rule" form="short">
       <single>règle</single>
       <multiple>règles</multiple>
     </term>
-    <term name="scene">
+    <term name="scene" form="short">
       <single>sc.</single>
       <multiple>sc.</multiple>
     </term>
-    <term name="table">
+    <term name="table" form="short">
       <single>tab.</single>
       <multiple>tab.</multiple>
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>
     </term>
-    <term name="title-locator">
+    <term name="title-locator" form="short">
       <single>tit.</single>
       <multiple>tit.</multiple>
     </term>

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">article de magazine</term>
     <term name="article-newspaper">article de presse</term>
     <term name="bill">projet de loi</term>
-    <term name="book">livre</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">émission</term>
-    <term name="chapter">chapitre de livre</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classique</term>
     <term name="collection">collection</term>
     <term name="dataset">jeu de données</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">art. de revue</term>
     <term name="article-magazine" form="short">art. de mag.</term>
     <term name="article-newspaper" form="short">art. de presse</term>
-    <term name="book" form="short">liv.</term>
-    <term name="chapter" form="short">chap. de liv.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -69,7 +69,6 @@
     <term name="in">בתוך</term>
     <term name="in press">בהדפסה</term>
     <term name="internet">אינטרנט</term>
-    <term name="interview">ראיון</term>
     <term name="letter">מכתב</term>
     <term name="no date">אין נתונים</term>
     <term name="no date" form="short">nd</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">ראיון</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -303,39 +303,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-hi-IN.xml
+++ b/locales-hi-IN.xml
@@ -93,9 +93,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -138,8 +138,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-hi-IN.xml
+++ b/locales-hi-IN.xml
@@ -313,39 +313,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-hi-IN.xml
+++ b/locales-hi-IN.xml
@@ -179,7 +179,7 @@
     <term name="long-ordinal-01">पहला</term>
     <term name="long-ordinal-01" gender-form="feminine">पहली</term>
     <term name="long-ordinal-02">दूसरा</term>
-    <term name="long-ordinal-01" gender-form="feminine">दूसरी</term>
+    <term name="long-ordinal-02" gender-form="feminine">दूसरी</term>
     <term name="long-ordinal-03">तीसरा</term>
     <term name="long-ordinal-03" gender-form="feminine">तीसरी</term>
     <term name="long-ordinal-04">चौथा</term>

--- a/locales-hi-IN.xml
+++ b/locales-hi-IN.xml
@@ -70,7 +70,6 @@
     <term name="in">में</term>
     <term name="in press">मुद्रण में</term>
     <term name="internet">इंटर्नेट</term>
-    <term name="interview">साक्षात्कार</term>
     <term name="letter">पत्र</term>
     <term name="no date">दिनांक अज्ञात</term>
     <term name="no date" form="short">n.d.</term>
@@ -108,7 +107,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">साक्षात्कार</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -69,7 +69,6 @@
     <term name="in">u</term>
     <term name="in press">u tisku</term>
     <term name="internet">internet</term>
-    <term name="interview">intervju</term>
     <term name="letter">pismo</term>
     <term name="no date">bez datuma</term>
     <term name="no date" form="short">bez dat.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervju</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -69,7 +69,6 @@
     <term name="in">in</term>
     <term name="in press">nyomtatás alatt</term>
     <term name="internet">internet</term>
-    <term name="interview">interjú</term>
     <term name="letter">levél</term>
     <term name="no date">évszám nélkül</term>
     <term name="no date" form="short">é. n.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">interjú</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -309,39 +309,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -75,7 +75,6 @@
     <term name="in">dalam</term>
     <term name="in press">dalam proses cetakan</term>
     <term name="internet">internet</term>
-    <term name="interview">wawancara</term>
     <term name="letter">surat</term>
     <term name="no date">tanpa tanggal</term>
     <term name="no date" form="short">t.t.</term>
@@ -113,7 +112,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">wawancara</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -98,9 +98,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -143,8 +143,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -72,7 +72,6 @@
     <term name="in">í</term>
     <term name="in press">í prentun</term>
     <term name="internet">rafrænt</term>
-    <term name="interview">viðtal</term>
     <term name="letter">bréf</term>
     <term name="no date">engin dagsetning</term>
     <term name="no date" form="short">e.d.</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">viðtal</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -96,9 +96,9 @@
     <term name="article-magazine">articolo di rivista generalista</term>
     <term name="article-newspaper">articolo di giornale</term>
     <term name="bill">proposta di legge</term>
-    <term name="book">libro</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">capitolo di libro</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classico</term>
     <term name="collection">collezione</term>
     <term name="dataset">dataset</term>
@@ -141,8 +141,8 @@
     <term name="article-journal" form="short">art. di riv.</term>
     <term name="article-magazine" form="short">art. di riv</term>
     <term name="article-newspaper" form="short">art. di g.</term>
-    <term name="book" form="short">l.</term>
-    <term name="chapter" form="short">c. di l.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">op. d'arte</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -323,39 +323,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>app.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>art.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eq.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>r.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>sc.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tab.</single>
       <multiple>tab.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -73,7 +73,6 @@
     <term name="in">in</term>
     <term name="in press">in stampa</term>
     <term name="internet">internet</term>
-    <term name="interview">intervista</term>
     <term name="letter">lettera</term>
     <term name="no date">sine data</term>
     <term name="no date" form="short">s.d.</term>

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -67,7 +67,6 @@
     <term name="et-al">et al.</term>
     <term name="forthcoming">futuro</term>
     <term name="from">da</term>
-    <term name="ibid">ibid.</term>
     <term name="ibid">ibidem</term>
     <term name="ibid" form="short">ibid.</term>
     <term name="in">in</term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -69,7 +69,6 @@
     <term name="in"></term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">手紙</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">日付なし</term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -303,39 +303,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -66,7 +66,6 @@
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">letter</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -66,7 +66,6 @@
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">편지</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">일자 없음</term>

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-la.xml
+++ b/locales-la.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-la.xml
+++ b/locales-la.xml
@@ -69,7 +69,6 @@
     <term name="in">in</term>
     <term name="in press">impressorio</term>
     <term name="internet">interrete</term>
-    <term name="interview">congressus</term>
     <term name="letter">epistula</term>
     <term name="no date">sine die</term>
     <term name="no date" form="short">s.d.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">congressus</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-la.xml
+++ b/locales-la.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -71,7 +71,6 @@
     <term name="in"></term>
     <term name="in press">priimta spaudai</term>
     <term name="internet">prieiga per internetą</term>
-    <term name="interview">interviu</term>
     <term name="letter">laiškas</term>
     <term name="no date">sine anno</term>
     <term name="no date" form="short">s.a.</term>
@@ -109,7 +108,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">interviu</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -94,9 +94,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -139,8 +139,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -316,39 +316,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -49,14 +49,12 @@
     <term name="video">video</term>
     <term name="working-paper">working paper</term>
     <term name="accessed">skatīts</term>
-    <term name="ad">m.ē.</term>
     <term name="and">un</term>
     <term name="and others">un citi</term>
     <term name="anonymous">anonīms</term>
     <term name="anonymous" form="short">anon.</term>
     <term name="at"></term>
     <term name="available at">pieejams</term>
-    <term name="bc">p.m.ē.</term>
     <term name="by"></term>
     <term name="circa">apmēram</term>
     <term name="circa" form="short">apm.</term>
@@ -155,8 +153,8 @@
     <term name="song" form="short">audio rec.</term>
 
     <!-- HISTORICAL ERA TERMS -->
-    <term name="ad">AD</term>
-    <term name="bc">BC</term>
+    <term name="ad">m.ē.</term>
+    <term name="bc">p.m.ē.</term>
     <term name="bce">BCE</term>
     <term name="ce">CE</term>
 

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -313,39 +313,39 @@
     </term>
     
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -73,7 +73,6 @@
     <term name="in">no</term>
     <term name="in press">presē</term>
     <term name="internet">internets</term>
-    <term name="interview">intervija</term>
     <term name="letter">vēstule</term>
     <term name="no date">bez datuma</term>
     <term name="no date" form="short">b.g.</term>
@@ -111,7 +110,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervija</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -96,9 +96,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -141,8 +141,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -66,7 +66,6 @@
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">захиа</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -294,39 +294,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -69,7 +69,6 @@
     <term name="in">i</term>
     <term name="in press">i trykk</term>
     <term name="internet">Internett</term>
-    <term name="interview">intervju</term>
     <term name="letter">brev</term>
     <term name="no date">ingen dato</term>
     <term name="no date" form="short">u.å.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervju</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -93,9 +93,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -138,8 +138,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -70,7 +70,6 @@
     <term name="in">in</term>
     <term name="in press">in druk</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">brief</term>
     <term name="no date">zonder datum</term>
     <term name="no date" form="short">z.d.</term>

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -316,39 +316,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -69,7 +69,6 @@
     <term name="in">i</term>
     <term name="in press">i trykk</term>
     <term name="internet">Internett</term>
-    <term name="interview">intervju</term>
     <term name="letter">brev</term>
     <term name="no date">ingen dato</term>
     <term name="no date" form="short">u.å.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervju</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -98,9 +98,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -143,8 +143,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -75,7 +75,6 @@
     <term name="in">w</term>
     <term name="in press">w druku</term>
     <term name="internet">internet</term>
-    <term name="interview">wywiad</term>
     <term name="letter">list</term>
     <term name="no date">brak daty</term>
     <term name="no date" form="short">b.d.</term>
@@ -113,7 +112,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">wywiad</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -303,39 +303,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -312,39 +312,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -72,7 +72,6 @@
     <term name="in">em</term>
     <term name="in press">no prelo</term>
     <term name="internet">internet</term>
-    <term name="interview">entrevista</term>
     <term name="letter">carta</term>
     <term name="no date">sem data</term>
     <term name="no date" form="short">[s.d.]</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">entrevista</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -69,7 +69,6 @@
     <term name="in">em</term>
     <term name="in press">no prelo</term>
     <term name="internet">internet</term>
-    <term name="interview">entrevista</term>
     <term name="letter">carta</term>
     <term name="no date">sem data</term>
     <term name="no date" form="short">sem data</term>

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">artigo de revista</term>
     <term name="article-newspaper">artigo de jornal</term>
     <term name="bill">bill</term>
-    <term name="book">livro</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">transmissão</term>
-    <term name="chapter">capítulo de livro</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">clássico</term>
     <term name="collection">coleção</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">gráf.</term>

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -308,39 +308,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tít.</single>
       <multiple>títs.</multiple>
     </term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -299,39 +299,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -93,9 +93,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -138,8 +138,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -70,7 +70,6 @@
     <term name="in">în</term>
     <term name="in press">sub tipar</term>
     <term name="internet">internet</term>
-    <term name="interview">interviu</term>
     <term name="letter">scrisoare</term>
     <term name="no date">fără dată</term>
     <term name="no date" form="short">f.a.</term>
@@ -108,7 +107,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">interviu</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -321,39 +321,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -96,9 +96,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -141,8 +141,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -71,7 +71,6 @@
     <term name="in">в</term>
     <term name="in press">в печати</term>
     <term name="internet">Интернет</term>
-    <term name="interview">интервью</term>
     <term name="letter">письмо</term>
     <term name="no date">без даты</term>
     <term name="no date" form="short">б. д.</term>
@@ -111,7 +110,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">интервью</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -306,39 +306,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -72,7 +72,6 @@
     <term name="in">v</term>
     <term name="in press">v tlači</term>
     <term name="internet">internet</term>
-    <term name="interview">osobná komunikácia</term>
     <term name="letter">list</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">osobná komunikácia</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -95,9 +95,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -140,8 +140,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -72,7 +72,6 @@
     <term name="in">v</term>
     <term name="in press">v tisku</term>
     <term name="internet">internet</term>
-    <term name="interview">intervju</term>
     <term name="letter">pismo</term>
     <term name="no date">brez datuma</term>
     <term name="no date" form="short">b. d.</term>
@@ -110,7 +109,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervju</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -300,39 +300,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -66,7 +66,6 @@
     <term name="in">у</term>
     <term name="in press">у штампи</term>
     <term name="internet">Интернет</term>
-    <term name="interview">интервју</term>
     <term name="letter">писмо</term>
     <term name="no date">no date</term>
     <term name="no date" form="short">без датума</term>
@@ -104,7 +103,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">интервју</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -78,7 +78,6 @@
     <term name="in">i</term>
     <term name="in press">i tryck</term>
     <term name="internet">internet</term>
-    <term name="interview">intervju</term>
     <term name="letter">brev</term>
     <term name="no date">utan årtal</term>
     <term name="no date" form="short">u.å.</term>
@@ -116,7 +115,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">intervju</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -310,39 +310,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -101,9 +101,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -146,8 +146,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -69,7 +69,6 @@
     <term name="in">ใน</term>
     <term name="in press">กำลังรอตีพิมพ์</term>
     <term name="internet">อินเทอร์เน็ต</term>
-    <term name="interview">การสัมภาษณ์</term>
     <term name="letter">จดหมาย</term>
     <term name="no date">ไม่ปรากฏปีที่พิมพ์</term>
     <term name="no date" form="short">ม.ป.ป.</term>
@@ -107,7 +106,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">การสัมภาษณ์</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -297,39 +297,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -102,9 +102,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -147,8 +147,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -307,39 +307,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -79,7 +79,6 @@
     <term name="in">içinde</term>
     <term name="in press">basımda</term>
     <term name="internet">internet</term>
-    <term name="interview">mülakat</term>
     <term name="letter">mektup</term>
     <term name="no date">tarih yok</term>
     <term name="no date" form="short">t.y.</term>
@@ -117,7 +116,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">mülakat</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -63,7 +63,6 @@
     <term name="in">в</term>
     <term name="in press">у пресі</term>
     <term name="internet">інтернет</term>
-    <term name="interview">інтервю</term>
     <term name="letter">лист</term>
     <term name="no date">без дати</term>
     <term name="no date" form="short">б. д.</term>
@@ -95,7 +94,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">інтервю</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -276,39 +276,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -80,9 +80,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -125,8 +125,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -92,9 +92,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -137,8 +137,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -69,7 +69,6 @@
     <term name="in">trong</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
-    <term name="interview">interview</term>
     <term name="letter">thư</term>
     <term name="no date">không ngày</term>
     <term name="no date" form="short">không ngày</term>

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -303,39 +303,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -72,7 +72,6 @@
     <term name="in">收入</term>
     <term name="in press">送印中</term>
     <term name="internet">网际网络</term>
-    <term name="interview">访谈</term>
     <term name="letter">信函</term>
     <term name="no date">日期不详</term>
     <term name="no date" form="short">不详</term>
@@ -104,7 +103,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">访谈</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -89,9 +89,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -134,8 +134,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -458,7 +458,7 @@
     <term name="illustrator" form="verb-short">绘</term>
     <term name="translator" form="verb-short">译</term>
     <term name="editortranslator" form="verb-short">编译</term>
-    <term name="reviewed-author" form="verb">校</term>
+    <term name="reviewed-author" form="verb-short">校</term>
 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">一月</term>

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -243,39 +243,39 @@
     <term name="volume">卷</term>
     
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -237,39 +237,39 @@
     <term name="volume">卷</term>
     
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix">			 
+    <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator" form="short">			 
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation" form="short">			 
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation" form="short">			 
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule" form="short">			 
       <single>r.</single>
       <multiple>rr.</multiple>						 
     </term>
-    <term name="scene">			 
+    <term name="scene" form="short">			 
       <single>sc.</single>
       <multiple>scs.</multiple>						 
     </term>
-    <term name="table">			 
+    <term name="table" form="short">			 
       <single>tbl.</single>
       <multiple>tbls.</multiple>						 
     </term>
-    <term name="timestamp"> <!-- generally blank -->
+    <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator" form="short">			 
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -66,7 +66,6 @@
     <term name="in">收入</term>
     <term name="in press">印行中</term>
     <term name="internet">互聯網</term>
-    <term name="interview">訪談</term>
     <term name="letter">信函</term>
     <term name="no date">日期不詳</term>
     <term name="no date" form="short">不詳</term>
@@ -98,7 +97,7 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
     <term name="hearing">hearing</term>
-    <term name="interview">interview</term>
+    <term name="interview">訪談</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
     <term name="manuscript">manuscript</term>

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -83,9 +83,9 @@
     <term name="article-magazine">magazine article</term>
     <term name="article-newspaper">newspaper article</term>
     <term name="bill">bill</term>
-    <term name="book">book</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
-    <term name="chapter">book chapter</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">classic</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
@@ -128,8 +128,8 @@
     <term name="article-journal" form="short">journal art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">bk. chap.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>


### PR DESCRIPTION
The duplicate term issue was discussed in #268 and this is a proposed PR.

I've also written a Python3 script to search for duplicate terms in each locale file and found several ones. I then resolved them in 18f3eb5 (thanks to Google Translate).

```python
import glob
import xml.etree.ElementTree as ET

ns = {'cs': 'http://purl.org/net/xbiblio/csl'}


def check_duplicates(path):
    tree = ET.parse(path)

    terms_dict = dict()
    duplicates = []

    for term in tree.findall('.//cs:term', ns):
        term_key = ' '.join([
            f'{key}="{value}"'
            for key, value in sorted(term.attrib.items(),
                                     key=lambda x: "0"
                                     if x[0] == 'name' else x[0])
        ])
        if term_key in terms_dict:
            duplicates.append(term_key)
        terms_dict[term_key] = term.text

    if duplicates:
        print(path)
        for term_key in duplicates:
            print('    ' + term_key)


for path in sorted(glob.glob('locales-*.xml')):
    check_duplicates(path)
```