### PR TITLE
Sr latn rs locale translation

### DIFF
--- a/locales-sr-Cyrl-RS.xml
+++ b/locales-sr-Cyrl-RS.xml
@@ -1,0 +1,604 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="sr-Cyrl-RS">
+  <info>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2012-07-04T23:31:02+00:00</updated>
+  </info>
+  <style-options punctuation-in-quote="false"/>
+  <date form="text">
+    <date-part name="day" form="numeric-leading-zeros" suffix=". "/>
+    <date-part name="month" suffix=" "/>
+    <date-part name="year" suffix="."/>
+  </date>
+  <date form="numeric">
+    <date-part name="year"/>
+    <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+  </date>
+  <terms>
+    <term name="advance-online-publication">advance online publication</term>
+    <term name="album">album</term>
+    <term name="audio-recording">audio recording</term>
+    <term name="film">film</term>
+    <term name="henceforth">henceforth</term>
+    <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="no-place">no place</term>
+    <term name="no-place" form="short">n.p.</term>
+    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">n.p.</term>
+    <term name="on">on</term>
+    <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="original-work-published">original work published</term>
+    <term name="personal-communication">лична комуникација</term>
+    <term name="podcast">podcast</term>
+    <term name="podcast-episode">podcast episode</term>
+    <term name="preprint">preprint</term>
+    <term name="radio-broadcast">radio broadcast</term>
+    <term name="radio-series">radio series</term>
+    <term name="radio-series-episode">radio series episode</term>
+    <term name="special-issue">special issue</term>
+    <term name="special-section">special section</term>
+    <term name="television-broadcast">television broadcast</term>
+    <term name="television-series">television series</term>
+    <term name="television-series-episode">television series episode</term>
+    <term name="video">video</term>
+    <term name="working-paper">working paper</term>
+    <term name="accessed">приступљено</term>
+    <term name="and">и</term>
+    <term name="and others">и остали</term>
+    <term name="anonymous">анонимна</term>
+    <term name="anonymous" form="short">анон.</term>
+    <term name="at">на</term>
+    <term name="available at">available at</term>
+    <term name="by">by</term>
+    <term name="circa">circa</term>
+    <term name="circa" form="short">c.</term>
+    <term name="cited">цитирано</term>
+    <term name="edition">
+      <single>издање</single>
+      <multiple>издања</multiple>
+    </term>
+    <term name="edition" form="short">изд.</term>
+    <term name="et-al">и остали</term>
+    <term name="forthcoming">долазећи</term>
+    <term name="from">од</term>
+    <term name="ibid">ibid.</term>
+    <term name="in">у</term>
+    <term name="in press">у штампи</term>
+    <term name="internet">Интернет</term>
+    <term name="letter">писмо</term>
+    <term name="no date">no date</term>
+    <term name="no date" form="short">без датума</term>
+    <term name="online">на Интернету</term>
+    <term name="presented at">представљено на</term>
+    <term name="reference">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="reference" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="retrieved">преузето</term>
+    <term name="scale">scale</term>
+    <term name="version">version</term>
+
+    <!-- LONG ITEM TYPE FORMS -->
+    <term name="article">preprint</term>
+    <term name="article-journal">journal article</term>
+    <term name="article-magazine">magazine article</term>
+    <term name="article-newspaper">newspaper article</term>
+    <term name="bill">bill</term>
+    <!-- book is in the list of locator terms -->
+    <term name="broadcast">broadcast</term>
+    <!-- chapter is in the list of locator terms -->
+    <term name="classic">classic</term>
+    <term name="collection">collection</term>
+    <term name="dataset">dataset</term>
+    <term name="document">document</term>
+    <term name="entry">entry</term>
+    <term name="entry-dictionary">dictionary entry</term>
+    <term name="entry-encyclopedia">encyclopedia entry</term>
+    <term name="event">event</term>
+    <!-- figure is in the list of locator terms -->
+    <term name="graphic">graphic</term>
+    <term name="hearing">hearing</term>
+    <term name="interview">интервју</term>
+    <term name="legal_case">legal case</term>
+    <term name="legislation">legislation</term>
+    <term name="manuscript">manuscript</term>
+    <term name="map">map</term>
+    <term name="motion_picture">video recording</term>
+    <term name="musical_score">musical score</term>
+    <term name="pamphlet">pamphlet</term>
+    <term name="paper-conference">conference paper</term>
+    <term name="patent">patent</term>
+    <term name="performance">performance</term>
+    <term name="periodical">periodical</term>
+    <term name="personal_communication">лична комуникација</term>
+    <term name="post">post</term>
+    <term name="post-weblog">blog post</term>
+    <term name="regulation">regulation</term>
+    <term name="report">report</term>
+    <term name="review">review</term>
+    <term name="review-book">book review</term>
+    <term name="software">software</term>
+    <term name="song">audio recording</term>
+    <term name="speech">presentation</term>
+    <term name="standard">standard</term>
+    <term name="thesis">thesis</term>
+    <term name="treaty">treaty</term>
+    <term name="webpage">webpage</term>
+
+    <!-- SHORT ITEM TYPE FORMS -->
+    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-magazine" form="short">mag. art.</term>
+    <term name="article-newspaper" form="short">newspaper art.</term>
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
+    <term name="document" form="short">doc.</term>
+    <!-- figure is in the list of locator terms -->
+    <term name="graphic" form="short">graph.</term>
+    <term name="interview" form="short">interv.</term>
+    <term name="manuscript" form="short">MS</term>
+    <term name="motion_picture" form="short">video rec.</term>
+    <term name="report" form="short">rep.</term>
+    <term name="review" form="short">rev.</term>
+    <term name="review-book" form="short">bk. rev.</term>
+    <term name="song" form="short">audio rec.</term>
+
+    <!-- HISTORICAL ERA TERMS -->
+    <term name="ad">AD</term>
+    <term name="bc">BC</term>
+    <term name="bce">BCE</term>
+    <term name="ce">CE</term>
+
+    <!-- PUNCTUATION -->
+    <term name="open-quote">„</term>
+    <term name="close-quote">“</term>
+    <term name="open-inner-quote">‚</term>
+    <term name="close-inner-quote">‘</term>
+    <term name="page-range-delimiter">–</term>
+    <term name="colon">:</term>
+    <term name="comma">,</term>
+    <term name="semicolon">;</term>
+
+    <!-- ORDINALS -->
+    <term name="ordinal">th</term>
+    <term name="ordinal-01">st</term>
+    <term name="ordinal-02">nd</term>
+    <term name="ordinal-03">rd</term>
+    <term name="ordinal-11">th</term>
+    <term name="ordinal-12">th</term>
+    <term name="ordinal-13">th</term>
+
+    <!-- LONG ORDINALS -->
+    <term name="long-ordinal-01">first</term>
+    <term name="long-ordinal-02">second</term>
+    <term name="long-ordinal-03">third</term>
+    <term name="long-ordinal-04">fourth</term>
+    <term name="long-ordinal-05">fifth</term>
+    <term name="long-ordinal-06">sixth</term>
+    <term name="long-ordinal-07">seventh</term>
+    <term name="long-ordinal-08">eighth</term>
+    <term name="long-ordinal-09">ninth</term>
+    <term name="long-ordinal-10">tenth</term>
+
+    <!-- LONG LOCATOR FORMS -->
+    <term name="act">			 
+      <single>act</single>
+      <multiple>acts</multiple>						 
+    </term>
+    <term name="appendix">			 
+      <single>appendix</single>
+      <multiple>appendices</multiple>						 
+    </term>
+    <term name="article-locator">			 
+      <single>article</single>
+      <multiple>articles</multiple>						 
+    </term>
+    <term name="canon">			 
+      <single>canon</single>
+      <multiple>canons</multiple>						 
+    </term>
+    <term name="elocation">			 
+      <single>location</single>
+      <multiple>locations</multiple>						 
+    </term>
+    <term name="equation">			 
+      <single>equation</single>
+      <multiple>equations</multiple>						 
+    </term>
+    <term name="rule">			 
+      <single>rule</single>
+      <multiple>rules</multiple>						 
+    </term>
+    <term name="scene">			 
+      <single>scene</single>
+      <multiple>scenes</multiple>						 
+    </term>
+    <term name="table">			 
+      <single>table</single>
+      <multiple>tables</multiple>						 
+    </term>
+    <term name="timestamp"> <!-- generally blank -->
+      <single></single>
+      <multiple></multiple>						 
+    </term>
+    <term name="title-locator">			 
+      <single>title</single>
+      <multiple>titles</multiple>						 
+    </term>
+    <term name="book">
+      <single>књига</single>
+      <multiple>књиге</multiple>
+    </term>
+    <term name="chapter">
+      <single>поглавље</single>
+      <multiple>поглавља</multiple>
+    </term>
+    <term name="column">
+      <single>колона</single>
+      <multiple>колоне</multiple>
+    </term>
+    <term name="figure">
+      <single>цртеж</single>
+      <multiple>цртежи</multiple>
+    </term>
+    <term name="folio">
+      <single>фолио</single>
+      <multiple>фолији</multiple>
+    </term>
+    <term name="issue">
+      <single>број</single>
+      <multiple>бројеви</multiple>
+    </term>
+    <term name="line">
+      <single>линија</single>
+      <multiple>линије</multiple>
+    </term>
+    <term name="note">
+      <single>белешка</single>
+      <multiple>белешке</multiple>
+    </term>
+    <term name="opus">
+      <single>опус</single>
+      <multiple>опера</multiple>
+    </term>
+    <term name="page">
+      <single>страница</single>
+      <multiple>странице</multiple>
+    </term>
+    <term name="number-of-pages">
+      <single>страница</single>
+      <multiple>странице</multiple>
+    </term>
+    <term name="paragraph">
+      <single>параграф</single>
+      <multiple>параграфи</multiple>
+    </term>
+    <term name="part">
+      <single>део</single>
+      <multiple>делова</multiple>
+    </term>
+    <term name="section">
+      <single>одељак</single>
+      <multiple>одељака</multiple>
+    </term>
+    <term name="sub-verbo">
+      <single>sub verbo</single>
+      <multiple>sub verbis</multiple>
+    </term>
+    <term name="verse">
+      <single>строфа</single>
+      <multiple>строфе</multiple>
+    </term>
+    <term name="volume">
+      <single>том</single>
+      <multiple>томова</multiple>
+    </term>
+
+    <!-- SHORT LOCATOR FORMS -->
+    <term name="appendix" form="short">			 
+      <single>app.</single>
+      <multiple>apps.</multiple>						 
+    </term>
+    <term name="article-locator" form="short">			 
+      <single>art.</single>
+      <multiple>arts.</multiple>
+    </term>
+    <term name="elocation" form="short">			 
+      <single>loc.</single>
+      <multiple>locs.</multiple>
+    </term>
+    <term name="equation" form="short">			 
+      <single>eq.</single>
+      <multiple>eqs.</multiple>
+    </term>
+    <term name="rule" form="short">			 
+      <single>r.</single>
+      <multiple>rr.</multiple>						 
+    </term>
+    <term name="scene" form="short">			 
+      <single>sc.</single>
+      <multiple>scs.</multiple>						 
+    </term>
+    <term name="table" form="short">			 
+      <single>tbl.</single>
+      <multiple>tbls.</multiple>						 
+    </term>
+    <term name="timestamp" form="short"> <!-- generally blank -->
+      <single></single>
+      <multiple></multiple>						 
+    </term>
+    <term name="title-locator" form="short">			 
+      <single>tit.</single>
+      <multiple>tits.</multiple>
+    </term>
+    <term name="book" form="short">књига</term>
+    <term name="chapter" form="short">Пог.</term>
+    <term name="column" form="short">кол.</term>
+    <term name="figure" form="short">црт.</term>
+    <term name="folio" form="short">фолио</term>
+    <term name="issue" form="short">изд.</term>
+    <term name="line" form="short">l.</term>
+    <term name="note" form="short">n.</term>
+    <term name="opus" form="short">оп.</term>
+    <term name="page" form="short">
+      <single>стр.</single>
+      <multiple>стр.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
+      <single>стр.</single>
+      <multiple>стр.</multiple>
+    </term>
+    <term name="paragraph" form="short">пар.</term>
+    <term name="part" form="short">део</term>
+    <term name="section" form="short">од.</term>
+    <term name="sub-verbo" form="short">
+      <single>s.v.</single>
+      <multiple>s.vv.</multiple>
+    </term>
+    <term name="verse" form="short">
+      <single>стр.</single>
+      <multiple>стр.</multiple>
+    </term>
+    <term name="volume" form="short">
+      <single>том</single>
+      <multiple>томови</multiple>
+    </term>
+
+    <!-- SYMBOL LOCATOR FORMS -->
+    <term name="paragraph" form="symbol">
+      <single>¶</single>
+      <multiple>¶¶</multiple>
+    </term>
+    <term name="section" form="symbol">
+      <single>§</single>
+      <multiple>§§</multiple>
+    </term>
+
+    <!-- LONG ROLE FORMS -->
+    <term name="chair">
+      <single>chair</single>
+      <multiple>chairs</multiple>
+    </term>
+    <term name="compiler">
+      <single>compiler</single>
+      <multiple>compilers</multiple>
+    </term>
+    <term name="contributor">
+      <single>contributor</single>
+      <multiple>contributors</multiple>
+    </term>
+    <term name="curator">
+      <single>curator</single>
+      <multiple>curators</multiple>
+    </term>
+    <term name="executive-producer">
+      <single>executive producer</single>
+      <multiple>executive producers</multiple>
+    </term>
+    <term name="guest">
+      <single>guest</single>
+      <multiple>guests</multiple>
+    </term>
+    <term name="host">
+      <single>host</single>
+      <multiple>hosts</multiple>
+    </term>
+    <term name="narrator">
+      <single>narrator</single>
+      <multiple>narrators</multiple>
+    </term>
+    <term name="organizer">
+      <single>organizer</single>
+      <multiple>organizers</multiple>
+    </term>
+    <term name="performer">
+      <single>performer</single>
+      <multiple>performers</multiple>
+    </term>
+    <term name="producer">
+      <single>producer</single>
+      <multiple>producers</multiple>
+    </term>
+    <term name="script-writer">
+      <single>writer</single>
+      <multiple>writers</multiple>
+    </term>
+    <term name="series-creator">
+      <single>series creator</single>
+      <multiple>series creators</multiple>
+    </term>
+    <term name="director">
+      <single>director</single>
+      <multiple>directors</multiple>
+    </term>
+    <term name="editor">
+      <single>уредник</single>
+      <multiple>урединици</multiple>
+    </term>
+    <term name="editorial-director">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
+    <term name="illustrator">
+      <single>illustrator</single>
+      <multiple>illustrators</multiple>
+    </term>
+    <term name="translator">
+      <single>преводилац</single>
+      <multiple>преводиоци</multiple>
+    </term>
+    <term name="editortranslator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+
+    <!-- SHORT ROLE FORMS -->
+    <term name="compiler" form="short">
+      <single>comp.</single>
+      <multiple>comps.</multiple>
+    </term>
+    <term name="contributor" form="short">
+      <single>contrib.</single>
+      <multiple>contribs.</multiple>
+    </term>
+    <term name="curator" form="short">
+      <single>cur.</single>
+      <multiple>curs.</multiple>
+    </term>
+    <term name="executive-producer" form="short">
+      <single>exec. prod.</single>
+      <multiple>exec. prods.</multiple>
+    </term>
+    <term name="narrator" form="short">
+      <single>narr.</single>
+      <multiple>narrs.</multiple>
+    </term>
+    <term name="organizer" form="short">
+      <single>org.</single>
+      <multiple>orgs.</multiple>
+    </term>
+    <term name="performer" form="short">
+      <single>perf.</single>
+      <multiple>perfs.</multiple>
+    </term>
+    <term name="producer" form="short">
+      <single>prod.</single>
+      <multiple>prods.</multiple>
+    </term>
+    <term name="script-writer" form="short">
+      <single>writ.</single>
+      <multiple>writs.</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <single>cre.</single>
+      <multiple>cres.</multiple>
+    </term>
+    <term name="director" form="short">
+      <single>dir.</single>
+      <multiple>dirs.</multiple>
+    </term>
+    <term name="editor" form="short">
+      <single>ур.</single>
+      <multiple>ур.</multiple>
+    </term>
+    <term name="editorial-director" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="illustrator" form="short">
+      <single>ill.</single>
+      <multiple>ills.</multiple>
+    </term>
+    <term name="translator" form="short">
+      <single>прев.</single>
+      <multiple>прев.</multiple>
+    </term>
+    <term name="editortranslator" form="short">
+      <single>ed. &amp; tran.</single>
+      <multiple>eds. &amp; trans.</multiple>
+    </term>
+
+    <!-- VERB ROLE FORMS -->
+    <term name="chair" form="verb">chaired by</term>
+    <term name="compiler" form="verb">compiled by</term>
+    <term name="contributor" form="verb">with</term>
+    <term name="curator" form="verb">curated by</term>
+    <term name="executive-producer" form="verb">executive produced by</term>
+    <term name="guest" form="verb">with guest</term>
+    <term name="host" form="verb">hosted by</term>
+    <term name="narrator" form="verb">narrated by</term>
+    <term name="organizer" form="verb">organized by</term>
+    <term name="performer" form="verb">performed by</term>
+    <term name="producer" form="verb">produced by</term>
+    <term name="script-writer" form="verb">written by</term>
+    <term name="series-creator" form="verb">created by</term>
+    <term name="container-author" form="verb">by</term>
+    <term name="director" form="verb">directed by</term>
+    <term name="editor" form="verb">уредио</term>
+    <term name="editorial-director" form="verb">edited by</term>
+    <term name="illustrator" form="verb">illustrated by</term>
+    <term name="interviewer" form="verb">интервјуисао</term>
+    <term name="recipient" form="verb">прима</term>
+    <term name="reviewed-author" form="verb">by</term>
+    <term name="translator" form="verb">превео</term>
+    <term name="editortranslator" form="verb">edited &amp; translated by</term>
+
+    <!-- SHORT VERB ROLE FORMS -->
+    <term name="compiler" form="verb-short">comp. by</term>
+    <term name="contributor" form="verb-short">w.</term>
+    <term name="curator" form="verb-short">cur. by</term>
+    <term name="executive-producer" form="verb-short">exec. prod. by</term>
+    <term name="guest" form="verb-short">w. guest</term>
+    <term name="host" form="verb-short">hosted by</term>
+    <term name="narrator" form="verb-short">narr. by</term>
+    <term name="organizer" form="verb-short">org. by</term>
+    <term name="performer" form="verb-short">perf. by</term>
+    <term name="producer" form="verb-short">prod. by</term>
+    <term name="script-writer" form="verb-short">writ. by</term>
+    <term name="series-creator" form="verb-short">cre. by</term>
+    <term name="director" form="verb-short">dir.</term>
+    <term name="editor" form="verb-short">ур.</term>
+    <term name="editorial-director" form="verb-short">ed.</term>
+    <term name="illustrator" form="verb-short">illus.</term>
+    <term name="translator" form="verb-short">прев.</term>
+    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+
+    <!-- LONG MONTH FORMS -->
+    <term name="month-01">Јануар</term>
+    <term name="month-02">Фебруар</term>
+    <term name="month-03">Март</term>
+    <term name="month-04">Април</term>
+    <term name="month-05">Мај</term>
+    <term name="month-06">Јуни</term>
+    <term name="month-07">Јули</term>
+    <term name="month-08">Август</term>
+    <term name="month-09">Септембар</term>
+    <term name="month-10">Октобар</term>
+    <term name="month-11">Новембар</term>
+    <term name="month-12">Децембар</term>
+
+    <!-- SHORT MONTH FORMS -->
+    <term name="month-01" form="short">Јан.</term>
+    <term name="month-02" form="short">Феб.</term>
+    <term name="month-03" form="short">Март</term>
+    <term name="month-04" form="short">Апр.</term>
+    <term name="month-05" form="short">Мај</term>
+    <term name="month-06" form="short">Јуни</term>
+    <term name="month-07" form="short">Јули</term>
+    <term name="month-08" form="short">Авг.</term>
+    <term name="month-09" form="short">Сеп.</term>
+    <term name="month-10" form="short">Окт.</term>
+    <term name="month-11" form="short">Нов.</term>
+    <term name="month-12" form="short">Дец.</term>
+
+    <!-- SEASONS -->
+    <term name="season-01">Spring</term>
+    <term name="season-02">Summer</term>
+    <term name="season-03">Autumn</term>
+    <term name="season-04">Winter</term>
+  </terms>
+</locale>

