### PR TITLE
Update Japanese Localization

### DIFF
--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -8,7 +8,7 @@
       <name>cmplstofB</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2023-09-21T23:31:02+00:00</updated>
+    <updated>2023-09-29T09:30:00+09:00</updated>
     <!--
       日本語化にあたって参考にした文献
       * SIST 02:2007「参照文献の書き方」
@@ -27,33 +27,34 @@
     <date-part name="day" suffix="日"/>
   </date>
   <terms>
-    <term name="advance-online-publication">advance online publication</term>
-    <term name="album">album</term>
-    <term name="audio-recording">audio recording</term>
-    <term name="film">film</term>
-    <term name="henceforth">henceforth</term>
-    <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
-    <term name="no-place">no place</term>
-    <term name="no-place" form="short">n.p.</term>
-    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
-    <term name="no-publisher" form="short">n.p.</term>
-    <term name="on">on</term>
-    <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <!-- cf: https://www.jstage.jst.go.jp/static/pages/advance_online_publication/-char/ja -->
+    <term name="advance-online-publication">早期公開</term>
+    <term name="album">アルバム</term>
+    <term name="audio-recording">音声録音</term>
+    <term name="film">映像作品</term>
+    <term name="henceforth">現在より</term>
+    <term name="loc-cit">同頁</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="no-place">所在不詳</term>
+    <term name="no-place" form="short">所在不詳</term>
+    <term name="no-publisher">作者不詳</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">作者不詳</term>
+    <term name="on">において</term>
+    <term name="op-cit">同前</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="personal-communication">個人的なやり取り</term>
-    <term name="podcast">podcast</term>
-    <term name="podcast-episode">podcast episode</term>
-    <term name="preprint">preprint</term>
-    <term name="radio-broadcast">radio broadcast</term>
-    <term name="radio-series">radio series</term>
-    <term name="radio-series-episode">radio series episode</term>
-    <term name="special-issue">special issue</term>
-    <term name="special-section">special section</term>
-    <term name="television-broadcast">television broadcast</term>
-    <term name="television-series">television series</term>
-    <term name="television-series-episode">television series episode</term>
-    <term name="video">video</term>
-    <term name="working-paper">working paper</term>
+    <term name="personal-communication">個人間疎通</term>
+    <term name="podcast">音声配信</term>
+    <term name="podcast-episode">音声配信の一話</term>
+    <term name="preprint">査読前原稿</term>
+    <term name="radio-broadcast">ラジオ配信</term>
+    <term name="radio-series">ラジオ番組</term>
+    <term name="radio-series-episode">ラジオ番組の一話</term>
+    <term name="special-issue">特別号</term>
+    <term name="special-section">特別節</term>
+    <term name="television-broadcast">テレビ放送</term>
+    <term name="television-series">テレビ番組</term>
+    <term name="television-series-episode">テレビ番組の一話</term>
+    <term name="video">動画</term>
+    <term name="working-paper">報告書</term>
     <term name="accessed">参照</term>
     <term name="and">と</term>
     <term name="and others">ほか</term>
@@ -65,10 +66,7 @@
     <term name="circa">およそ</term>
     <term name="circa" form="short">およそ</term>
     <term name="cited">引用</term>
-    <term name="edition">
-      <single>版</single>
-      <multiple>版</multiple>
-    </term>
+    <term name="edition">版</term>
     <term name="edition" form="short">版</term>
     <term name="et-al">ほか</term>
     <term name="forthcoming">近刊</term>
@@ -80,89 +78,83 @@
     <term name="letter">手紙</term>
     <term name="no date">日付なし</term>
     <term name="no date" form="short">日付なし</term>
