### PR TITLE
Update nn and nb (Norwegian)

### DIFF
--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -203,7 +203,7 @@
     </term>
     <term name="scene">			 
       <single>scene</single>
-      <multiple>scener</multiple>						 
+      <multiple>scene</multiple>						 
     </term>
     <term name="table">			 
       <single>tabell</single>
@@ -419,7 +419,7 @@
     <!-- SHORT ROLE FORMS -->
     <term name="executive-producer" form="short">
       <single>utøv. prod.</single>
-      <multiple>utøv. prodr.</multiple>
+      <multiple>utøv. prod.</multiple>
     </term>
     <term name="producer" form="short">
       <single>prod.</single>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -19,33 +19,33 @@
     <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
   </date>
   <terms>
-    <term name="advance-online-publication">advance online publication</term>
+    <term name="advance-online-publication">forhåndspublisert på nett</term>
     <term name="album">album</term>
-    <term name="audio-recording">audio recording</term>
+    <term name="audio-recording">lydopptak</term>
     <term name="film">film</term>
-    <term name="henceforth">henceforth</term>
+    <term name="henceforth">heretter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="no-place">no place</term>
-    <term name="no-place" form="short">n.p.</term>
-    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
-    <term name="no-publisher" form="short">n.p.</term>
-    <term name="on">on</term>
+    <term name="no-place">intet sted</term>
+    <term name="no-place" form="short">i.s.</term>
+    <term name="no-publisher">mangler utgiver</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">s.n.</term>
+    <term name="on">om</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="original-work-published">original work published</term>
+    <term name="original-work-published">opprinnelig verk utgitt</term>
     <term name="personal-communication">personlig kommunikasjon</term>
-    <term name="podcast">podcast</term>
-    <term name="podcast-episode">podcast episode</term>
-    <term name="preprint">preprint</term>
-    <term name="radio-broadcast">radio broadcast</term>
-    <term name="radio-series">radio series</term>
-    <term name="radio-series-episode">radio series episode</term>
-    <term name="special-issue">special issue</term>
-    <term name="special-section">special section</term>
-    <term name="television-broadcast">television broadcast</term>
-    <term name="television-series">television series</term>
-    <term name="television-series-episode">television series episode</term>
+    <term name="podcast">podkast</term>
+    <term name="podcast-episode">podkastepisode</term>
+    <term name="preprint">innsendt manuskript</term>
+    <term name="radio-broadcast">radiosending</term>
+    <term name="radio-series">radioserie</term>
+    <term name="radio-series-episode">radioserie-episode</term>
+    <term name="special-issue">spesialutgave</term>
+    <term name="special-section">spesialseksjon</term>
+    <term name="television-broadcast">fjernsynssending</term>
+    <term name="television-series">fjernsynsserie</term>
+    <term name="television-series-episode">fjernsynsserie-episode</term>
     <term name="video">video</term>
-    <term name="working-paper">working paper</term>
+    <term name="working-paper">notat</term>
     <term name="accessed">åpnet</term>
     <term name="and">og</term>
     <term name="and others">med flere</term>
@@ -70,7 +70,7 @@
     <term name="in press">i trykk</term>
     <term name="internet">Internett</term>
     <term name="letter">brev</term>
-    <term name="no date">ingen dato</term>
+    <term name="no date">uten dato</term>
     <term name="no date" form="short">u.å.</term>
     <term name="online">online</term>
     <term name="presented at">presentert på</term>
@@ -87,68 +87,68 @@
     <term name="version">versjon</term>
 
     <!-- LONG ITEM TYPE FORMS -->
-    <term name="article">preprint</term>
-    <term name="article-journal">journal article</term>
-    <term name="article-magazine">magazine article</term>
-    <term name="article-newspaper">newspaper article</term>
-    <term name="bill">bill</term>
+    <term name="article">innsendt manuskript</term>
+    <term name="article-journal">tidsskriftartikkel</term>
+    <term name="article-magazine">magasinartikkel</term>
+    <term name="article-newspaper">avisartikkel</term>
+    <term name="bill">proposisjon</term>
     <!-- book is in the list of locator terms -->
-    <term name="broadcast">broadcast</term>
+    <term name="broadcast">kringkasting</term>
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">classic</term>
-    <term name="collection">collection</term>
-    <term name="dataset">dataset</term>
-    <term name="document">document</term>
-    <term name="entry">entry</term>
-    <term name="entry-dictionary">dictionary entry</term>
-    <term name="entry-encyclopedia">encyclopedia entry</term>
-    <term name="event">event</term>
+    <term name="classic">klassiker</term>
+    <term name="collection">samling</term>
+    <term name="dataset">datasett</term>
+    <term name="document">dokument</term>
+    <term name="entry">oppføring</term>
+    <term name="entry-dictionary">ordbokoppføring</term>
+    <term name="entry-encyclopedia">leksikonoppføring</term>
+    <term name="event">begivenhet</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic">graphic</term>
-    <term name="hearing">hearing</term>
+    <term name="graphic">grafikk</term>
+    <term name="hearing">høring</term>
     <term name="interview">intervju</term>
-    <term name="legal_case">legal case</term>
-    <term name="legislation">legislation</term>
-    <term name="manuscript">manuscript</term>
-    <term name="map">map</term>
-    <term name="motion_picture">video recording</term>
-    <term name="musical_score">musical score</term>
-    <term name="pamphlet">pamphlet</term>
-    <term name="paper-conference">conference paper</term>
+    <term name="legal_case">rettssak</term>
+    <term name="legislation">lovgiving</term>
+    <term name="manuscript">manuskript</term>
+    <term name="map">kart</term>
+    <term name="motion_picture">videoopptak</term>
+    <term name="musical_score">partitur</term>
+    <term name="pamphlet">pamflett</term>
+    <term name="paper-conference">konferanseartikkel</term>
     <term name="patent">patent</term>
-    <term name="performance">performance</term>
-    <term name="periodical">periodical</term>
+    <term name="performance">fremføring</term>
+    <term name="periodical">tidsskrift</term>
     <term name="personal_communication">personlig kommunikasjon</term>
-    <term name="post">post</term>
-    <term name="post-weblog">blog post</term>
-    <term name="regulation">regulation</term>
-    <term name="report">report</term>
-    <term name="review">review</term>
-    <term name="review-book">book review</term>
-    <term name="software">software</term>
-    <term name="song">audio recording</term>
-    <term name="speech">presentation</term>
+    <term name="post">innlegg</term>
+    <term name="post-weblog">blogginnlegg</term>
+    <term name="regulation">forskrift</term>
+    <term name="report">rapport</term>
+    <term name="review">anmeldelse</term>
+    <term name="review-book">bokanmeldelse</term>
+    <term name="software">programvare</term>
+    <term name="song">lydopptak</term>
+    <term name="speech">presentasjon</term>
     <term name="standard">standard</term>
-    <term name="thesis">thesis</term>
-    <term name="treaty">treaty</term>
-    <term name="webpage">webpage</term>
+    <term name="thesis">avhandling</term>
+    <term name="treaty">traktat</term>
+    <term name="webpage">nettside</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-journal" form="short">tidsskriftart.</term>
     <term name="article-magazine" form="short">mag. art.</term>
-    <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="article-newspaper" form="short">avisart.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="document" form="short">doc.</term>
+    <term name="document" form="short">dok.</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graph.</term>
+    <term name="graphic" form="short">graf.</term>
     <term name="interview" form="short">interv.</term>