--- a/locales-sr-Latn-RS.xml
+++ b/locales-sr-Latn-RS.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="sr-RS">
+<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="sr-Latn-RS">
   <info>
+    <translator>
+      <name>Nikola N. Grubor</name>
+      <email>nikola.n.grubor@med.bg.ac.rs</email>
+      <uri>nikola-grubor.github.io/</uri>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>
@@ -18,7 +23,7 @@
   <terms>
     <term name="advance-online-publication">advance online publication</term>
     <term name="album">album</term>
-    <term name="audio-recording">audio recording</term>
+    <term name="audio-recording">audio zapis</term>
     <term name="film">film</term>
     <term name="henceforth">henceforth</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
@@ -29,8 +34,8 @@
     <term name="on">on</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="personal-communication">лична комуникација</term>
-    <term name="podcast">podcast</term>
+    <term name="personal-communication">lična komunikacija</term>
+    <term name="podcast">podkast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
     <term name="radio-broadcast">radio broadcast</term>
@@ -43,51 +48,51 @@
     <term name="television-series-episode">television series episode</term>
     <term name="video">video</term>
     <term name="working-paper">working paper</term>
-    <term name="accessed">приступљено</term>
-    <term name="and">и</term>
-    <term name="and others">и остали</term>
-    <term name="anonymous">анонимна</term>
-    <term name="anonymous" form="short">анон.</term>
-    <term name="at">на</term>
-    <term name="available at">available at</term>
+    <term name="accessed">pristupljeno</term>
+    <term name="and">i</term>
+    <term name="and others">i ostali</term>
+    <term name="anonymous">anonimno</term>
+    <term name="anonymous" form="short">anon.</term>
+    <term name="at">na</term>
+    <term name="available at">dostupno na</term>
     <term name="by">by</term>
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
-    <term name="cited">цитирано</term>
+    <term name="cited">citirano</term>
     <term name="edition">
