### PR TITLE
Fix date format for Basque

### DIFF
--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -12,7 +12,7 @@
   <date form="text">
     <date-part name="year" suffix="(e)ko "/>
     <date-part name="month" suffix="aren "/>
-    <date-part name="day" suffix="a"/>
+    <date-part name="day" suffix="(e)an"/>
   </date>
   <date form="numeric">
     <date-part name="year" suffix="/"/>
@@ -65,7 +65,7 @@
     <term name="edition" form="short">arg.</term>
     <term name="et-al">et al.</term>
     <term name="forthcoming">bidean</term>
-    <term name="from">-(e)tik</term>
+    <term name="from">hemendik: </term>
     <term name="ibid">ibíd.</term>
     <term name="in">in</term>
     <term name="in press">moldiztegian</term>
@@ -566,18 +566,18 @@
     <term name="editortranslator" form="verb-short">-(e)k arg. eta itzul.</term>
 
     <!-- LONG MONTH FORMS -->
-    <term name="month-01">urtarrilak</term>
-    <term name="month-02">otsailak</term>
-    <term name="month-03">martxoak</term>
-    <term name="month-04">apirilak</term>
-    <term name="month-05">maiatzak</term>
-    <term name="month-06">ekainak</term>
-    <term name="month-07">uztailak</term>
-    <term name="month-08">abuztuak</term>
-    <term name="month-09">irailak</term>
-    <term name="month-10">urriak</term>
-    <term name="month-11">azaroak</term>
-    <term name="month-12">abenduak</term>
+    <term name="month-01">urtarrila</term>
+    <term name="month-02">otsaila</term>
+    <term name="month-03">martxoa</term>
+    <term name="month-04">apirila</term>
+    <term name="month-05">maiatza</term>
+    <term name="month-06">ekaina</term>
+    <term name="month-07">uztaila</term>
+    <term name="month-08">abuztua</term>
+    <term name="month-09">iraila</term>
+    <term name="month-10">urria</term>
+    <term name="month-11">azaroa</term>
+    <term name="month-12">abendua</term>
 
     <!-- SHORT MONTH FORMS -->
     <term name="month-01" form="short">urt.</term>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -3,6 +3,8 @@
   <info>
     <translator>
       <name>Amaraun</name>
+    </translator>
+    <translator>
       <name>Miren BZ</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -3,6 +3,7 @@
   <info>
     <translator>
       <name>Amaraun</name>
+      <name>Miren BZ</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
@@ -84,7 +85,7 @@
     </term>
     <term name="retrieved">berreskuratua</term>
     <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="version">bertsioa</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">preprint</term>
@@ -170,7 +171,7 @@
     <term name="ordinal">.</term>
 
     <!-- LONG ORDINALS -->
-    <term name="long-ordinal-01">lehengo</term>
+    <term name="long-ordinal-01">lehenengo</term>
     <term name="long-ordinal-02">bigarren</term>
     <term name="long-ordinal-03">hirugarren</term>
     <term name="long-ordinal-04">laugarren</term>
@@ -291,8 +292,8 @@
       <multiple>bertsoak</multiple>
     </term>
     <term name="volume">
-      <single>luburikia</single>
-      <multiple>luburukiak</multiple>
+      <single>liburukia</single>
+      <multiple>liburukiak</multiple>
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
@@ -581,7 +582,7 @@
     <!-- SHORT MONTH FORMS -->
     <term name="month-01" form="short">urt.</term>
     <term name="month-02" form="short">ots.</term>
-    <term name="month-03" form="short">martx.</term>
+    <term name="month-03" form="short">mar.</term>
     <term name="month-04" form="short">apr.</term>
     <term name="month-05" form="short">mai.</term>
     <term name="month-06" form="short">eka.</term>


### PR DESCRIPTION
### Description

Dates are not rendering in correct Basque, which requires different formats for the `date-bib` and `access` macros (retrieved date). I've tried to modify date elements so they can both be generated correctly. This will require some modifications in the `.csl` file as well, which I'm working on: https://github.com/citation-style-language/styles/pull/6370.

I have also corrected some typos. 

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