-    <term name="manuscript" form="short">MS</term>
-    <term name="motion_picture" form="short">video rec.</term>
-    <term name="report" form="short">rep.</term>
-    <term name="review" form="short">rev.</term>
-    <term name="review-book" form="short">bk. rev.</term>
-    <term name="song" form="short">audio rec.</term>
+    <term name="manuscript" form="short">ms.</term>
+    <term name="motion_picture" form="short">videoopp.</term>
+    <term name="report" form="short">rap.</term>
+    <term name="review" form="short">anmeld.</term>
+    <term name="review-book" form="short">bokanmeld.</term>
+    <term name="song" form="short">lydopp.</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">e.Kr.</term>
@@ -183,48 +183,48 @@
 
     <!-- LONG LOCATOR FORMS -->
     <term name="act">			 
-      <single>act</single>
-      <multiple>acts</multiple>						 
+      <single>akt</single>
+      <multiple>akter</multiple>						 
     </term>
     <term name="appendix">			 
-      <single>appendix</single>
-      <multiple>appendices</multiple>						 
+      <single>appendiks</single>
+      <multiple>appendikser</multiple>						 
     </term>
     <term name="article-locator">			 
-      <single>article</single>
-      <multiple>articles</multiple>						 
+      <single>artikkel</single>
+      <multiple>artikler</multiple>						 
     </term>
     <term name="canon">			 
-      <single>canon</single>
-      <multiple>canons</multiple>						 
+      <single>kanon</single>
+      <multiple>kanoner</multiple>						 
     </term>
     <term name="elocation">			 
-      <single>location</single>
-      <multiple>locations</multiple>						 
+      <single>sted</single>
+      <multiple>steder</multiple>						 
     </term>
     <term name="equation">			 
-      <single>equation</single>
-      <multiple>equations</multiple>						 
+      <single>ligning</single>
+      <multiple>ligninger</multiple>						 
     </term>
     <term name="rule">			 
-      <single>rule</single>
-      <multiple>rules</multiple>						 
+      <single>regel</single>
+      <multiple>regler</multiple>						 
     </term>
     <term name="scene">			 
       <single>scene</single>
-      <multiple>scenes</multiple>						 
+      <multiple>scener</multiple>						 
     </term>
     <term name="table">			 
-      <single>table</single>
-      <multiple>tables</multiple>						 
+      <single>tabell</single>
+      <multiple>tabeller</multiple>						 
     </term>
     <term name="timestamp"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
     <term name="title-locator">			 
-      <single>title</single>
-      <multiple>titles</multiple>						 
+      <single>tittel</single>
+      <multiple>titler</multiple>						 
     </term>
     <term name="book">
       <single>bok</single>
@@ -298,19 +298,19 @@
     <!-- SHORT LOCATOR FORMS -->
     <term name="appendix" form="short">			 
       <single>app.</single>
-      <multiple>apps.</multiple>						 
+      <multiple>appr.</multiple>						 
     </term>
     <term name="article-locator" form="short">			 
       <single>art.</single>
-      <multiple>arts.</multiple>
+      <multiple>artr.</multiple>
     </term>
     <term name="elocation" form="short">			 
-      <single>loc.</single>
-      <multiple>locs.</multiple>
+      <single>sted</single>
+      <multiple>steder</multiple>
     </term>
     <term name="equation" form="short">			 
-      <single>eq.</single>
-      <multiple>eqs.</multiple>
+      <single>likn.</single>
+      <multiple>liknr.</multiple>
     </term>
     <term name="rule" form="short">			 
       <single>r.</single>
@@ -318,11 +318,11 @@
     </term>
     <term name="scene" form="short">			 
       <single>sc.</single>
-      <multiple>scs.</multiple>						 
+      <multiple>scr.</multiple>						 
     </term>
     <term name="table" form="short">			 
       <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
+      <multiple>tblr.</multiple>						 
     </term>
     <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
@@ -330,7 +330,7 @@
     </term>
     <term name="title-locator" form="short">			 
       <single>tit.</single>
-      <multiple>tits.</multiple>
+      <multiple>titr.</multiple>
     </term>
     <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
@@ -377,56 +377,56 @@
 
     <!-- LONG ROLE FORMS -->
     <term name="chair">
-      <single>chair</single>
-      <multiple>chairs</multiple>
+      <single>leder</single>
+      <multiple>ledere</multiple>
     </term>
     <term name="compiler">
-      <single>compiler</single>
-      <multiple>compilers</multiple>
+      <single>samler</single>
+      <multiple>samlere</multiple>
     </term>
     <term name="contributor">
-      <single>contributor</single>
-      <multiple>contributors</multiple>
+      <single>bidragsyter</single>
+      <multiple>bidragsytere</multiple>
     </term>
     <term name="curator">
-      <single>curator</single>
-      <multiple>curators</multiple>
+      <single>kurator</single>
+      <multiple>kuratorer</multiple>
     </term>
     <term name="executive-producer">
-      <single>executive producer</single>
-      <multiple>executive producers</multiple>
+      <single>utøvende produsent</single>
+      <multiple>utøvende produsenter</multiple>
     </term>
     <term name="guest">
-      <single>guest</single>
-      <multiple>guests</multiple>
+      <single>gjest</single>
+      <multiple>gjester</multiple>
     </term>
     <term name="host">
-      <single>host</single>
-      <multiple>hosts</multiple>
+      <single>vert</single>
+      <multiple>verter</multiple>
     </term>
     <term name="narrator">
-      <single>narrator</single>
-      <multiple>narrators</multiple>
+      <single>forteller</single>
+      <multiple>fortellere</multiple>
     </term>
     <term name="organizer">
-      <single>organizer</single>
-      <multiple>organizers</multiple>
+      <single>organisator</single>
+      <multiple>organisatorer</multiple>
     </term>
     <term name="performer">
-      <single>performer</single>
-      <multiple>performers</multiple>
+      <single>utøver</single>
+      <multiple>utøvere</multiple>
     </term>
     <term name="producer">
-      <single>producer</single>
-      <multiple>producers</multiple>
+      <single>produsent</single>
+      <multiple>produsenter</multiple>
     </term>
     <term name="script-writer">
-      <single>writer</single>
-      <multiple>writers</multiple>
+      <single>manusforfatter</single>
+      <multiple>manusforfattere</multiple>
     </term>
     <term name="series-creator">
-      <single>series creator</single>
-      <multiple>series creators</multiple>
+      <single>serieskaper</single>
+      <multiple>serieskapere</multiple>
     </term>
     <term name="director">
       <single>regissør</single>
@@ -455,44 +455,44 @@
 
     <!-- SHORT ROLE FORMS -->
     <term name="compiler" form="short">
-      <single>comp.</single>
-      <multiple>comps.</multiple>
+      <single>saml.</single>
+      <multiple>samlr.</multiple>
     </term>
     <term name="contributor" form="short">
-      <single>contrib.</single>
-      <multiple>contribs.</multiple>
+      <single>bidrags.</single>
+      <multiple>bidragsr.</multiple>
     </term>
     <term name="curator" form="short">
-      <single>cur.</single>
-      <multiple>curs.</multiple>
+      <single>kur.</single>
+      <multiple>kurr.</multiple>
     </term>
     <term name="executive-producer" form="short">
-      <single>exec. prod.</single>
-      <multiple>exec. prods.</multiple>
+      <single>utøv. prod.</single>
+      <multiple>utøv. prodr.</multiple>
     </term>
     <term name="narrator" form="short">
-      <single>narr.</single>
-      <multiple>narrs.</multiple>
+      <single>fortel.</single>
+      <multiple>fortelr.</multiple>
     </term>
     <term name="organizer" form="short">
       <single>org.</single>
-      <multiple>orgs.</multiple>
+      <multiple>orgr.</multiple>
     </term>
     <term name="performer" form="short">