-      <single>издање</single>
-      <multiple>издања</multiple>
+      <single>izdanje</single>
+      <multiple>izdanja</multiple>
     </term>
-    <term name="edition" form="short">изд.</term>
-    <term name="et-al">и остали</term>
-    <term name="forthcoming">долазећи</term>
-    <term name="from">од</term>
+    <term name="edition" form="short">izd.</term>
+    <term name="et-al">i ostali</term>
+    <term name="forthcoming">dolazeći</term>
+    <term name="from">od</term>
     <term name="ibid">ibid.</term>
-    <term name="in">у</term>
-    <term name="in press">у штампи</term>
-    <term name="internet">Интернет</term>
-    <term name="letter">писмо</term>
-    <term name="no date">no date</term>
-    <term name="no date" form="short">без датума</term>
-    <term name="online">на Интернету</term>
-    <term name="presented at">представљено на</term>
+    <term name="in">u</term>
+    <term name="in press">u štampi</term>
+    <term name="internet">Internet</term>
+    <term name="letter">pismo</term>
+    <term name="no date">bez datuma</term>
+    <term name="no date" form="short">bez datuma</term>
+    <term name="online">na Internetu</term>
+    <term name="presented at">predstavljeno na</term>
     <term name="reference">
-      <single>reference</single>
-      <multiple>references</multiple>
+      <single>referenca</single>
+      <multiple>reference</multiple>
     </term>
     <term name="reference" form="short">
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
-    <term name="retrieved">преузето</term>
-    <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="retrieved">preuzeto</term>
+    <term name="scale">skala</term>
+    <term name="version">verzija</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">preprint</term>
-    <term name="article-journal">journal article</term>
-    <term name="article-magazine">magazine article</term>
-    <term name="article-newspaper">newspaper article</term>
+    <term name="article-journal">članak iz časopisa</term>
+    <term name="article-magazine">članak iz magazina</term>
+    <term name="article-newspaper">novinarski članak</term>
     <term name="bill">bill</term>
     <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
