### PR TITLE
Add verb form of term "hearing"

### DIFF
--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -162,6 +162,10 @@
     <term name="review-book" form="short">bk. rev.</term>
     <term name="song" form="short">audio rec.</term>
 
+    <!-- VERB ITEM TYPE FORMS -->
+    <!-- Only where applicable -->
+    <term name="hearing" form="verb">testimony of</term>
+
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">AD</term>
     <term name="bc">BC</term>


### PR DESCRIPTION
@adam3smith What do you think of this?

"hearing" is an item type term rather than a role term, but it makes sense to me to use the verb form of the term to refer to the author/giver of testimony at the hearing

This would be used for localizing phrasing like `(testimony of <author>)`