-      <single>perf.</single>
-      <multiple>perfs.</multiple>
+      <single>utøv.</single>
+      <multiple>utøvr.</multiple>
     </term>
     <term name="producer" form="short">
       <single>prod.</single>
-      <multiple>prods.</multiple>
+      <multiple>prodr.</multiple>
     </term>
     <term name="script-writer" form="short">
-      <single>writ.</single>
-      <multiple>writs.</multiple>
+      <single>forf.</single>
+      <multiple>forfr.</multiple>
     </term>
     <term name="series-creator" form="short">
-      <single>cre.</single>
-      <multiple>cres.</multiple>
+      <single>skap.</single>
+      <multiple>skapr.</multiple>
     </term>
     <term name="director" form="short">
       <single>regi</single>
@@ -508,7 +508,7 @@
     </term>
     <term name="illustrator" form="short">
       <single>ill.</single>
-      <multiple>ills.</multiple>
+      <multiple>illr.</multiple>
     </term>
     <term name="translator" form="short">
       <single>overs.</single>
@@ -520,19 +520,19 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="chair" form="verb">chaired by</term>
-    <term name="compiler" form="verb">compiled by</term>
-    <term name="contributor" form="verb">with</term>
-    <term name="curator" form="verb">curated by</term>
-    <term name="executive-producer" form="verb">executive produced by</term>
-    <term name="guest" form="verb">with guest</term>
-    <term name="host" form="verb">hosted by</term>
-    <term name="narrator" form="verb">narrated by</term>
-    <term name="organizer" form="verb">organized by</term>
-    <term name="performer" form="verb">performed by</term>
-    <term name="producer" form="verb">produced by</term>
-    <term name="script-writer" form="verb">written by</term>
-    <term name="series-creator" form="verb">created by</term>
+    <term name="chair" form="verb">leda av</term>
+    <term name="compiler" form="verb">samla av</term>
+    <term name="contributor" form="verb">med</term>
+    <term name="curator" form="verb">kuratert av</term>
+    <term name="executive-producer" form="verb">utøvende produsert av</term>
+    <term name="guest" form="verb">med gjest</term>
+    <term name="host" form="verb">vertskap av</term>
+    <term name="narrator" form="verb">fortalt av</term>
+    <term name="organizer" form="verb">organisert av</term>
+    <term name="performer" form="verb">fremført av</term>
+    <term name="producer" form="verb">produsert av</term>
+    <term name="script-writer" form="verb">forfatta av</term>
+    <term name="series-creator" form="verb">skapt av</term>
     <term name="container-author" form="verb">av</term>
     <term name="director" form="verb">regissert av</term>
     <term name="editor" form="verb">redigert av</term>
@@ -545,18 +545,18 @@
     <term name="editortranslator" form="verb">redigert &amp; oversatt av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="compiler" form="verb-short">comp. by</term>
-    <term name="contributor" form="verb-short">w.</term>
-    <term name="curator" form="verb-short">cur. by</term>
-    <term name="executive-producer" form="verb-short">exec. prod. by</term>
-    <term name="guest" form="verb-short">w. guest</term>
-    <term name="host" form="verb-short">hosted by</term>
-    <term name="narrator" form="verb-short">narr. by</term>
-    <term name="organizer" form="verb-short">org. by</term>
-    <term name="performer" form="verb-short">perf. by</term>
-    <term name="producer" form="verb-short">prod. by</term>
-    <term name="script-writer" form="verb-short">writ. by</term>
-    <term name="series-creator" form="verb-short">cre. by</term>
+    <term name="compiler" form="verb-short">saml. av</term>
+    <term name="contributor" form="verb-short">m.</term>
+    <term name="curator" form="verb-short">kur. av</term>
+    <term name="executive-producer" form="verb-short">utøv. prod. av</term>
+    <term name="guest" form="verb-short">m. gjest</term>
+    <term name="host" form="verb-short">vertskap av</term>
+    <term name="narrator" form="verb-short">fort. av</term>
+    <term name="organizer" form="verb-short">org. av</term>
+    <term name="performer" form="verb-short">fremf. av</term>
+    <term name="producer" form="verb-short">prod. av</term>
+    <term name="script-writer" form="verb-short">forf. av</term>
+    <term name="series-creator" form="verb-short">skapt av</term>
     <term name="director" form="verb-short">regi</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -25,8 +25,7 @@
     <term name="film">film</term>
     <term name="henceforth">heretter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="no-place">intet sted</term>
-    <term name="no-place" form="short">i.s.</term>
+    <term name="no-place">mangler sted</term>
     <term name="no-publisher">mangler utgiver</term> <!-- sine nomine -->
     <term name="no-publisher" form="short">s.n.</term>
     <term name="on">om</term>
@@ -59,7 +58,7 @@
     <term name="cited">sitert</term>
     <term name="edition">
       <single>utgave</single>
-      <multiple>utgaver</multiple>
+      <multiple>utgave</multiple>
     </term>
     <term name="edition" form="short">utg.</term>
     <term name="et-al">mfl.</term>
@@ -76,11 +75,11 @@
     <term name="presented at">presentert på</term>
     <term name="reference">
       <single>referanse</single>
-      <multiple>referanser</multiple>
+      <multiple>referanse</multiple>
     </term>
     <term name="reference" form="short">
       <single>ref.</single>
-      <multiple>refr.</multiple>
+      <multiple>ref.</multiple>
     </term>
     <term name="retrieved">hentet</term>
     <term name="scale">målestokk</term>
@@ -135,20 +134,12 @@
 
     <!-- SHORT ITEM TYPE FORMS -->
     <term name="article-journal" form="short">tidsskriftart.</term>
-    <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">avisart.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">dok.</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graf.</term>
-    <term name="interview" form="short">interv.</term>
     <term name="manuscript" form="short">ms.</term>
-    <term name="motion_picture" form="short">videoopp.</term>
-    <term name="report" form="short">rap.</term>
-    <term name="review" form="short">anmeld.</term>
-    <term name="review-book" form="short">bokanmeld.</term>
-    <term name="song" form="short">lydopp.</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">e.Kr.</term>
@@ -184,31 +175,31 @@
     <!-- LONG LOCATOR FORMS -->
     <term name="act">			 
       <single>akt</single>
-      <multiple>akter</multiple>						 
+      <multiple>akt</multiple>						 
     </term>
     <term name="appendix">			 
       <single>appendiks</single>
-      <multiple>appendikser</multiple>						 
+      <multiple>appendiks</multiple>						 
     </term>
     <term name="article-locator">			 
       <single>artikkel</single>
-      <multiple>artikler</multiple>						 
+      <multiple>artikkel</multiple>						 
     </term>
     <term name="canon">			 
       <single>kanon</single>
-      <multiple>kanoner</multiple>						 
+      <multiple>kanon</multiple>						 
     </term>
     <term name="elocation">			 
       <single>sted</single>
-      <multiple>steder</multiple>						 
+      <multiple>sted</multiple>						 
     </term>
     <term name="equation">			 
       <single>ligning</single>
-      <multiple>ligninger</multiple>						 
+      <multiple>ligning</multiple>						 
     </term>
     <term name="rule">			 
       <single>regel</single>
-      <multiple>regler</multiple>						 
+      <multiple>regel</multiple>						 
     </term>
     <term name="scene">			 
       <single>scene</single>
@@ -216,7 +207,7 @@
     </term>
     <term name="table">			 
       <single>tabell</single>
-      <multiple>tabeller</multiple>						 
+      <multiple>tabell</multiple>						 
     </term>
     <term name="timestamp"> <!-- generally blank -->
       <single></single>