@@ -106,8 +111,8 @@
     <term name="interview">интервју</term>
     <term name="legal_case">legal case</term>
     <term name="legislation">legislation</term>
-    <term name="manuscript">manuscript</term>
-    <term name="map">map</term>
+    <term name="manuscript">rukopis</term>
+    <term name="map">mapa</term>
     <term name="motion_picture">video recording</term>
     <term name="musical_score">musical score</term>
     <term name="pamphlet">pamphlet</term>
@@ -126,9 +131,9 @@
     <term name="song">audio recording</term>
     <term name="speech">presentation</term>
     <term name="standard">standard</term>
-    <term name="thesis">thesis</term>
+    <term name="thesis">teza</term>
     <term name="treaty">treaty</term>
-    <term name="webpage">webpage</term>
+    <term name="webpage">web stranica</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
     <term name="article-journal" form="short">journal art.</term>
@@ -173,16 +178,16 @@
     <term name="ordinal-13">th</term>
 
     <!-- LONG ORDINALS -->
-    <term name="long-ordinal-01">first</term>
-    <term name="long-ordinal-02">second</term>
-    <term name="long-ordinal-03">third</term>
-    <term name="long-ordinal-04">fourth</term>
-    <term name="long-ordinal-05">fifth</term>
-    <term name="long-ordinal-06">sixth</term>
-    <term name="long-ordinal-07">seventh</term>
-    <term name="long-ordinal-08">eighth</term>
-    <term name="long-ordinal-09">ninth</term>
-    <term name="long-ordinal-10">tenth</term>
+    <term name="long-ordinal-01">prvi</term>
+    <term name="long-ordinal-02">drugi</term>
+    <term name="long-ordinal-03">treći</term>
+    <term name="long-ordinal-04">četvrti</term>
+    <term name="long-ordinal-05">peti</term>
+    <term name="long-ordinal-06">šesti</term>
+    <term name="long-ordinal-07">sedmi</term>
+    <term name="long-ordinal-08">osmi</term>
+    <term name="long-ordinal-09">deveti</term>
+    <term name="long-ordinal-10">deseti</term>
 
     <!-- LONG LOCATOR FORMS -->
     <term name="act">			 