-    <term name="online">online</term>
-    <term name="presented at">presented at the</term>
-    <term name="reference">
-      <single>参照</single>
-      <multiple>参照</multiple>
-    </term>
-    <term name="reference" form="short">
-      <single>参照</single>
-      <multiple>参照</multiple>
-    </term>
-    <term name="retrieved">読み込み</term>
+    <term name="online">オンライン</term>
+    <term name="presented at">講演場所</term>
+    <term name="reference">参照</term>
+    <term name="reference" form="short">参照</term>
+    <term name="retrieved">回収</term>
     <term name="scale">位</term>
     <term name="version">版</term>
 
     <!-- LONG ITEM TYPE FORMS -->
-    <term name="article">preprint</term>
-    <term name="article-journal">journal article</term>
-    <term name="article-magazine">magazine article</term>
-    <term name="article-newspaper">newspaper article</term>
-    <term name="bill">bill</term>
+    <term name="article">記事</term>
+    <term name="article-journal">学術論文</term>
+    <term name="article-magazine">雑誌記事</term>
+    <term name="article-newspaper">報道記事</term>
+    <term name="bill">証書</term>
     <!-- book is in the list of locator terms -->
-    <term name="broadcast">broadcast</term>
+    <term name="broadcast">配信</term>
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">classic</term>
-    <term name="collection">collection</term>
-    <term name="dataset">dataset</term>
-    <term name="document">document</term>
-    <term name="entry">entry</term>
-    <term name="entry-dictionary">dictionary entry</term>
-    <term name="entry-encyclopedia">encyclopedia entry</term>
-    <term name="event">event</term>
+    <term name="classic">古典</term>
+    <term name="collection">集体</term>
+    <term name="dataset">データ集合</term>
+    <term name="document">文書</term>
+    <term name="entry">見出し語</term>
+    <term name="entry-dictionary">辞書の見出し語</term>
+    <term name="entry-encyclopedia">辞典の見出し語</term>
+    <term name="event">催し</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic">graphic</term>
-    <term name="hearing">hearing</term>
+    <term name="graphic">視覚的</term>
+    <term name="hearing">聴覚的</term>
     <term name="interview">面接</term>
-    <term name="legal_case">legal case</term>
-    <term name="legislation">legislation</term>
-    <term name="manuscript">manuscript</term>
-    <term name="map">map</term>
-    <term name="motion_picture">video recording</term>
-    <term name="musical_score">musical score</term>
-    <term name="pamphlet">pamphlet</term>
-    <term name="paper-conference">conference paper</term>
-    <term name="patent">patent</term>
-    <term name="performance">performance</term>
-    <term name="periodical">periodical</term>
-    <term name="personal_communication">個人的なやり取り</term>
-    <term name="post">post</term>
-    <term name="post-weblog">blog post</term>
-    <term name="regulation">regulation</term>
-    <term name="report">report</term>
-    <term name="review">review</term>
-    <term name="review-book">book review</term>
-    <term name="software">software</term>
-    <term name="song">audio recording</term>
-    <term name="speech">presentation</term>
-    <term name="standard">standard</term>
-    <term name="thesis">thesis</term>
-    <term name="treaty">treaty</term>
-    <term name="webpage">webpage</term>
+    <term name="legal_case">裁判事例</term>
+    <term name="legislation">法律</term>
+    <term name="manuscript">写本</term>
+    <term name="map">地図</term>
+    <term name="motion_picture">映像記録</term>
+    <term name="musical_score">楽譜</term>
+    <term name="pamphlet">小冊子</term>
+    <term name="paper-conference">会議論文</term>
+    <term name="patent">特許</term>
+    <term name="performance">実演</term>
+    <term name="periodical">定期刊行物</term>
+    <term name="personal_communication">個人間疎通</term>
+    <term name="post">投稿</term>
+    <term name="post-weblog">ブログ投稿</term>
+    <term name="regulation">規則</term>
+    <term name="report">報告書</term>
+    <term name="review">論評</term>
+    <term name="review-book">書評</term>
+    <term name="software">ソフトウェア</term>
+    <term name="song">音声記録</term>
+    <term name="speech">講演</term>
+    <term name="standard">標準</term>
+    <term name="thesis">定立</term>
+    <term name="treaty">条約</term>
+    <term name="webpage">Webページ</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <term name="article-journal" form="short">journal art.</term>
-    <term name="article-magazine" form="short">mag. art.</term>
-    <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="article-journal" form="short">学術論文</term>
+    <term name="article-magazine" form="short">雑誌記事</term>
+    <term name="article-newspaper" form="short">報道記事</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="document" form="short">doc.</term>
+    <term name="document" form="short">文書</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graph.</term>
+    <term name="graphic" form="short">視覚的</term>
     <term name="interview">面接</term>