@@ -224,39 +215,39 @@
     </term>
     <term name="title-locator">			 
       <single>tittel</single>
-      <multiple>titler</multiple>						 
+      <multiple>tittel</multiple>						 
     </term>
     <term name="book">
       <single>bok</single>
-      <multiple>bøker</multiple>
+      <multiple>bok</multiple>
     </term>
     <term name="chapter">
       <single>kapittel</single>
-      <multiple>kapitler</multiple>
+      <multiple>kapittel</multiple>
     </term>
     <term name="column">
       <single>kolonne</single>
-      <multiple>kolonner</multiple>
+      <multiple>kolonne</multiple>
     </term>
     <term name="figure">
       <single>figur</single>
-      <multiple>figurer</multiple>
+      <multiple>figur</multiple>
     </term>
     <term name="folio">
       <single>folio</single>
-      <multiple>folioer</multiple>
+      <multiple>folio</multiple>
     </term>
     <term name="issue">
       <single>nummer</single>
-      <multiple>numre</multiple>
+      <multiple>nummer</multiple>
     </term>
     <term name="line">
       <single>linje</single>
-      <multiple>linjer</multiple>
+      <multiple>linje</multiple>
     </term>
     <term name="note">
       <single>note</single>
-      <multiple>noter</multiple>
+      <multiple>note</multiple>
     </term>
     <term name="opus">
       <single>opus</single>
@@ -276,11 +267,11 @@
     </term>
     <term name="part">
       <single>del</single>
-      <multiple>deler</multiple>
+      <multiple>del</multiple>
     </term>
     <term name="section">
       <single>paragraf</single>
-      <multiple>paragrafer</multiple>
+      <multiple>paragraf</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -296,61 +287,33 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix" form="short">			 
-      <single>app.</single>
-      <multiple>appr.</multiple>						 
-    </term>
     <term name="article-locator" form="short">			 
       <single>art.</single>
-      <multiple>artr.</multiple>
-    </term>
-    <term name="elocation" form="short">			 
-      <single>sted</single>
-      <multiple>steder</multiple>
-    </term>
-    <term name="equation" form="short">			 
-      <single>likn.</single>
-      <multiple>liknr.</multiple>
-    </term>
-    <term name="rule" form="short">			 
-      <single>r.</single>
-      <multiple>rr.</multiple>						 
-    </term>
-    <term name="scene" form="short">			 
-      <single>sc.</single>
-      <multiple>scr.</multiple>						 
+      <multiple>art.</multiple>
     </term>
     <term name="table" form="short">			 
-      <single>tbl.</single>
-      <multiple>tblr.</multiple>						 
+      <single>tab.</single>
+      <multiple>tab.</multiple>						 
     </term>
     <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator" form="short">			 
-      <single>tit.</single>
-      <multiple>titr.</multiple>
-    </term>
-    <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">kol.</term>
     <term name="figure" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr.</term>
-    <term name="line" form="short">l.</term>
-    <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
       <single>s.</single>
-      <multiple>s.</multiple>
+      <multiple>ss.</multiple>
     </term>
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
     <term name="paragraph" form="short">avsn.</term>
-    <term name="part" form="short">d.</term>
     <term name="section" form="short">pargr.</term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
@@ -381,8 +344,8 @@
       <multiple>ledere</multiple>
     </term>
     <term name="compiler">
-      <single>samler</single>
-      <multiple>samlere</multiple>
+      <single>kompilator</single>
+      <multiple>kompilatorer</multiple>
     </term>
     <term name="contributor">
       <single>bidragsyter</single>
@@ -454,45 +417,17 @@
     </term>
 
     <!-- SHORT ROLE FORMS -->
-    <term name="compiler" form="short">
-      <single>saml.</single>
-      <multiple>samlr.</multiple>
-    </term>
-    <term name="contributor" form="short">
-      <single>bidrags.</single>
-      <multiple>bidragsr.</multiple>
-    </term>
-    <term name="curator" form="short">
-      <single>kur.</single>
-      <multiple>kurr.</multiple>
-    </term>
     <term name="executive-producer" form="short">
       <single>utøv. prod.</single>
       <multiple>utøv. prodr.</multiple>
     </term>
-    <term name="narrator" form="short">
-      <single>fortel.</single>
-      <multiple>fortelr.</multiple>
-    </term>
-    <term name="organizer" form="short">
-      <single>org.</single>
-      <multiple>orgr.</multiple>
-    </term>
-    <term name="performer" form="short">
-      <single>utøv.</single>
-      <multiple>utøvr.</multiple>
-    </term>
     <term name="producer" form="short">
       <single>prod.</single>
-      <multiple>prodr.</multiple>
+      <multiple>prod.</multiple>
     </term>
     <term name="script-writer" form="short">
       <single>forf.</single>
-      <multiple>forfr.</multiple>
-    </term>
-    <term name="series-creator" form="short">
-      <single>skap.</single>
-      <multiple>skapr.</multiple>
+      <multiple>forf.</multiple>
     </term>
     <term name="director" form="short">
       <single>regi</single>
@@ -508,7 +443,7 @@
     </term>
     <term name="illustrator" form="short">
       <single>ill.</single>
-      <multiple>illr.</multiple>
+      <multiple>ill.</multiple>
     </term>
     <term name="translator" form="short">
       <single>overs.</single>
@@ -521,7 +456,7 @@
 
     <!-- VERB ROLE FORMS -->
     <term name="chair" form="verb">leda av</term>
-    <term name="compiler" form="verb">samla av</term>
+    <term name="compiler" form="verb">kompilert av</term>
     <term name="contributor" form="verb">med</term>
     <term name="curator" form="verb">kuratert av</term>
     <term name="executive-producer" form="verb">utøvende produsert av</term>
@@ -545,18 +480,9 @@
     <term name="editortranslator" form="verb">redigert &amp; oversatt av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="compiler" form="verb-short">saml. av</term>
-    <term name="contributor" form="verb-short">m.</term>
-    <term name="curator" form="verb-short">kur. av</term>
     <term name="executive-producer" form="verb-short">utøv. prod. av</term>
-    <term name="guest" form="verb-short">m. gjest</term>
-    <term name="host" form="verb-short">vertskap av</term>
-    <term name="narrator" form="verb-short">fort. av</term>
-    <term name="organizer" form="verb-short">org. av</term>
-    <term name="performer" form="verb-short">fremf. av</term>
     <term name="producer" form="verb-short">prod. av</term>
     <term name="script-writer" form="verb-short">forf. av</term>
-    <term name="series-creator" form="verb-short">skapt av</term>
     <term name="director" form="verb-short">regi</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -27,8 +27,8 @@
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="no-place">ingen stad</term>
     <term name="no-place" form="short">i.s.</term>
-    <term name="no-publisher">ingen utgjevar</term> <!-- sine nomine -->
-    <term name="no-publisher" form="short">i.u.</term>
+    <term name="no-publisher">manglar utgjevar</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">s.n.</term>
     <term name="on">om</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">opphavleg verk utgitt</term>
@@ -425,8 +425,8 @@
       <multiple>manusforfattarar</multiple>
     </term>
     <term name="series-creator">
-      <single>serieforfattar</single>
-      <multiple>serieforfattarar</multiple>
+      <single>serieskapar</single>
+      <multiple>serieskaparar</multiple>
     </term>
     <term name="director">
       <single>regissør</single>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -19,33 +19,33 @@
     <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
   </date>
   <terms>
-    <term name="advance-online-publication">advance online publication</term>
+    <term name="advance-online-publication">førehandspublisert på nett</term>
     <term name="album">album</term>