@@ -194,8 +199,8 @@
       <multiple>appendices</multiple>						 
     </term>
     <term name="article-locator">			 
-      <single>article</single>
-      <multiple>articles</multiple>						 
+      <single>članak</single>
+      <multiple>članci</multiple>						 
     </term>
     <term name="canon">			 
       <single>canon</single>
@@ -230,72 +235,72 @@
       <multiple>titles</multiple>						 
     </term>
     <term name="book">
-      <single>књига</single>
-      <multiple>књиге</multiple>
+      <single>knjiga</single>
+      <multiple>knjige</multiple>
     </term>
     <term name="chapter">
-      <single>поглавље</single>
-      <multiple>поглавља</multiple>
+      <single>poglavlje</single>
+      <multiple>poglavlja</multiple>
     </term>
     <term name="column">
-      <single>колона</single>
-      <multiple>колоне</multiple>
+      <single>kolona</single>
+      <multiple>kolone</multiple>
     </term>
     <term name="figure">
-      <single>цртеж</single>
-      <multiple>цртежи</multiple>
+      <single>figura</single>
+      <multiple>figure</multiple>
     </term>
     <term name="folio">
-      <single>фолио</single>
-      <multiple>фолији</multiple>
+      <single>folio</single>
+      <multiple>foliji</multiple>
     </term>
     <term name="issue">
