### PR TITLE
Translate original-work-published

### DIFF
--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -32,7 +32,7 @@
     <term name="no-publisher" form="short">n.p.</term>
     <term name="on">on</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="original-work-published">original work published</term>
+    <term name="original-work-published">obra original publicada en</term>
     <term name="personal-communication">comunicación personal</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>


### PR DESCRIPTION
Hi! I am in the process of contributing to the CSL community for the first time. A few days ago, I proposed a change to the APA style, which was replacing the text “Original work published” with the correspondent term, so it can be shown in many languages. My proposal to the APA style is under consideration. @adam3smith kindly suggested me to take a look here at Locales. I am entering to this particular locale because Spanish is my first language, and es-MX is the locale I use in my software. My translation of the text is:  “obra original publicada en”.  I hope you find this translation useful. If this is good for approval, then my plan is to submit the same translation to es-CL and es-ES next. Thanks for considering this proposal!

## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Briefly describe the changes you're proposing.

### Checklist

- [ ] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