-    <term name="audio-recording">audio recording</term>
+    <term name="audio-recording">lydopptak</term>
     <term name="film">film</term>
-    <term name="henceforth">henceforth</term>
+    <term name="henceforth">heretter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="no-place">no place</term>
-    <term name="no-place" form="short">n.p.</term>
-    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
-    <term name="no-publisher" form="short">n.p.</term>
-    <term name="on">on</term>
+    <term name="no-place">ingen stad</term>
+    <term name="no-place" form="short">i.s.</term>
+    <term name="no-publisher">ingen utgjevar</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">i.u.</term>
+    <term name="on">om</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="original-work-published">original work published</term>
+    <term name="original-work-published">opphavleg verk utgitt</term>
     <term name="personal-communication">personlig kommunikasjon</term>
-    <term name="podcast">podcast</term>
-    <term name="podcast-episode">podcast episode</term>
-    <term name="preprint">preprint</term>
-    <term name="radio-broadcast">radio broadcast</term>
-    <term name="radio-series">radio series</term>
-    <term name="radio-series-episode">radio series episode</term>
-    <term name="special-issue">special issue</term>
-    <term name="special-section">special section</term>
-    <term name="television-broadcast">television broadcast</term>
-    <term name="television-series">television series</term>
-    <term name="television-series-episode">television series episode</term>
+    <term name="podcast">podkast</term>
+    <term name="podcast-episode">podkast-episode</term>
+    <term name="preprint">innsendt manuskript</term>
+    <term name="radio-broadcast">radiosending</term>
+    <term name="radio-series">radioserie</term>
+    <term name="radio-series-episode">radioserie-episode</term>
+    <term name="special-issue">spesialutgåve</term>
+    <term name="special-section">spesialbolk</term>
+    <term name="television-broadcast">fjernsynssending</term>
+    <term name="television-series">fjernsynsserie</term>
+    <term name="television-series-episode">fjernsynsserie-episode</term>
     <term name="video">video</term>
-    <term name="working-paper">working paper</term>
+    <term name="working-paper">notat</term>
     <term name="accessed">vitja</term>
     <term name="and">og</term>
     <term name="and others">med fleire</term>
@@ -70,9 +70,9 @@
     <term name="in press">i trykk</term>
     <term name="internet">Internett</term>
     <term name="letter">brev</term>
-    <term name="no date">ingen dato</term>
+    <term name="no date">utan dato</term>
     <term name="no date" form="short">u.å.</term>
-    <term name="online">online</term>
+    <term name="online">på nett</term>
     <term name="presented at">presentert på</term>
     <term name="reference">
       <single>referanse</single>
@@ -87,68 +87,68 @@
     <term name="version">versjon</term>
 
     <!-- LONG ITEM TYPE FORMS -->
-    <term name="article">preprint</term>
-    <term name="article-journal">journal article</term>
-    <term name="article-magazine">magazine article</term>
-    <term name="article-newspaper">newspaper article</term>
-    <term name="bill">bill</term>
+    <term name="article">innsendt manuskript</term>
+    <term name="article-journal">tidsskriftartikkel</term>
+    <term name="article-magazine">magasinartikkel</term>
+    <term name="article-newspaper">avisartikkel</term>
+    <term name="bill">proposisjon</term>
     <!-- book is in the list of locator terms -->
-    <term name="broadcast">broadcast</term>
+    <term name="broadcast">kringkasting</term>
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">classic</term>
-    <term name="collection">collection</term>
-    <term name="dataset">dataset</term>
-    <term name="document">document</term>
-    <term name="entry">entry</term>
-    <term name="entry-dictionary">dictionary entry</term>
-    <term name="entry-encyclopedia">encyclopedia entry</term>
-    <term name="event">event</term>
+    <term name="classic">klassikar</term>
+    <term name="collection">samling</term>
+    <term name="dataset">datasett</term>
+    <term name="document">dokument</term>
+    <term name="entry">oppføring</term>
+    <term name="entry-dictionary">ordbok-oppføring</term>
+    <term name="entry-encyclopedia">leksikon-oppføring</term>
+    <term name="event">hending</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic">graphic</term>
-    <term name="hearing">hearing</term>
+    <term name="graphic">grafikk</term>
+    <term name="hearing">høyring</term>
     <term name="interview">intervju</term>
-    <term name="legal_case">legal case</term>
-    <term name="legislation">legislation</term>
-    <term name="manuscript">manuscript</term>
-    <term name="map">map</term>
-    <term name="motion_picture">video recording</term>
-    <term name="musical_score">musical score</term>
-    <term name="pamphlet">pamphlet</term>
-    <term name="paper-conference">conference paper</term>
+    <term name="legal_case">rettssak</term>
+    <term name="legislation">lovgjeving</term>
+    <term name="manuscript">manuskript</term>
+    <term name="map">kart</term>
+    <term name="motion_picture">video-opptak</term>
+    <term name="musical_score">partitur</term>
+    <term name="pamphlet">pamflett</term>
+    <term name="paper-conference">konferanseartikkel</term>
     <term name="patent">patent</term>
-    <term name="performance">performance</term>
-    <term name="periodical">periodical</term>
-    <term name="personal_communication">personlig kommunikasjon</term>
-    <term name="post">post</term>
-    <term name="post-weblog">blog post</term>
-    <term name="regulation">regulation</term>
-    <term name="report">report</term>
-    <term name="review">review</term>
-    <term name="review-book">book review</term>
-    <term name="software">software</term>
-    <term name="song">audio recording</term>
-    <term name="speech">presentation</term>
+    <term name="performance">framføring</term>
+    <term name="periodical">tidsskrift</term>
+    <term name="personal_communication">personleg kommunikasjon</term>
+    <term name="post">innlegg</term>
+    <term name="post-weblog">blogginnlegg</term>
+    <term name="regulation">forskrift</term>
+    <term name="report">rapport</term>
+    <term name="review">melding</term>
+    <term name="review-book">bokmelding</term>
+    <term name="software">programvare</term>
+    <term name="song">lydopptak</term>
+    <term name="speech">presentasjon</term>
     <term name="standard">standard</term>
-    <term name="thesis">thesis</term>
-    <term name="treaty">treaty</term>
-    <term name="webpage">webpage</term>
+    <term name="thesis">avhandling</term>
+    <term name="treaty">traktat</term>
+    <term name="webpage">nettside</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-journal" form="short">tidsskrift art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
-    <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="article-newspaper" form="short">avisart.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="document" form="short">doc.</term>
+    <term name="document" form="short">dok.</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graph.</term>
+    <term name="graphic" form="short">graf.</term>
     <term name="interview" form="short">interv.</term>
-    <term name="manuscript" form="short">MS</term>
-    <term name="motion_picture" form="short">video rec.</term>
-    <term name="report" form="short">rep.</term>
-    <term name="review" form="short">rev.</term>
-    <term name="review-book" form="short">bk. rev.</term>
-    <term name="song" form="short">audio rec.</term>
+    <term name="manuscript" form="short">ms.</term>
+    <term name="motion_picture" form="short">videoopp.</term>
+    <term name="report" form="short">rap.</term>
+    <term name="review" form="short">meld.</term>
+    <term name="review-book" form="short">bokmeld.</term>
+    <term name="song" form="short">lydopp.</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">e.Kr.</term>
@@ -182,49 +182,49 @@
     <term name="long-ordinal-10">tiande</term>
 
     <!-- LONG LOCATOR FORMS -->
-    <term name="act">			 
-      <single>act</single>
-      <multiple>acts</multiple>						 
+    <term name="act">
+      <single>akt</single>
+      <multiple>akter</multiple>						 
     </term>
     <term name="appendix">			 