-      <single>број</single>
-      <multiple>бројеви</multiple>
+      <single>broj</single>
+      <multiple>brojevi</multiple>
     </term>
     <term name="line">
-      <single>линија</single>
-      <multiple>линије</multiple>
+      <single>linija</single>
+      <multiple>linije</multiple>
     </term>
     <term name="note">
-      <single>белешка</single>
-      <multiple>белешке</multiple>
+      <single>beleška</single>
+      <multiple>beleške</multiple>
     </term>
     <term name="opus">
-      <single>опус</single>
-      <multiple>опера</multiple>
+      <single>opus</single>
+      <multiple>opera</multiple>
     </term>
     <term name="page">
-      <single>страница</single>
-      <multiple>странице</multiple>
+      <single>stranica</single>
+      <multiple>stranice</multiple>
     </term>
     <term name="number-of-pages">
-      <single>страница</single>
-      <multiple>странице</multiple>
+      <single>stranica</single>
+      <multiple>stranice</multiple>
     </term>
     <term name="paragraph">
-      <single>параграф</single>
-      <multiple>параграфи</multiple>
+      <single>paragraf</single>
+      <multiple>paragrafi</multiple>
     </term>
     <term name="part">
-      <single>део</single>
-      <multiple>делова</multiple>
+      <single>deo</single>
+      <multiple>delova</multiple>
     </term>
     <term name="section">