-    <term name="manuscript" form="short">MS</term>
-    <term name="motion_picture" form="short">video rec.</term>
-    <term name="report" form="short">rep.</term>
-    <term name="review" form="short">rev.</term>
-    <term name="review-book" form="short">bk. rev.</term>
-    <term name="song" form="short">audio rec.</term>
+    <term name="manuscript" form="short">写本</term>
+    <term name="motion_picture" form="short">映像記録</term>
+    <term name="report" form="short">報告書</term>
+    <term name="review" form="short">論評</term>
+    <term name="review-book" form="short">書評</term>
+    <term name="song" form="short">音声記録</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">紀元前</term>
     <term name="bc">紀元後</term>
-    <term name="bce">BCE</term>
-    <term name="ce">CE</term>
+    <term name="bce">通用紀元前</term>
+    <term name="ce">通用紀元</term>
 
     <!-- PUNCTUATION -->
     <term name="open-quote">「</term>
@@ -196,192 +188,72 @@
     <term name="long-ordinal-10">10番目</term>
 
     <!-- LONG LOCATOR FORMS -->
-    <term name="act">			 
-      <single>act</single>
-      <multiple>acts</multiple>						 
-    </term>
-    <term name="appendix">			 
-      <single>appendix</single>
-      <multiple>appendices</multiple>						 
-    </term>
-    <term name="article-locator">			 
-      <single>article</single>
-      <multiple>articles</multiple>						 
-    </term>
-    <term name="canon">			 
-      <single>canon</single>
-      <multiple>canons</multiple>						 
-    </term>
-    <term name="elocation">			 
-      <single>location</single>
-      <multiple>locations</multiple>						 
-    </term>
-    <term name="equation">			 
-      <single>equation</single>
-      <multiple>equations</multiple>						 
-    </term>
-    <term name="rule">			 
-      <single>rule</single>
-      <multiple>rules</multiple>						 
-    </term>
-    <term name="scene">			 
-      <single>scene</single>
-      <multiple>scenes</multiple>						 
-    </term>
-    <term name="table">			 
-      <single>table</single>
-      <multiple>tables</multiple>						 
-    </term>
-    <term name="timestamp"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
-    </term>
-    <term name="title-locator">			 
-      <single>title</single>
-      <multiple>titles</multiple>						 
-    </term>
-    <term name="book">
-      <single>書籍</single>
-      <multiple>書籍</multiple>
-    </term>
-    <term name="chapter">
-      <single>章</single>
-      <multiple>章</multiple>
-    </term>
-    <term name="column">
-      <single>欄</single>
-      <multiple>欄</multiple>
-    </term>
-    <term name="figure">
-      <single>図</single>
-      <multiple>図</multiple>
-    </term>
-    <term name="folio">
-      <single>面</single>
-      <multiple>面</multiple>
-    </term>
-    <term name="issue">
-      <single>号</single>
-      <multiple>号</multiple>
-    </term>
-    <term name="line">
-      <single>行</single>
-      <multiple>行</multiple>
-    </term>
-    <term name="note">
-      <single>註</single>
-      <multiple>註</multiple>
-    </term>
-    <term name="opus">
-      <single>作品</single>
-      <multiple>作品</multiple>
-    </term>
-    <term name="page">
-      <single>ページ</single>
-      <multiple>ページ</multiple>
-    </term>
-    <term name="number-of-pages">
-      <single>ページ</single>
-      <multiple>ページ</multiple>
-    </term>
-    <term name="paragraph">
-      <single>段落</single>
-      <multiple>段落</multiple>
-    </term>
-    <term name="part">
-      <single>部</single>
-      <multiple>部</multiple>
-    </term>
-    <term name="section">
-      <single>節</single>
-      <multiple>節</multiple>
-    </term>
-    <term name="sub-verbo">
-      <!--
-        『辞書』における「単語」
-                ^^^^^^^^
-      -->
-      <single>における</single>
-      <multiple>における</multiple>
-    </term>
-    <term name="verse">
-      <single>詩歌</single>
-      <multiple>詩歌</multiple>
-    </term>
-    <term name="volume">
-      <single>巻</single>
-      <multiple>巻</multiple>
-    </term>
+    <term name="act">幕</term>
+    <term name="appendix">附録</term>
+    <term name="article-locator">記事</term>
+    <term name="book">書籍</term>
+    <term name="canon">規範</term>
+    <term name="chapter">章</term>
+    <term name="column">欄</term>
+    <term name="elocation">場所</term>
+    <term name="equation">式</term>
+    <term name="figure">図</term>
+    <term name="folio">面</term>
+    <term name="issue">号</term>
+    <term name="line">行</term>
+    <term name="note">註</term>
+    <term name="number-of-pages">ページ</term>
+    <term name="opus">作品</term>
+    <term name="page">ページ</term>
+    <term name="paragraph">段落</term>
+    <term name="part">部</term>
+    <term name="rule">規則</term>
+    <!-- sub-verbo:
+      『辞書』における「単語」
+              ^^^^^^^^
+    -->
+    <term name="sub-verbo">における</term>
+    <term name="scene">舞台</term>
+    <term name="section">節</term>
+    <term name="table">表</term>
+    <term name="timestamp"></term> <!-- generally blank -->
+    <term name="title-locator">題名</term>
+    <term name="verse">詩歌</term>
+    <term name="volume">巻</term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix" form="short">			 
-      <single>app.</single>
-      <multiple>apps.</multiple>						 
-    </term>
-    <term name="article-locator" form="short">			 
-      <single>art.</single>
-      <multiple>arts.</multiple>
-    </term>
-    <term name="elocation" form="short">			 
-      <single>loc.</single>
-      <multiple>locs.</multiple>
-    </term>
-    <term name="equation" form="short">			 
-      <single>eq.</single>
-      <multiple>eqs.</multiple>
-    </term>
-    <term name="rule" form="short">			 
-      <single>r.</single>
-      <multiple>rr.</multiple>						 
-    </term>
-    <term name="scene" form="short">			 
-      <single>sc.</single>
-      <multiple>scs.</multiple>						 
-    </term>
-    <term name="table" form="short">			 
-      <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
-    </term>
-    <term name="timestamp" form="short"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
-    </term>
-    <term name="title-locator" form="short">			 
-      <single>tit.</single>
-      <multiple>tits.</multiple>
-    </term>
-    <term name="book" form="short">bk.</term>
-    <term name="chapter" form="short">chap.</term>
-    <term name="column" form="short">col.</term>
-    <term name="figure" form="short">fig.</term>
-    <term name="folio" form="short">f.</term>
-    <term name="issue" form="short">no.</term>
-    <term name="line" form="short">l.</term>
-    <term name="note" form="short">n.</term>
-    <term name="opus" form="short">op.</term>
-    <term name="page" form="short">
-      <single>p.</single>
-      <multiple>pp.</multiple>
-    </term>
-    <term name="number-of-pages" form="short">
-      <single>p.</single>
-      <multiple>pp.</multiple>
-    </term>
-    <term name="paragraph" form="short">para.</term>
-    <term name="part" form="short">pt.</term>
-    <term name="section" form="short">sec.</term>
-    <term name="sub-verbo" form="short">
-      <single>s.v.</single>
-      <multiple>s.vv.</multiple>
-    </term>
-    <term name="verse" form="short">
-      <single>v.</single>
-      <multiple>vv.</multiple>
-    </term>
-    <term name="volume" form="short">
-      <single>vol.</single>
-      <multiple>vols.</multiple>
-    </term>
+    <term name="act" form="short">幕</term>
+    <term name="appendix" form="short">附録</term>
+    <term name="article-locator" form="short">記事</term>
+    <term name="book" form="short">書籍</term>
+    <term name="canon" form="short">規範</term>
+    <term name="chapter" form="short">章</term>
+    <term name="column" form="short">欄</term>
+    <term name="elocation" form="short">場所</term>
+    <term name="equation" form="short">式</term>
+    <term name="figure" form="short">図</term>
+    <term name="folio" form="short">面</term>
+    <term name="issue" form="short">号</term>
+    <term name="line" form="short">行</term>
+    <term name="note" form="short">註</term>
+    <term name="number-of-pages" form="short">ページ</term>
+    <term name="opus" form="short">作品</term>
+    <term name="page" form="short">ページ</term>
+    <term name="paragraph" form="short">段落</term>
+    <term name="part" form="short">部</term>
+    <term name="rule" form="short">規則</term>
+    <term name="scene" form="short">舞台</term>
+    <term name="section" form="short">節</term>
+    <!-- sub-verbo:
+      『辞書』における「単語」
+              ^^^^^^^^
+    -->
+    <term name="sub-verbo" form="short">における</term>
+    <term name="table" form="short">表</term>
+    <term name="timestamp" form="short"></term> <!-- generally blank -->
+    <term name="title-locator" form="short">題名</term>
+    <term name="verse" form="short">詩歌</term>
+    <term name="volume" form="short">巻</term>
 
     <!-- SYMBOL LOCATOR FORMS -->
     <term name="paragraph" form="symbol">