-      <single>appendix</single>
-      <multiple>appendices</multiple>						 
+      <single>appendiks</single>
+      <multiple>appendiksar</multiple>						 
     </term>
     <term name="article-locator">			 
-      <single>article</single>
-      <multiple>articles</multiple>						 
+      <single>artikkel</single>
+      <multiple>artiklar</multiple>						 
     </term>
     <term name="canon">			 
-      <single>canon</single>
-      <multiple>canons</multiple>						 
+      <single>kanon</single>
+      <multiple>kanonar</multiple>						 
     </term>
     <term name="elocation">			 
-      <single>location</single>
-      <multiple>locations</multiple>						 
+      <single>stad</single>
+      <multiple>stader</multiple>						 
     </term>
     <term name="equation">			 
-      <single>equation</single>
-      <multiple>equations</multiple>						 
+      <single>likning</single>
+      <multiple>likningar</multiple>						 
     </term>
     <term name="rule">			 
-      <single>rule</single>
-      <multiple>rules</multiple>						 
+      <single>regel</single>
+      <multiple>reglar</multiple>						 
     </term>
     <term name="scene">			 
       <single>scene</single>
-      <multiple>scenes</multiple>						 
+      <multiple>scenar</multiple>						 
     </term>
     <term name="table">			 
-      <single>table</single>
-      <multiple>tables</multiple>						 
+      <single>tabell</single>
+      <multiple>tabellar</multiple>						 
     </term>
     <term name="timestamp"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
     <term name="title-locator">			 
-      <single>title</single>
-      <multiple>titles</multiple>						 
+      <single>tittel</single>
+      <multiple>titlar</multiple>						 
     </term>
     <term name="book">
       <single>bok</single>
@@ -305,12 +305,12 @@
       <multiple>arts.</multiple>
     </term>
     <term name="elocation" form="short">			 
-      <single>loc.</single>
-      <multiple>locs.</multiple>
+      <single>stad</single>
+      <multiple>stader</multiple>
     </term>
     <term name="equation" form="short">			 
-      <single>eq.</single>
-      <multiple>eqs.</multiple>
+      <single>likn.</single>
+      <multiple>likn.</multiple>
     </term>
     <term name="rule" form="short">			 
       <single>r.</single>
@@ -318,11 +318,11 @@
     </term>
     <term name="scene" form="short">			 
       <single>sc.</single>
-      <multiple>scs.</multiple>						 
+      <multiple>scr.</multiple>						 
     </term>
     <term name="table" form="short">			 
       <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
+      <multiple>tblr.</multiple>						 
     </term>
     <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
@@ -330,7 +330,7 @@
     </term>
     <term name="title-locator" form="short">			 
       <single>tit.</single>
-      <multiple>tits.</multiple>
+      <multiple>titr.</multiple>
     </term>
     <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
@@ -377,56 +377,56 @@
 
     <!-- LONG ROLE FORMS -->
     <term name="chair">
-      <single>chair</single>
-      <multiple>chairs</multiple>
+      <single>leiar</single>
+      <multiple>leiarar</multiple>
     </term>
     <term name="compiler">
-      <single>compiler</single>
-      <multiple>compilers</multiple>
+      <single>samlar</single>
+      <multiple>samlarar</multiple>
     </term>
     <term name="contributor">
-      <single>contributor</single>
-      <multiple>contributors</multiple>
+      <single>bidragsytar</single>
+      <multiple>bidragsytarar</multiple>
     </term>
     <term name="curator">
-      <single>curator</single>
-      <multiple>curators</multiple>
+      <single>kurator</single>
+      <multiple>kuratorar</multiple>
     </term>
     <term name="executive-producer">
-      <single>executive producer</single>
-      <multiple>executive producers</multiple>
+      <single>utøvande produsent</single>
+      <multiple>utøvande produsentar</multiple>
     </term>
     <term name="guest">
-      <single>guest</single>
-      <multiple>guests</multiple>
+      <single>gjest</single>
+      <multiple>gjester</multiple>
     </term>
     <term name="host">
-      <single>host</single>
-      <multiple>hosts</multiple>
+      <single>vert</single>
+      <multiple>vertar</multiple>
     </term>
     <term name="narrator">
-      <single>narrator</single>
-      <multiple>narrators</multiple>
+      <single>forteljar</single>
+      <multiple>forteljarar</multiple>
     </term>
     <term name="organizer">
-      <single>organizer</single>
-      <multiple>organizers</multiple>
+      <single>organisator</single>
+      <multiple>organisatorar</multiple>
     </term>
     <term name="performer">
-      <single>performer</single>
-      <multiple>performers</multiple>
+      <single>utøvar</single>
+      <multiple>utøvarar</multiple>
     </term>
     <term name="producer">
-      <single>producer</single>
-      <multiple>producers</multiple>
+      <single>produsent</single>
+      <multiple>produsentar</multiple>
     </term>
     <term name="script-writer">
-      <single>writer</single>
-      <multiple>writers</multiple>
+      <single>manusforfattar</single>
+      <multiple>manusforfattarar</multiple>
     </term>
     <term name="series-creator">
-      <single>series creator</single>
-      <multiple>series creators</multiple>
+      <single>serieforfattar</single>
+      <multiple>serieforfattarar</multiple>
     </term>
     <term name="director">
       <single>regissør</single>
@@ -455,44 +455,44 @@
 
     <!-- SHORT ROLE FORMS -->
     <term name="compiler" form="short">
-      <single>comp.</single>
-      <multiple>comps.</multiple>
+      <single>saml.</single>
+      <multiple>samlr.</multiple>
     </term>
     <term name="contributor" form="short">
-      <single>contrib.</single>
-      <multiple>contribs.</multiple>
+      <single>bidragsyt.</single>
+      <multiple>bidragsytr.</multiple>
     </term>
     <term name="curator" form="short">
-      <single>cur.</single>
-      <multiple>curs.</multiple>
+      <single>kur.</single>
+      <multiple>kurr.</multiple>
     </term>
     <term name="executive-producer" form="short">
-      <single>exec. prod.</single>
-      <multiple>exec. prods.</multiple>
+      <single>utøv. prod.</single>
+      <multiple>utøv. prodr.</multiple>
     </term>
     <term name="narrator" form="short">
-      <single>narr.</single>
-      <multiple>narrs.</multiple>
+      <single>fortel.</single>
+      <multiple>fortelr.</multiple>
     </term>
     <term name="organizer" form="short">
       <single>org.</single>
-      <multiple>orgs.</multiple>
+      <multiple>orgr.</multiple>
     </term>
     <term name="performer" form="short">
-      <single>perf.</single>
-      <multiple>perfs.</multiple>
+      <single>utøv.</single>
+      <multiple>utøvr.</multiple>
     </term>
     <term name="producer" form="short">
       <single>prod.</single>
-      <multiple>prods.</multiple>
+      <multiple>prodr.</multiple>
     </term>
     <term name="script-writer" form="short">
-      <single>writ.</single>
-      <multiple>writs.</multiple>
+      <single>forf.</single>
+      <multiple>forfr.</multiple>
     </term>
     <term name="series-creator" form="short">
-      <single>cre.</single>
-      <multiple>cres.</multiple>
+      <single>serieforf.</single>
+      <multiple>serieforfr.</multiple>
     </term>
     <term name="director" form="short">
       <single>regi</single>
@@ -508,7 +508,7 @@
     </term>
     <term name="illustrator" form="short">
       <single>ill.</single>
-      <multiple>ills.</multiple>
+      <multiple>illr.</multiple>
     </term>
     <term name="translator" form="short">
       <single>oms.</single>