-      <single>одељак</single>
-      <multiple>одељака</multiple>
+      <single>odeljak</single>
+      <multiple>odeljaka</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
     <term name="verse">
-      <single>строфа</single>
-      <multiple>строфе</multiple>
+      <single>strofa</single>
+      <multiple>strofe</multiple>
     </term>
     <term name="volume">
-      <single>том</single>
-      <multiple>томова</multiple>
+      <single>tom</single>
+      <multiple>tomova</multiple>
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
@@ -335,37 +340,37 @@
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>
-    <term name="book" form="short">књига</term>
-    <term name="chapter" form="short">Пог.</term>
-    <term name="column" form="short">кол.</term>
-    <term name="figure" form="short">црт.</term>
-    <term name="folio" form="short">фолио</term>
-    <term name="issue" form="short">изд.</term>
+    <term name="book" form="short">knjiga</term>
+    <term name="chapter" form="short">Pog.</term>
+    <term name="column" form="short">Kol.</term>
+    <term name="figure" form="short">fig.</term>
+    <term name="folio" form="short">folio</term>
+    <term name="issue" form="short">izd.</term>
     <term name="line" form="short">l.</term>
     <term name="note" form="short">n.</term>
-    <term name="opus" form="short">оп.</term>
+    <term name="opus" form="short">op.</term>
     <term name="page" form="short">
-      <single>стр.</single>
-      <multiple>стр.</multiple>
+      <single>str.</single>
+      <multiple>str.</multiple>
     </term>
     <term name="number-of-pages" form="short">
-      <single>стр.</single>
-      <multiple>стр.</multiple>
+      <single>str.</single>
+      <multiple>str.</multiple>
     </term>
-    <term name="paragraph" form="short">пар.</term>
-    <term name="part" form="short">део</term>
-    <term name="section" form="short">од.</term>
+    <term name="paragraph" form="short">par.</term>
+    <term name="part" form="short">deo</term>
+    <term name="section" form="short">od.</term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>
     <term name="verse" form="short">
-      <single>стр.</single>
-      <multiple>стр.</multiple>
+      <single>str.</single>
+      <multiple>str.</multiple>
     </term>
     <term name="volume" form="short">
-      <single>том</single>
-      <multiple>томови</multiple>
+      <single>tom</single>
+      <multiple>tomovi</multiple>
     </term>
 
     <!-- SYMBOL LOCATOR FORMS -->
@@ -436,8 +441,8 @@
       <multiple>directors</multiple>
     </term>
     <term name="editor">
-      <single>уредник</single>
-      <multiple>урединици</multiple>
+      <single>urednik</single>
+      <multiple>urednici</multiple>
     </term>
     <term name="editorial-director">
       <single>editor</single>
@@ -448,8 +453,8 @@
       <multiple>illustrators</multiple>
     </term>
     <term name="translator">
-      <single>преводилац</single>
-      <multiple>преводиоци</multiple>
+      <single>prevodilac</single>
+      <multiple>prevodioci</multiple>
     </term>
     <term name="editortranslator">
       <single>editor &amp; translator</single>
@@ -462,8 +467,8 @@
       <multiple>comps.</multiple>
     </term>
     <term name="contributor" form="short">
-      <single>contrib.</single>
-      <multiple>contribs.</multiple>
+      <single>sarad.</single>
+      <multiple>sarad.</multiple>
     </term>
     <term name="curator" form="short">
       <single>cur.</single>
@@ -502,8 +507,8 @@
       <multiple>dirs.</multiple>
     </term>
     <term name="editor" form="short">
-      <single>ур.</single>
-      <multiple>ур.</multiple>
+      <single>ur.</single>
+      <multiple>ur.</multiple>
     </term>
     <term name="editorial-director" form="short">
       <single>ed.</single>
@@ -514,8 +519,8 @@
       <multiple>ills.</multiple>
     </term>
     <term name="translator" form="short">
-      <single>прев.</single>
-      <multiple>прев.</multiple>
+      <single>prev.</single>
+      <multiple>prev.</multiple>
     </term>
     <term name="editortranslator" form="short">
       <single>ed. &amp; tran.</single>
@@ -538,13 +543,13 @@
     <term name="series-creator" form="verb">created by</term>
     <term name="container-author" form="verb">by</term>
     <term name="director" form="verb">directed by</term>
