### PR TITLE
Update locales-ca-AD.xml

### DIFF
--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -541,7 +541,7 @@
     <term name="editor" form="verb">editat per</term>
     <term name="editorial-director" form="verb">editat per</term>
     <term name="illustrator" form="verb">il·lustrat per</term>
-    <term name="interviewer" form="verb">entrevistat per</term>
+    <term name="interviewer" form="verb">entrevista feta per</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">per</term>
     <term name="translator" form="verb">traduït per</term>


### PR DESCRIPTION
The "interviewed by" form is related to the author(s), not to the cited work. In Catalan this form has to agree in gender and number with the author(s), and "entrevistat per" would only agree with a single male author. The proposed form "interview made by" is gender neutral in Catalan and works with single or multiple authors.

## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Briefly describe the changes you're proposing.

### Checklist

- [ ] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