@@ -394,163 +266,58 @@
     </term>
 
     <!-- LONG ROLE FORMS -->
-    <term name="chair">
-      <single>chair</single>
-      <multiple>chairs</multiple>
-    </term>
-    <term name="compiler">
-      <single>compiler</single>
-      <multiple>compilers</multiple>
-    </term>
-    <term name="contributor">
-      <single>contributor</single>
-      <multiple>contributors</multiple>
-    </term>
-    <term name="curator">
-      <single>curator</single>
-      <multiple>curators</multiple>
-    </term>
-    <term name="executive-producer">
-      <single>executive producer</single>
-      <multiple>executive producers</multiple>
-    </term>
-    <term name="guest">
-      <single>guest</single>
-      <multiple>guests</multiple>
-    </term>
-    <term name="host">
-      <single>host</single>
-      <multiple>hosts</multiple>
-    </term>
-    <term name="narrator">
-      <single>narrator</single>
-      <multiple>narrators</multiple>
-    </term>
-    <term name="organizer">
-      <single>organizer</single>
-      <multiple>organizers</multiple>
-    </term>
-    <term name="performer">
-      <single>performer</single>
-      <multiple>performers</multiple>
-    </term>
-    <term name="producer">
-      <single>producer</single>
-      <multiple>producers</multiple>
-    </term>
-    <term name="script-writer">
-      <single>writer</single>
-      <multiple>writers</multiple>
-    </term>
-    <term name="series-creator">
-      <single>series creator</single>
-      <multiple>series creators</multiple>
-    </term>
-    <term name="director">
-      <single>指導者</single>
-      <multiple>指導者</multiple>
-    </term>
-    <term name="editor">
-      <single>編集者</single>
-      <multiple>編集者</multiple>
-    </term>
-    <term name="editorial-director">
-      <single>編集者</single>
-      <multiple>編集者</multiple>
-    </term>
-    <term name="illustrator">
-      <single>図解者</single>
-      <multiple>図解者</multiple>
-    </term>
-    <term name="translator">
-      <single>翻訳者</single>
-      <multiple>翻訳者</multiple>
-    </term>
-    <term name="editortranslator">
-      <single>編集・翻訳者</single>
-      <multiple>編集・翻訳者</multiple>
-    </term>
+    <term name="chair">議長</term>
+    <term name="compiler">編纂者</term>
+    <term name="contributor">協力者</term>
+    <term name="curator">管理者</term>
+    <term name="executive-producer">制作総指揮者</term>
+    <term name="guest">特別出演者</term>
+    <term name="host">主催者</term>
+    <term name="narrator">語り手</term>
+    <term name="organizer">組織者</term>
+    <term name="performer">演者</term>
+    <term name="producer">指揮者</term>
+    <term name="script-writer">執筆者</term>
+    <term name="series-creator">番組制作者</term>
+    <term name="director">指導者</term>
+    <term name="editor">編集者</term>
+    <term name="editorial-director">編集・指導者</term>
+    <term name="illustrator">図解者</term>
+    <term name="translator">翻訳者</term>
+    <term name="editortranslator">編集・翻訳者</term>
 
     <!-- SHORT ROLE FORMS -->