-    <term name="editor" form="verb">уредио</term>
+    <term name="editor" form="verb">uredio</term>
     <term name="editorial-director" form="verb">edited by</term>
     <term name="illustrator" form="verb">illustrated by</term>
-    <term name="interviewer" form="verb">интервјуисао</term>
-    <term name="recipient" form="verb">прима</term>
+    <term name="interviewer" form="verb">intervjuisao</term>
+    <term name="recipient" form="verb">prima</term>
     <term name="reviewed-author" form="verb">by</term>
-    <term name="translator" form="verb">превео</term>
+    <term name="translator" form="verb">preveo</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
@@ -561,44 +566,44 @@
     <term name="script-writer" form="verb-short">writ. by</term>
     <term name="series-creator" form="verb-short">cre. by</term>
     <term name="director" form="verb-short">dir.</term>
-    <term name="editor" form="verb-short">ур.</term>
+    <term name="editor" form="verb-short">ur.</term>
     <term name="editorial-director" form="verb-short">ed.</term>
     <term name="illustrator" form="verb-short">illus.</term>
-    <term name="translator" form="verb-short">прев.</term>
+    <term name="translator" form="verb-short">prev.</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
 
     <!-- LONG MONTH FORMS -->
-    <term name="month-01">Јануар</term>
-    <term name="month-02">Фебруар</term>
-    <term name="month-03">Март</term>
-    <term name="month-04">Април</term>
-    <term name="month-05">Мај</term>
-    <term name="month-06">Јуни</term>
-    <term name="month-07">Јули</term>
-    <term name="month-08">Август</term>
-    <term name="month-09">Септембар</term>
-    <term name="month-10">Октобар</term>
-    <term name="month-11">Новембар</term>
-    <term name="month-12">Децембар</term>
+    <term name="month-01">Januar</term>
+    <term name="month-02">Februar</term>
+    <term name="month-03">Mart</term>
+    <term name="month-04">April</term>
+    <term name="month-05">Maj</term>
+    <term name="month-06">Juni</term>
+    <term name="month-07">Juli</term>
+    <term name="month-08">Avgust</term>
+    <term name="month-09">Septembar</term>
+    <term name="month-10">Oktobar</term>
+    <term name="month-11">Novembar</term>
+    <term name="month-12">Decembar</term>
 
     <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">Јан.</term>
-    <term name="month-02" form="short">Феб.</term>
+    <term name="month-01" form="short">Jan.</term>
+    <term name="month-02" form="short">Feb.</term>
     <term name="month-03" form="short">Март</term>
     <term name="month-04" form="short">Апр.</term>
-    <term name="month-05" form="short">Мај</term>
-    <term name="month-06" form="short">Јуни</term>
-    <term name="month-07" form="short">Јули</term>
-    <term name="month-08" form="short">Авг.</term>
-    <term name="month-09" form="short">Сеп.</term>
-    <term name="month-10" form="short">Окт.</term>
-    <term name="month-11" form="short">Нов.</term>
-    <term name="month-12" form="short">Дец.</term>
+    <term name="month-05" form="short">Maj</term>
+    <term name="month-06" form="short">Juni</term>
+    <term name="month-07" form="short">Juli</term>
+    <term name="month-08" form="short">Avg.</term>
+    <term name="month-09" form="short">Sep.</term>
+    <term name="month-10" form="short">Okt.</term>
+    <term name="month-11" form="short">Nov.</term>
+    <term name="month-12" form="short">Dec.</term>
 
     <!-- SEASONS -->
-    <term name="season-01">Spring</term>
-    <term name="season-02">Summer</term>
-    <term name="season-03">Autumn</term>
-    <term name="season-04">Winter</term>
+    <term name="season-01">Proleće</term>
+    <term name="season-02">Leto</term>
+    <term name="season-03">Jesen</term>
+    <term name="season-04">Zima</term>
   </terms>
 </locale>

--- a/locales-sr-Latn-RS.xml
+++ b/locales-sr-Latn-RS.xml
@@ -589,8 +589,8 @@
     <!-- SHORT MONTH FORMS -->
     <term name="month-01" form="short">Jan.</term>
     <term name="month-02" form="short">Feb.</term>
-    <term name="month-03" form="short">Март</term>
-    <term name="month-04" form="short">Апр.</term>
+    <term name="month-03" form="short">Mart</term>
+    <term name="month-04" form="short">Apr.</term>
     <term name="month-05" form="short">Maj</term>
     <term name="month-06" form="short">Juni</term>
     <term name="month-07" form="short">Juli</term>


### PR DESCRIPTION
### Description

As Serbian has two official scripts, the Latin script being used for scientific writing, I propose changing "sr-RS" (which was in Cyrillic) to "sr-Cyrl-RS" as per BCP 47.

I have also partially translated the existing "sr-RS" locale file into its Latin script equivalent ("sr-Latn-RS").

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