@@ -520,19 +520,19 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="chair" form="verb">chaired by</term>
-    <term name="compiler" form="verb">compiled by</term>
-    <term name="contributor" form="verb">with</term>
-    <term name="curator" form="verb">curated by</term>
-    <term name="executive-producer" form="verb">executive produced by</term>
-    <term name="guest" form="verb">with guest</term>
-    <term name="host" form="verb">hosted by</term>
-    <term name="narrator" form="verb">narrated by</term>
-    <term name="organizer" form="verb">organized by</term>
-    <term name="performer" form="verb">performed by</term>
-    <term name="producer" form="verb">produced by</term>
-    <term name="script-writer" form="verb">written by</term>
-    <term name="series-creator" form="verb">created by</term>
+    <term name="chair" form="verb">leia av</term>
+    <term name="compiler" form="verb">samla av</term>
+    <term name="contributor" form="verb">med</term>
+    <term name="curator" form="verb">kuratert av</term>
+    <term name="executive-producer" form="verb">utøvande produsert av</term>
+    <term name="guest" form="verb">med gjest</term>
+    <term name="host" form="verb">vertskap av</term>
+    <term name="narrator" form="verb">fortald av</term>
+    <term name="organizer" form="verb">organisert av</term>
+    <term name="performer" form="verb">utført av</term>
+    <term name="producer" form="verb">produsert av</term>
+    <term name="script-writer" form="verb">forfatta av</term>
+    <term name="series-creator" form="verb">skapt av</term>
     <term name="container-author" form="verb">av</term>
     <term name="director" form="verb">regissert av</term>
     <term name="editor" form="verb">redigert av</term>
@@ -545,18 +545,18 @@
     <term name="editortranslator" form="verb">redigert &amp; omsett av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="compiler" form="verb-short">comp. by</term>
-    <term name="contributor" form="verb-short">w.</term>
-    <term name="curator" form="verb-short">cur. by</term>
-    <term name="executive-producer" form="verb-short">exec. prod. by</term>
-    <term name="guest" form="verb-short">w. guest</term>
-    <term name="host" form="verb-short">hosted by</term>
-    <term name="narrator" form="verb-short">narr. by</term>
-    <term name="organizer" form="verb-short">org. by</term>
-    <term name="performer" form="verb-short">perf. by</term>
-    <term name="producer" form="verb-short">prod. by</term>
-    <term name="script-writer" form="verb-short">writ. by</term>
-    <term name="series-creator" form="verb-short">cre. by</term>
+    <term name="compiler" form="verb-short">saml. av</term>
+    <term name="contributor" form="verb-short">m.</term>
+    <term name="curator" form="verb-short">kur. av</term>
+    <term name="executive-producer" form="verb-short">utøv. prod. av</term>
+    <term name="guest" form="verb-short">m. gjest</term>
+    <term name="host" form="verb-short">vert</term>
+    <term name="narrator" form="verb-short">fortel. av</term>
+    <term name="organizer" form="verb-short">org. av</term>
+    <term name="performer" form="verb-short">utført av</term>
+    <term name="producer" form="verb-short">prod. av</term>
+    <term name="script-writer" form="verb-short">forf. av</term>
+    <term name="series-creator" form="verb-short">skapt av</term>
     <term name="director" form="verb-short">regi</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -25,8 +25,7 @@
     <term name="film">film</term>
     <term name="henceforth">heretter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="no-place">ingen stad</term>
-    <term name="no-place" form="short">i.s.</term>
+    <term name="no-place">manglar stad</term>
     <term name="no-publisher">manglar utgjevar</term> <!-- sine nomine -->
     <term name="no-publisher" form="short">s.n.</term>
     <term name="on">om</term>
@@ -59,7 +58,7 @@
     <term name="cited">sitert</term>
     <term name="edition">
       <single>utgåve</single>
-      <multiple>utgåver</multiple>
+      <multiple>utgåve</multiple>
     </term>
     <term name="edition" form="short">utg.</term>
     <term name="et-al">mfl.</term>
@@ -76,11 +75,11 @@
     <term name="presented at">presentert på</term>
     <term name="reference">
       <single>referanse</single>
-      <multiple>referansar</multiple>
+      <multiple>referanse</multiple>
     </term>
     <term name="reference" form="short">
       <single>ref.</single>
-      <multiple>refr.</multiple>
+      <multiple>ref.</multiple>
     </term>
     <term name="retrieved">henta</term>
     <term name="scale">målestokk</term>
@@ -100,8 +99,8 @@
     <term name="dataset">datasett</term>
     <term name="document">dokument</term>
     <term name="entry">oppføring</term>
-    <term name="entry-dictionary">ordbok-oppføring</term>
-    <term name="entry-encyclopedia">leksikon-oppføring</term>
+    <term name="entry-dictionary">ordbokoppføring</term>
+    <term name="entry-encyclopedia">leksikonoppføring</term>
     <term name="event">hending</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic">grafikk</term>
@@ -135,20 +134,12 @@
 
     <!-- SHORT ITEM TYPE FORMS -->
     <term name="article-journal" form="short">tidsskrift art.</term>
-    <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">avisart.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="document" form="short">dok.</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graf.</term>
-    <term name="interview" form="short">interv.</term>
     <term name="manuscript" form="short">ms.</term>
-    <term name="motion_picture" form="short">videoopp.</term>
-    <term name="report" form="short">rap.</term>
-    <term name="review" form="short">meld.</term>
-    <term name="review-book" form="short">bokmeld.</term>
-    <term name="song" form="short">lydopp.</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">e.Kr.</term>
@@ -184,39 +175,39 @@
     <!-- LONG LOCATOR FORMS -->
     <term name="act">
       <single>akt</single>
-      <multiple>akter</multiple>						 
+      <multiple>akt</multiple>						 
     </term>
     <term name="appendix">			 
       <single>appendiks</single>
-      <multiple>appendiksar</multiple>						 
+      <multiple>appendiks</multiple>						 
     </term>
     <term name="article-locator">			 
       <single>artikkel</single>
-      <multiple>artiklar</multiple>						 
+      <multiple>artikkel</multiple>						 
     </term>
     <term name="canon">			 
       <single>kanon</single>
-      <multiple>kanonar</multiple>						 
+      <multiple>kanon</multiple>						 
     </term>
     <term name="elocation">			 
       <single>stad</single>
-      <multiple>stader</multiple>						 
+      <multiple>stad</multiple>						 
     </term>
     <term name="equation">			 
       <single>likning</single>
-      <multiple>likningar</multiple>						 
+      <multiple>likning</multiple>						 
     </term>
     <term name="rule">			 
       <single>regel</single>
-      <multiple>reglar</multiple>						 
+      <multiple>regel</multiple>						 
     </term>
     <term name="scene">			 
       <single>scene</single>
-      <multiple>scenar</multiple>						 
+      <multiple>scene</multiple>						 
     </term>
     <term name="table">			 
       <single>tabell</single>
-      <multiple>tabellar</multiple>						 
+      <multiple>tabell</multiple>						 
     </term>
     <term name="timestamp"> <!-- generally blank -->
       <single></single>
@@ -224,11 +215,11 @@
     </term>
     <term name="title-locator">			 
       <single>tittel</single>
-      <multiple>titlar</multiple>						 
+      <multiple>tittel</multiple>						 
     </term>
     <term name="book">
       <single>bok</single>
-      <multiple>bøker</multiple>
+      <multiple>bok</multiple>
     </term>
     <term name="chapter">
       <single>kapittel</single>
@@ -236,15 +227,15 @@
     </term>
     <term name="column">
       <single>kolonne</single>