-    <term name="compiler" form="short">
-      <single>comp.</single>
-      <multiple>comps.</multiple>
-    </term>
-    <term name="contributor" form="short">
-      <single>contrib.</single>
-      <multiple>contribs.</multiple>
-    </term>
-    <term name="curator" form="short">
-      <single>cur.</single>
-      <multiple>curs.</multiple>
-    </term>
-    <term name="executive-producer" form="short">
-      <single>exec. prod.</single>
-      <multiple>exec. prods.</multiple>
-    </term>
-    <term name="narrator" form="short">
-      <single>narr.</single>
-      <multiple>narrs.</multiple>
-    </term>
-    <term name="organizer" form="short">
-      <single>org.</single>
-      <multiple>orgs.</multiple>
-    </term>
-    <term name="performer" form="short">
-      <single>perf.</single>
-      <multiple>perfs.</multiple>
-    </term>
-    <term name="producer" form="short">
-      <single>prod.</single>
-      <multiple>prods.</multiple>
-    </term>
-    <term name="script-writer" form="short">
-      <single>writ.</single>
-      <multiple>writs.</multiple>
-    </term>
-    <term name="series-creator" form="short">
-      <single>cre.</single>
-      <multiple>cres.</multiple>
-    </term>
-    <term name="director" form="short">
-      <single>指導</single>
-      <multiple>指導</multiple>
-    </term>
-    <term name="editor" form="short">
-      <single>編</single>
-      <multiple>編</multiple>
-    </term>
-    <term name="editorial-director" form="short">
-      <single>編</single>
-      <multiple>編</multiple>
-    </term>
-    <term name="illustrator" form="short">
-      <single>図</single>
-      <multiple>図</multiple>
-    </term>
-    <term name="translator" form="short">
-      <single>訳</single>
-      <multiple>訳</multiple>
-    </term>
-    <term name="editortranslator" form="short">
-      <single>編・訳</single>
-      <multiple>編・訳</multiple>
-    </term>
+    <term name="compiler" form="short">纂</term>
+    <term name="contributor" form="short">協力</term>
+    <term name="curator" form="short">管理</term>
+    <term name="executive-producer" form="short">総指揮</term>
+    <term name="narrator" form="short">語り</term>
+    <term name="organizer" form="short">組織</term>
+    <term name="performer" form="short">演</term>
+    <term name="producer" form="short">指揮</term>
+    <term name="script-writer" form="short">執筆</term>
+    <term name="series-creator" form="short">番組制作</term>
+    <term name="director" form="short">指導</term>
+    <term name="editor" form="short">編</term>
+    <term name="editorial-director" form="short">編・指導</term>
+    <term name="illustrator" form="short">図解</term>
+    <term name="translator" form="short">訳</term>
+    <term name="editortranslator" form="short">編・訳</term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="chair" form="verb">chaired by</term>
-    <term name="compiler" form="verb">compiled by</term>
-    <term name="contributor" form="verb">with</term>
-    <term name="curator" form="verb">curated by</term>
-    <term name="executive-producer" form="verb">executive produced by</term>
-    <term name="guest" form="verb">with guest</term>
-    <term name="host" form="verb">hosted by</term>
-    <term name="narrator" form="verb">narrated by</term>
-    <term name="organizer" form="verb">organized by</term>
-    <term name="performer" form="verb">performed by</term>
-    <term name="producer" form="verb">produced by</term>
-    <term name="script-writer" form="verb">written by</term>
-    <term name="series-creator" form="verb">created by</term>
+    <term name="chair" form="verb">議長: </term>
+    <term name="compiler" form="verb">編纂者: </term>
+    <term name="contributor" form="verb">協力者: </term>
+    <term name="curator" form="verb">蒐集者: </term>
+    <term name="executive-producer" form="verb">制作総指揮者: </term>
+    <term name="guest" form="verb">特別出演者: </term>
+    <term name="host" form="verb">主催者: </term>
+    <term name="narrator" form="verb">語り手: </term>
+    <term name="organizer" form="verb">組織者: </term>
+    <term name="performer" form="verb">演者: </term>
+    <term name="producer" form="verb">指揮者: </term>
+    <term name="script-writer" form="verb">執筆者: </term>
+    <term name="series-creator" form="verb">番組作成者: </term>
     <term name="container-author" form="verb">作者: </term>
     <term name="director" form="verb">指導者: </term>
     <term name="editor" form="verb">編集者: </term>