-      <multiple>kolonner</multiple>
+      <multiple>kolonne</multiple>
     </term>
     <term name="figure">
       <single>figur</single>
-      <multiple>figurar</multiple>
+      <multiple>figur</multiple>
     </term>
     <term name="folio">
       <single>folio</single>
-      <multiple>folioar</multiple>
+      <multiple>folio</multiple>
     </term>
     <term name="issue">
       <single>nummer</single>
@@ -252,11 +243,11 @@
     </term>
     <term name="line">
       <single>linje</single>
-      <multiple>linjer</multiple>
+      <multiple>linje</multiple>
     </term>
     <term name="note">
       <single>note</single>
-      <multiple>notar</multiple>
+      <multiple>note</multiple>
     </term>
     <term name="opus">
       <single>opus</single>
@@ -276,11 +267,11 @@
     </term>
     <term name="part">
       <single>del</single>
-      <multiple>deler</multiple>
+      <multiple>del</multiple>
     </term>
     <term name="section">
       <single>paragraf</single>
-      <multiple>paragrafar</multiple>
+      <multiple>paragraf</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -296,61 +287,33 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix" form="short">			 
-      <single>app.</single>
-      <multiple>apps.</multiple>						 
-    </term>
     <term name="article-locator" form="short">			 
       <single>art.</single>
-      <multiple>arts.</multiple>
-    </term>
-    <term name="elocation" form="short">			 
-      <single>stad</single>
-      <multiple>stader</multiple>
-    </term>
-    <term name="equation" form="short">			 
-      <single>likn.</single>
-      <multiple>likn.</multiple>
-    </term>
-    <term name="rule" form="short">			 
-      <single>r.</single>
-      <multiple>rr.</multiple>						 
-    </term>
-    <term name="scene" form="short">			 
-      <single>sc.</single>
-      <multiple>scr.</multiple>						 
+      <multiple>art.</multiple>
     </term>
     <term name="table" form="short">			 
-      <single>tbl.</single>
-      <multiple>tblr.</multiple>						 
+      <single>tab.</single>
+      <multiple>tab.</multiple>						 
     </term>
     <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
       <multiple></multiple>						 
     </term>
-    <term name="title-locator" form="short">			 
-      <single>tit.</single>
-      <multiple>titr.</multiple>
-    </term>
-    <term name="book" form="short">b.</term>
     <term name="chapter" form="short">kap.</term>
     <term name="column" form="short">kol.</term>
     <term name="figure" form="short">fig.</term>
     <term name="folio" form="short">fol.</term>
     <term name="issue" form="short">nr.</term>
-    <term name="line" form="short">l.</term>
-    <term name="note" form="short">n.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
       <single>s.</single>
-      <multiple>s.</multiple>
+      <multiple>ss.</multiple>
     </term>
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
     <term name="paragraph" form="short">avsn.</term>
-    <term name="part" form="short">d.</term>
     <term name="section" form="short">par.</term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
@@ -381,8 +344,8 @@
       <multiple>leiarar</multiple>
     </term>
     <term name="compiler">
-      <single>samlar</single>
-      <multiple>samlarar</multiple>
+      <single>kompilator</single>
+      <multiple>kompilatorar</multiple>
     </term>
     <term name="contributor">
       <single>bidragsytar</single>
@@ -454,45 +417,17 @@
     </term>
 
     <!-- SHORT ROLE FORMS -->
-    <term name="compiler" form="short">
-      <single>saml.</single>
-      <multiple>samlr.</multiple>
-    </term>
-    <term name="contributor" form="short">
-      <single>bidragsyt.</single>
-      <multiple>bidragsytr.</multiple>
-    </term>
-    <term name="curator" form="short">
-      <single>kur.</single>
-      <multiple>kurr.</multiple>
-    </term>
     <term name="executive-producer" form="short">
       <single>utøv. prod.</single>
-      <multiple>utøv. prodr.</multiple>
-    </term>
-    <term name="narrator" form="short">
-      <single>fortel.</single>
-      <multiple>fortelr.</multiple>
-    </term>
-    <term name="organizer" form="short">
-      <single>org.</single>
-      <multiple>orgr.</multiple>
-    </term>
-    <term name="performer" form="short">
-      <single>utøv.</single>
-      <multiple>utøvr.</multiple>
+      <multiple>utøv. prod.</multiple>
     </term>
     <term name="producer" form="short">
       <single>prod.</single>
-      <multiple>prodr.</multiple>
+      <multiple>prod.</multiple>
     </term>
     <term name="script-writer" form="short">
       <single>forf.</single>
-      <multiple>forfr.</multiple>
-    </term>
-    <term name="series-creator" form="short">
-      <single>serieforf.</single>
-      <multiple>serieforfr.</multiple>
+      <multiple>forf.</multiple>
     </term>
     <term name="director" form="short">
       <single>regi</single>
@@ -508,7 +443,7 @@
     </term>
     <term name="illustrator" form="short">
       <single>ill.</single>
-      <multiple>illr.</multiple>
+      <multiple>ill.</multiple>
     </term>
     <term name="translator" form="short">
       <single>oms.</single>
@@ -521,7 +456,7 @@
 
     <!-- VERB ROLE FORMS -->
     <term name="chair" form="verb">leia av</term>
-    <term name="compiler" form="verb">samla av</term>
+    <term name="compiler" form="verb">kompilert av</term>
     <term name="contributor" form="verb">med</term>
     <term name="curator" form="verb">kuratert av</term>
     <term name="executive-producer" form="verb">utøvande produsert av</term>
@@ -545,22 +480,13 @@
     <term name="editortranslator" form="verb">redigert &amp; omsett av</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="compiler" form="verb-short">saml. av</term>
-    <term name="contributor" form="verb-short">m.</term>
-    <term name="curator" form="verb-short">kur. av</term>
-    <term name="executive-producer" form="verb-short">utøv. prod. av</term>
-    <term name="guest" form="verb-short">m. gjest</term>
     <term name="host" form="verb-short">vert</term>
-    <term name="narrator" form="verb-short">fortel. av</term>
-    <term name="organizer" form="verb-short">org. av</term>
-    <term name="performer" form="verb-short">utført av</term>
     <term name="producer" form="verb-short">prod. av</term>
     <term name="script-writer" form="verb-short">forf. av</term>
-    <term name="series-creator" form="verb-short">skapt av</term>
     <term name="director" form="verb-short">regi</term>
     <term name="editor" form="verb-short">red.</term>
     <term name="editorial-director" form="verb-short">red.</term>
-    <term name="illustrator" form="verb-short">illus.</term>
+    <term name="illustrator" form="verb-short">ill.</term>
     <term name="translator" form="verb-short">oms.</term>
     <term name="editortranslator" form="verb-short">red. &amp; oms. av</term>
 


### PR DESCRIPTION
### Description

Update locales-nn-NO.xml and locales-nb-NO.xml with new terms etc. from new version of CSL.

### Questions

#### Abbreviations

In the current submitted patch (and possibly in the former version) I think at least half of the abbreviations are invented for CSL and not established forms in use. What is the best way to handle this?

1. Invent abbreviations (as done in patch)?
2. Only include established abbreviations, and leave english terms?
3. Only include established abbreviations, and remove english terms?
4. Alternative 2 or 3, but with latin abbreviations where available?
5. Add long form terms instead of abbreviated terms?

#### Multiples

I suspect that the multiple forms of many terms are superflous, or wrong, but can`t be sure, as I`m not sure what it looks like in practice. What could be example uses of multiples of for example "canon", "elocation" or "equation" be?

### Checklist

- [X] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