@@ -562,19 +329,20 @@
     <term name="translator" form="verb">翻訳者: </term>
     <term name="editortranslator" form="verb">編集・翻訳者: </term>
 
+
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="compiler" form="verb-short">comp. by</term>
-    <term name="contributor" form="verb-short">w.</term>
-    <term name="curator" form="verb-short">cur. by</term>
-    <term name="executive-producer" form="verb-short">exec. prod. by</term>
-    <term name="guest" form="verb-short">w. guest</term>
-    <term name="host" form="verb-short">hosted by</term>
-    <term name="narrator" form="verb-short">narr. by</term>
-    <term name="organizer" form="verb-short">org. by</term>
-    <term name="performer" form="verb-short">perf. by</term>
-    <term name="producer" form="verb-short">prod. by</term>
-    <term name="script-writer" form="verb-short">writ. by</term>
-    <term name="series-creator" form="verb-short">cre. by</term>
+    <term name="compiler" form="verb-short">纂: </term>
+    <term name="contributor" form="verb-short">協力: </term>
+    <term name="curator" form="verb-short">管理: </term>
+    <term name="executive-producer" form="verb-short">総指揮: </term>
+    <term name="guest" form="verb-short">特別出演: </term>
+    <term name="host" form="verb-short">主催: </term>
+    <term name="narrator" form="verb-short">語り: </term>
+    <term name="organizer" form="verb-short">組織: </term>
+    <term name="performer" form="verb-short">演: </term>
+    <term name="producer" form="verb-short">指揮: </term>
+    <term name="script-writer" form="verb-short">執筆: </term>
+    <term name="series-creator" form="verb-short">番組制作: </term>
     <term name="director" form="verb-short">指導: </term>
     <term name="editor" form="verb-short">編: </term>
     <term name="editorial-director" form="verb-short">編: </term>


### PR DESCRIPTION
### Description

Update Japanese localization file (locales-ja-JP.xml)

- Follow CSL 1.0.2 (issue #246)
- Remove unnecessary plural form definitions. (In Japanese, it is almost always singular and plural isomorphic)
- Solve issue #237 (line 304)

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
