### PR TITLE
Add missing terms to en-US and alphabetize

### DIFF
--- a/locales-af-ZA.xml
+++ b/locales-af-ZA.xml
@@ -54,9 +54,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edition</single>
       <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">et al.</term>
@@ -79,6 +95,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">opgehaal</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -269,6 +287,31 @@
       <single>bladsy</single>
       <multiple>bladsye</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>bladsy</single>
       <multiple>bladsye</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>bl</single>
       <multiple>bll</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>bl</single>
       <multiple>bll</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">sec</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">vertaal deur</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-ar.xml
+++ b/locales-ar.xml
@@ -60,9 +60,25 @@
     <term name="circa">حوالي</term>
     <term name="circa" form="short">حوالي</term>
     <term name="cited">وثق</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>الطبعة</single>
       <multiple>الطبعات</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ط</term>
     <term name="et-al">وآخرون</term>
@@ -85,6 +101,8 @@
       <single>مرجع</single>
       <multiple>مراجع</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">استرجع في</term>
     <term name="scale">السلم الموسيقي</term>
     <term name="version">إصدار</term>
@@ -269,6 +287,31 @@
       <single>صفحة</single>
       <multiple>صفحات</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>صفحة</single>
       <multiple>صفحات</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>قسم</single>
       <multiple>أقسام</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>تفسير فرعي</single>
@@ -348,6 +395,20 @@
       <single>ص</single>
       <multiple>ص</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>ص</single>
       <multiple>ص</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">فقرة</term>
     <term name="part" form="short">ج</term>
     <term name="section" form="short">قسم</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>تفسير فرعي</single>
       <multiple>تفسيرات فرعية</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -481,6 +562,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -502,6 +584,7 @@
     <term name="interviewer" form="verb">مقابلة مع</term>
     <term name="recipient" form="verb">المستلم</term>
     <term name="reviewed-author" form="verb">مراجعة</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">ترجمة</term>
     <term name="editortranslator" form="verb">تحقيق وترجمة</term>
 

--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -59,9 +59,25 @@
     <term name="circa">около</term>
     <term name="circa" form="short">ок.</term>
     <term name="cited">цитиран</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>издание</single>
       <multiple>издания</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">изд.</term>
     <term name="et-al">и съавт.</term>
@@ -84,6 +100,8 @@
       <single>изт.</single>
       <multiple>изт.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">изтеглен на</term>
     <term name="scale">скала</term>
     <term name="version">версия</term>
@@ -308,6 +326,31 @@
       <single>страница</single>
       <multiple>страници</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">брой страници</term>
     <term name="paragraph">
       <single>абзац</single>
@@ -320,6 +363,10 @@
     <term name="section">
       <single>раздел</single>
       <multiple>раздели</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>под раздел</single>
@@ -381,10 +428,28 @@
     <term name="note" form="short">бел.</term>
     <term name="opus" form="short">оп.</term>
     <term name="page" form="short">стр.</term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">бр.стр.</term>
     <term name="paragraph" form="short">абз.</term>
     <term name="part" form="short">ч.</term>
     <term name="section" form="short">разд.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">подразд.</term>
     <term name="verse" form="short">ст.</term>
     <term name="volume" form="short">
@@ -397,12 +462,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -535,6 +616,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -556,6 +638,7 @@
     <term name="interviewer" form="verb">интервюиран от</term>
     <term name="recipient" form="verb">до</term>
     <term name="reviewed-author" form="verb">рецензент</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">преведен от</term>
     <term name="editortranslator" form="verb">редактирано &amp; преведено от</term>
 

--- a/locales-ca-AD.xml
+++ b/locales-ca-AD.xml
@@ -60,9 +60,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citat</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edició</single>
       <multiple>edicions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et al.</term>
@@ -85,6 +101,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperat</term>
     <term name="scale">escala</term>
     <term name="version">versió</term>
@@ -269,6 +287,31 @@
       <single>pàgina</single>
       <multiple>pàgines</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>pàgina</single>
       <multiple>pàgines</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>secció</single>
       <multiple>seccions</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub voce</single>
@@ -348,6 +395,20 @@
       <single>p.</single>
       <multiple>p.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
@@ -373,12 +438,28 @@
       <single>§</single>
       <multiple>§</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">entrevista feta per</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">per</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traduït per</term>
     <term name="editortranslator" form="verb">editat i traduït per</term>
 

--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -67,9 +67,25 @@
     <term name="circa">asi</term>
     <term name="circa" form="short">cca.</term>
     <term name="cited">citován</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>vydání</single>
       <multiple>vydání</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">vyd.</term>
     <term name="et-al">et al.</term>
@@ -92,6 +108,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">získáno</term>
     <term name="scale">měřítko</term>
     <term name="version">verze</term>
@@ -276,6 +294,31 @@
       <single>strana</single>
       <multiple>strany</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>strana</single>
       <multiple>strany</multiple>
@@ -291,6 +334,10 @@
     <term name="section">
       <single>sekce</single>
       <multiple>sekce</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>pod heslem</single>
@@ -355,6 +402,20 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
@@ -362,6 +423,10 @@
     <term name="paragraph" form="short">odst.</term>
     <term name="part" form="short">č.</term>
     <term name="section" form="short">sek.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
@@ -380,12 +445,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -530,6 +611,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -551,6 +633,7 @@
     <term name="interviewer" form="verb">rozhovor vedl</term>
     <term name="recipient" form="verb">pro</term>
     <term name="reviewed-author" form="verb">recenzoval</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">přeložil</term>
     <term name="editortranslator" form="verb">editoval a přeložil</term>
 

--- a/locales-cy-GB.xml
+++ b/locales-cy-GB.xml
@@ -54,9 +54,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">dyfynnwyd</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>argraffiad</single>
       <multiple>argraffiadau</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">arg.</term>
     <term name="et-al">et al.</term>
@@ -79,6 +95,8 @@
       <single>cyf.</single>
       <multiple>cyf’au.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">gwelwyd</term>
     <term name="scale">graddfa</term>
     <term name="version">fersiwn</term>
@@ -269,6 +287,31 @@
       <single>tudalen</single>
       <multiple>tudalennau</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>tudalen</single>
       <multiple>tudalennau</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>adran</single>
       <multiple>adrannau</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>t.</single>
       <multiple>tt.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>t.</single>
       <multiple>tt.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">rhan.</term>
     <term name="section" form="short">adr.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">cyfweliad gan</term>
     <term name="recipient" form="verb">i</term>
     <term name="reviewed-author" form="verb">gan</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">cyfieithwyd gan </term>
     <term name="editortranslator" form="verb">golygwyd a chyfieithwyd gan</term>
 

--- a/locales-da-DK.xml
+++ b/locales-da-DK.xml
@@ -63,9 +63,25 @@
     <term name="circa">cirka</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">henvist</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>udgave</single>
       <multiple>udgaver</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">udg.</term>
     <term name="et-al">m.fl.</term>
@@ -88,6 +104,8 @@
       <single>ref.</single>
       <multiple>refr.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">hentet</term>
     <term name="scale">skala</term>
     <term name="version">version</term>
@@ -272,6 +290,31 @@
       <single>side</single>
       <multiple>sider</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>side</single>
       <multiple>sider</multiple>
@@ -287,6 +330,10 @@
     <term name="section">
       <single>paragraf</single>
       <multiple>paragraffer</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub voce</single>
@@ -351,6 +398,20 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
@@ -358,6 +419,10 @@
     <term name="paragraph" form="short">afs.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">par.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
@@ -376,12 +441,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -526,6 +607,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -547,6 +629,7 @@
     <term name="interviewer" form="verb">interviewet af</term>
     <term name="recipient" form="verb">modtaget af</term>
     <term name="reviewed-author" form="verb">af</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">oversat af</term>
     <term name="editortranslator" form="verb">redigeret &amp; oversat af</term>
 

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -72,9 +72,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">zitiert</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>Auflage</single>
       <multiple>Auflagen</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">Aufl.</term>
     <term name="et-al">u.&#160;a.</term>
@@ -97,6 +113,8 @@
       <single>Ref.</single>
       <multiple>Ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">abgerufen</term>
     <term name="scale">Maßstab</term>
     <term name="version">Version</term>
@@ -281,6 +299,31 @@
       <single>Seite</single>
       <multiple>Seiten</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>Seite</single>
       <multiple>Seiten</multiple>
@@ -296,6 +339,10 @@
     <term name="section">
       <single>Abschnitt</single>
       <multiple>Abschnitte</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -360,6 +407,20 @@
       <single>S.</single>
       <multiple>S.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>S.</single>
       <multiple>S.</multiple>
@@ -367,6 +428,10 @@
     <term name="paragraph" form="short">Abs.</term>
     <term name="part" form="short">Teil</term>
     <term name="section" form="short">Abschn.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -384,6 +449,18 @@
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>
+    </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
     </term>
     <term name="section" form="symbol">
       <single>§</single>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -66,9 +66,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">zitiert</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>Auflage</single>
       <multiple>Auflagen</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">Aufl.</term>
     <term name="et-al">u.&#160;a.</term>
@@ -91,6 +107,8 @@
       <single>Ref.</single>
       <multiple>Ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">abgerufen</term>
     <term name="scale">Massstab</term>
     <term name="version">Version</term>
@@ -275,6 +293,31 @@
       <single>Seite</single>
       <multiple>Seiten</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>Seite</single>
       <multiple>Seiten</multiple>
@@ -290,6 +333,10 @@
     <term name="section">
       <single>Abschnitt</single>
       <multiple>Abschnitte</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -354,6 +401,20 @@
       <single>S.</single>
       <multiple>S.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>S.</single>
       <multiple>S.</multiple>
@@ -361,6 +422,10 @@
     <term name="paragraph" form="short">Abs.</term>
     <term name="part" form="short">Teil</term>
     <term name="section" form="short">Abschn.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -379,12 +444,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -529,6 +610,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -550,6 +632,7 @@
     <term name="interviewer" form="verb">interviewt von</term>
     <term name="recipient" form="verb">an</term>
     <term name="reviewed-author" form="verb">von</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">übersetzt von</term>
     <term name="editortranslator" form="verb">herausgegeben und übersetzt von</term>
 

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -69,9 +69,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">zitiert</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>Auflage</single>
       <multiple>Auflagen</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">Aufl.</term>
     <term name="et-al">u.&#160;a.</term>
@@ -94,6 +110,8 @@
       <single>Ref.</single>
       <multiple>Ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">abgerufen</term>
     <term name="scale">Maßstab</term>
     <term name="version">Version</term>
@@ -278,6 +296,31 @@
       <single>Seite</single>
       <multiple>Seiten</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>Seite</single>
       <multiple>Seiten</multiple>
@@ -293,6 +336,10 @@
     <term name="section">
       <single>Abschnitt</single>
       <multiple>Abschnitte</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -357,6 +404,20 @@
       <single>S.</single>
       <multiple>S.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>S.</single>
       <multiple>S.</multiple>
@@ -364,6 +425,10 @@
     <term name="paragraph" form="short">Abs.</term>
     <term name="part" form="short">Teil</term>
     <term name="section" form="short">Abschn.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -381,6 +446,18 @@
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>
+    </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
     </term>
     <term name="section" form="symbol">
       <single>§</single>

--- a/locales-el-GR.xml
+++ b/locales-el-GR.xml
@@ -60,9 +60,25 @@
     <term name="circa">περίπου</term>
     <term name="circa" form="short">περ.</term>
     <term name="cited">παρατίθεται</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition" gender="feminine">
       <single>έκδοση</single>
       <multiple>εκδόσεις</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">έκδ.</term>
     <term name="et-al">κ.ά.</term>
@@ -85,6 +101,8 @@
       <single>παρ.</single>
       <multiple>παρ.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">ανακτήθηκε</term>
     <term name="scale">κλίμακα</term>
     <term name="version">εκδοχή</term>
@@ -271,6 +289,31 @@
       <single>σελίδα</single>
       <multiple>σελίδες</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>σελίδα</single>
       <multiple>σελίδες</multiple>
@@ -286,6 +329,10 @@
     <term name="section">
       <single>τμήμα</single>
       <multiple>τμήματα</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>λήμμα</single>
@@ -350,6 +397,20 @@
       <single>σ.</single>
       <multiple>σσ.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>σ.</single>
       <multiple>σσ.</multiple>
@@ -357,6 +418,10 @@
     <term name="paragraph" form="short">παρ.</term>
     <term name="part" form="short">μέρ.</term>
     <term name="section" form="short">τμ.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>λήμ.</single>
       <multiple>λήμ.</multiple>
@@ -375,12 +440,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -525,6 +606,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -546,6 +628,7 @@
     <term name="interviewer" form="verb">συνέντευξη</term>
     <term name="recipient" form="verb">παραλήπτης</term>
     <term name="reviewed-author" form="verb">συγγραφέας:</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">μετάφραση</term>
     <term name="editortranslator" form="verb">μετάφραση και επιμέλεια</term>
 

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -63,9 +63,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edition</single>
       <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et al.</term>
@@ -88,6 +104,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">retrieved</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -278,6 +296,31 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>page</single>
       <multiple>pages</multiple>
@@ -293,6 +336,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -384,6 +431,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -399,6 +460,10 @@
     <term name="section" form="short">
       <single>sec.</single>
       <multiple>secs</multiple>
+    </term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
     </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
@@ -418,12 +483,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -568,6 +649,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -589,6 +671,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -31,61 +31,50 @@
     <date-part name="year"/>
   </date>
   <terms>
+    <!-- GENERAL TERMS -->
+    <term name="accessed">accessed</term>
     <term name="advance-online-publication">advance online publication</term>
     <term name="album">album</term>
+    <term name="and">and</term>
+    <term name="and others">and others</term>
+    <term name="anonymous">anonymous</term>
+    <term name="anonymous" form="short">anon.</term>
+    <term name="at">at</term>
     <term name="audio-recording">audio recording</term>
+    <term name="available at">available at</term>
+    <term name="by">by</term>
+    <term name="circa">circa</term>
+    <term name="circa" form="short">c.</term>
+    <term name="cited">cited</term>
+    <term name="et-al">et al.</term>
     <term name="film">film</term>
+    <term name="forthcoming">forthcoming</term>
+    <term name="from">from</term>
     <term name="henceforth">henceforth</term>
+    <term name="ibid">ibid.</term>
+    <term name="in">in</term>
+    <term name="in press">in press</term>
+    <term name="internet">internet</term>
+    <term name="letter">letter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="no date">no date</term>
+    <term name="no date" form="short">n.d.</term>
     <term name="no-place">no place</term>
     <term name="no-place" form="short">n.p.</term>
     <term name="no-publisher">no publisher</term> <!-- sine nomine -->
     <term name="no-publisher" form="short">n.p.</term>
     <term name="on">on</term>
+    <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
     <term name="personal-communication">personal communication</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
+    <term name="presented at">presented at the</term>
     <term name="radio-broadcast">radio broadcast</term>
     <term name="radio-series">radio series</term>
     <term name="radio-series-episode">radio series episode</term>
-    <term name="special-issue">special issue</term>
-    <term name="special-section">special section</term>
-    <term name="television-broadcast">television broadcast</term>
-    <term name="television-series">television series</term>
-    <term name="television-series-episode">television series episode</term>
-    <term name="video">video</term>
-    <term name="working-paper">working paper</term>
-    <term name="accessed">accessed</term>
-    <term name="and">and</term>
-    <term name="and others">and others</term>
-    <term name="anonymous">anonymous</term>
-    <term name="anonymous" form="short">anon.</term>
-    <term name="at">at</term>
-    <term name="available at">available at</term>
-    <term name="by">by</term>
-    <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term>
-    <term name="cited">cited</term>
-    <term name="edition">
-      <single>edition</single>
-      <multiple>editions</multiple>
-    </term>
-    <term name="edition" form="short">ed.</term>
-    <term name="et-al">et al.</term>
-    <term name="forthcoming">forthcoming</term>
-    <term name="from">from</term>
-    <term name="ibid">ibid.</term>
-    <term name="in">in</term>
-    <term name="in press">in press</term>
-    <term name="internet">internet</term>
-    <term name="letter">letter</term>
-    <term name="no date">no date</term>
-    <term name="no date" form="short">n.d.</term>
-    <term name="online">online</term>
-    <term name="presented at">presented at the</term>
     <term name="reference">
       <single>reference</single>
       <multiple>references</multiple>
@@ -95,8 +84,16 @@
       <multiple>refs.</multiple>
     </term>
     <term name="retrieved">retrieved</term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="scale">scale</term>
-    <term name="version">version</term>
+    <term name="special-issue">special issue</term>
+    <term name="special-section">special section</term>
+    <term name="television-broadcast">television broadcast</term>
+    <term name="television-series">television series</term>
+    <term name="television-series-episode">television series episode</term>
+    <term name="video">video</term>
+    <term name="working-paper">working paper</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">preprint</term>
@@ -212,41 +209,13 @@
       <single>article</single>
       <multiple>articles</multiple>						 
     </term>
-    <term name="canon">			 
-      <single>canon</single>
-      <multiple>canons</multiple>						 
-    </term>
-    <term name="elocation">			 
-      <single>location</single>
-      <multiple>locations</multiple>						 
-    </term>
-    <term name="equation">			 
-      <single>equation</single>
-      <multiple>equations</multiple>						 
-    </term>
-    <term name="rule">			 
-      <single>rule</single>
-      <multiple>rules</multiple>						 
-    </term>
-    <term name="scene">			 
-      <single>scene</single>
-      <multiple>scenes</multiple>						 
-    </term>
-    <term name="table">			 
-      <single>table</single>
-      <multiple>tables</multiple>						 
-    </term>
-    <term name="timestamp"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
-    </term>
-    <term name="title-locator">			 
-      <single>title</single>
-      <multiple>titles</multiple>						 
-    </term>
     <term name="book">
       <single>book</single>
       <multiple>books</multiple>
+    </term>
+    <term name="canon">			 
+      <single>canon</single>
+      <multiple>canons</multiple>						 
     </term>
     <term name="chapter">
       <single>chapter</single>
@@ -255,6 +224,14 @@
     <term name="column">
       <single>column</single>
       <multiple>columns</multiple>
+    </term>
+    <term name="elocation">			 
+      <single>location</single>
+      <multiple>locations</multiple>						 
+    </term>
+    <term name="equation">			 
+      <single>equation</single>
+      <multiple>equations</multiple>						 
     </term>
     <term name="figure">
       <single>figure</single>
@@ -284,10 +261,6 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
-    <term name="number-of-pages">
-      <single>page</single>
-      <multiple>pages</multiple>
-    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraphs</multiple>
@@ -295,6 +268,14 @@
     <term name="part">
       <single>part</single>
       <multiple>parts</multiple>
+    </term>
+    <term name="rule">			 
+      <single>rule</single>
+      <multiple>rules</multiple>						 
+    </term>
+    <term name="scene">			 
+      <single>scene</single>
+      <multiple>scenes</multiple>						 
     </term>
     <term name="section">
       <single>section</single>
@@ -304,9 +285,29 @@
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
+    </term>
+    <term name="table">			 
+      <single>table</single>
+      <multiple>tables</multiple>						 
+    </term>
+    <term name="timestamp"> <!-- generally blank -->
+      <single></single>
+      <multiple></multiple>						 
+    </term>
+    <term name="title-locator">			 
+      <single>title</single>
+      <multiple>titles</multiple>						 
+    </term>
     <term name="verse">
       <single>verse</single>
       <multiple>verses</multiple>
+    </term>
+    <term name="version">
+      <single>version</single>
+      <multiple>versions</multiple>
     </term>
     <term name="volume">
       <single>volume</single>
@@ -314,6 +315,7 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
+    <!-- Omitted short forms: act, timestamp -->
     <term name="appendix" form="short">			 
       <single>app.</single>
       <multiple>apps.</multiple>						 
@@ -322,37 +324,13 @@
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation" form="short">			 
-      <single>loc.</single>
-      <multiple>locs.</multiple>
-    </term>
-    <term name="equation" form="short">			 
-      <single>eq.</single>
-      <multiple>eqs.</multiple>
-    </term>
-    <term name="rule" form="short">			 
-      <single>r.</single>
-      <multiple>rr.</multiple>						 
-    </term>
-    <term name="scene" form="short">			 
-      <single>sc.</single>
-      <multiple>scs.</multiple>						 
-    </term>
-    <term name="table" form="short">			 
-      <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
-    </term>
-    <term name="timestamp" form="short"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
-    </term>
-    <term name="title-locator" form="short">			 
-      <single>tit.</single>
-      <multiple>tits.</multiple>
-    </term>
     <term name="book" form="short">
       <single>bk.</single>
       <multiple>bks.</multiple>
+    </term>
+    <term name="canon">			 
+      <single>c.</single>
+      <multiple>cc.</multiple>						 
     </term>
     <term name="chapter" form="short">
       <single>chap.</single>
@@ -361,6 +339,14 @@
     <term name="column" form="short">
       <single>col.</single>
       <multiple>cols.</multiple>
+    </term>
+    <term name="elocation" form="short">			 
+      <single>loc.</single>
+      <multiple>locs.</multiple>
+    </term>
+    <term name="equation" form="short">			 
+      <single>eq.</single>
+      <multiple>eqs.</multiple>
     </term>
     <term name="figure" form="short">
       <single>fig.</single>
@@ -390,10 +376,6 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
-    <term name="number-of-pages" form="short">
-      <single>p.</single>
-      <multiple>pp.</multiple>
-    </term>
     <term name="paragraph" form="short">
       <single>para.</single>
       <multiple>paras.</multiple>
@@ -401,6 +383,14 @@
     <term name="part" form="short">
       <single>pt.</single>
       <multiple>pts.</multiple>
+    </term>
+    <term name="rule" form="short">			 
+      <single>r.</single>
+      <multiple>rr.</multiple>						 
+    </term>
+    <term name="scene" form="short">			 
+      <single>sc.</single>
+      <multiple>scs.</multiple>						 
     </term>
     <term name="section" form="short">
       <single>sec.</single>
@@ -410,9 +400,25 @@
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
+    <term name="table" form="short">			 
+      <single>tbl.</single>
+      <multiple>tbls.</multiple>						 
+    </term>
+    <term name="title-locator" form="short">			 
+      <single>tit.</single>
+      <multiple>tits.</multiple>
+    </term>
     <term name="verse" form="short">
       <single>v.</single>
       <multiple>vv.</multiple>
+    </term>
+    <term name="version" form="short">
+      <single>v.</single>
+      <multiple>v.</multiple>
     </term>
     <term name="volume" form="short">
       <single>vol.</single>
@@ -429,10 +435,106 @@
       <multiple>§§</multiple>
     </term>
 
+    <!-- LONG NUMBER VARIABLE FORMS -->
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
+    <term name="edition">
+      <single>edition</single>
+      <multiple>editions</multiple>
+    </term>
+    <term name="edition">
+      <single>edition</single>
+      <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <!-- SHORT NUMBER VARIABLE FORMS -->
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
+    <term name="edition" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <!-- LONG ROLE FORMS -->
+    <!-- Omitted roles: 
+         author, composer, container-author, interviewer, original-author, recipient, reviewed-author 
+    -->
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
+    </term>
+    <term name="collection-editor">
+      <single>editor</single>
+      <multiple>editors</multiple>
     </term>
     <term name="compiler">
       <single>compiler</single>
@@ -446,6 +548,22 @@
       <single>curator</single>
       <multiple>curators</multiple>
     </term>
+    <term name="director">
+      <single>director</single>
+      <multiple>directors</multiple>
+    </term>
+    <term name="editor">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
+    <term name="editortranslator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+    <term name="editorial-director">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
     <term name="executive-producer">
       <single>executive producer</single>
       <multiple>executive producers</multiple>
@@ -457,6 +575,10 @@
     <term name="host">
       <single>host</single>
       <multiple>hosts</multiple>
+    </term>
+    <term name="illustrator">
+      <single>illustrator</single>
+      <multiple>illustrators</multiple>
     </term>
     <term name="narrator">
       <single>narrator</single>
@@ -482,32 +604,19 @@
       <single>series creator</single>
       <multiple>series creators</multiple>
     </term>
-    <term name="director">
-      <single>director</single>
-      <multiple>directors</multiple>
-    </term>
-    <term name="editor">
-      <single>editor</single>
-      <multiple>editors</multiple>
-    </term>
-    <term name="editorial-director">
-      <single>editor</single>
-      <multiple>editors</multiple>
-    </term>
-    <term name="illustrator">
-      <single>illustrator</single>
-      <multiple>illustrators</multiple>
-    </term>
     <term name="translator">
       <single>translator</single>
       <multiple>translators</multiple>
     </term>
-    <term name="editortranslator">
-      <single>editor &amp; translator</single>
-      <multiple>editors &amp; translators</multiple>
-    </term>
 
     <!-- SHORT ROLE FORMS -->
+    <!-- Omitted roles: 
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author 
+    -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="compiler" form="short">
       <single>comp.</single>
       <multiple>comps.</multiple>
@@ -520,9 +629,29 @@
       <single>cur.</single>
       <multiple>curs.</multiple>
     </term>
+    <term name="director" form="short">
+      <single>dir.</single>
+      <multiple>dirs.</multiple>
+    </term>
+    <term name="editor" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="editortranslator" form="short">
+      <single>ed. &amp; tran.</single>
+      <multiple>eds. &amp; trans.</multiple>
+    </term>
+    <term name="editorial-director" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="executive-producer" form="short">
       <single>exec. prod.</single>
       <multiple>exec. prods.</multiple>
+    </term>
+    <term name="illustrator" form="short">
+      <single>ill.</single>
+      <multiple>ills.</multiple>
     </term>
     <term name="narrator" form="short">
       <single>narr.</single>
@@ -548,75 +677,63 @@
       <single>cre.</single>
       <multiple>cres.</multiple>
     </term>
-    <term name="director" form="short">
-      <single>dir.</single>
-      <multiple>dirs.</multiple>
-    </term>
-    <term name="editor" form="short">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
-    </term>
-    <term name="editorial-director" form="short">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
-    </term>
-    <term name="illustrator" form="short">
-      <single>ill.</single>
-      <multiple>ills.</multiple>
-    </term>
     <term name="translator" form="short">
       <single>tran.</single>
       <multiple>trans.</multiple>
     </term>
-    <term name="editortranslator" form="short">
-      <single>ed. &amp; tran.</single>
-      <multiple>eds. &amp; trans.</multiple>
-    </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="author" form="verb">by</term>
     <term name="chair" form="verb">chaired by</term>
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="compiler" form="verb">compiled by</term>
+    <term name="composer" form="verb">composed by</term>
+    <term name="container-author" form="verb">by</term>
     <term name="contributor" form="verb">with</term>
     <term name="curator" form="verb">curated by</term>
+    <term name="director" form="verb">directed by</term>
+    <term name="editor" form="verb">edited by</term>
+    <term name="editortranslator" form="verb">edited &amp; translated by</term>
+    <term name="editorial-director" form="verb">edited by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
     <term name="guest" form="verb">with guest</term>
     <term name="host" form="verb">hosted by</term>
-    <term name="narrator" form="verb">narrated by</term>
-    <term name="organizer" form="verb">organized by</term>
-    <term name="performer" form="verb">performed by</term>
-    <term name="producer" form="verb">produced by</term>
-    <term name="script-writer" form="verb">written by</term>
-    <term name="series-creator" form="verb">created by</term>
-    <term name="container-author" form="verb">by</term>
-    <term name="director" form="verb">directed by</term>
-    <term name="editor" form="verb">edited by</term>
-    <term name="editorial-director" form="verb">edited by</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">interview by</term>
+    <term name="narrator" form="verb">narrated by</term>
+    <term name="organizer" form="verb">organized by</term>
+    <term name="original-author" form="verb">by</term>
+    <term name="performer" form="verb">performed by</term>
+    <term name="producer" form="verb">produced by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="script-writer" form="verb">written by</term>
+    <term name="series-creator" form="verb">created by</term>
     <term name="translator" form="verb">translated by</term>
-    <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
+    <!-- Omitted roles: 
+         author, chair, container-author, host, interviewer, original-author, recipient, reviewed-author
+    -->
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
+    <term name="composer" form="verb-short">comp. by</term>
     <term name="contributor" form="verb-short">w.</term>
     <term name="curator" form="verb-short">cur. by</term>
+    <term name="director" form="verb-short">dir. by</term>
+    <term name="editor" form="verb-short">ed. by</term>
+    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="editorial-director" form="verb-short">ed. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term>
     <term name="guest" form="verb-short">w. guest</term>
-    <term name="host" form="verb-short">hosted by</term>
+    <term name="illustrator" form="verb-short">illus. by</term>
     <term name="narrator" form="verb-short">narr. by</term>
     <term name="organizer" form="verb-short">org. by</term>
     <term name="performer" form="verb-short">perf. by</term>
     <term name="producer" form="verb-short">prod. by</term>
     <term name="script-writer" form="verb-short">writ. by</term>
     <term name="series-creator" form="verb-short">cre. by</term>
-    <term name="director" form="verb-short">dir. by</term>
-    <term name="editor" form="verb-short">ed. by</term>
-    <term name="editorial-director" form="verb-short">ed. by</term>
-    <term name="illustrator" form="verb-short">illus. by</term>
     <term name="translator" form="verb-short">trans. by</term>
-    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">January</term>

--- a/locales-es-CL.xml
+++ b/locales-es-CL.xml
@@ -58,9 +58,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citado</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edición</single>
       <multiple>ediciones</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et&#160;al.</term>
@@ -83,6 +99,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperado</term>
     <term name="scale">escala</term>
     <term name="version">versión</term>
@@ -267,6 +285,31 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>página</single>
       <multiple>páginas</multiple>
@@ -282,6 +325,10 @@
     <term name="section">
       <single>sección</single>
       <multiple>secciones</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub voce</single>
@@ -346,6 +393,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -353,6 +414,10 @@
     <term name="paragraph" form="short">párr.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -371,12 +436,28 @@
       <single>§</single>
       <multiple>§</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -521,6 +602,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -542,6 +624,7 @@
     <term name="interviewer" form="verb">entrevistado por</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">por</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traducido por</term>
     <term name="editortranslator" form="verb">editado y traducido por</term>
 

--- a/locales-es-ES.xml
+++ b/locales-es-ES.xml
@@ -57,9 +57,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citado</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edición</single>
       <multiple>ediciones</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et&#160;al.</term>
@@ -82,6 +98,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperado</term>
     <term name="scale">escala</term>
     <term name="version">versión</term>
@@ -266,6 +284,31 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>página</single>
       <multiple>páginas</multiple>
@@ -281,6 +324,10 @@
     <term name="section">
       <single>sección</single>
       <multiple>secciones</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub voce</single>
@@ -345,6 +392,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -352,6 +413,10 @@
     <term name="paragraph" form="short">párr.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -370,12 +435,28 @@
       <single>§</single>
       <multiple>§</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -520,6 +601,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -541,6 +623,7 @@
     <term name="interviewer" form="verb">entrevistado por</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">por</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traducido por</term>
     <term name="editortranslator" form="verb">editado y traducido por</term>
 

--- a/locales-es-MX.xml
+++ b/locales-es-MX.xml
@@ -58,9 +58,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citado</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edición</single>
       <multiple>ediciones</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">
       <single>ed.</single>
@@ -86,6 +102,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperado</term>
     <term name="scale">escala</term>
     <term name="version">versión</term>
@@ -272,6 +290,31 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>página</single>
       <multiple>páginas</multiple>
@@ -287,6 +330,10 @@
     <term name="section">
       <single>sección</single>
       <multiple>secciones</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub voce</single>
@@ -378,6 +425,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -393,6 +454,10 @@
     <term name="section" form="short">
       <single>sec.</single>
       <multiple>secs.</multiple>
+    </term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
     </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
@@ -412,12 +477,28 @@
       <single>¶</single>
       <multiple>¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -562,6 +643,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -583,6 +665,7 @@
     <term name="interviewer" form="verb">entrevistado por</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">por</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traducido por</term>
     <term name="editortranslator" form="verb">editado y traducido por</term>
 

--- a/locales-et-EE.xml
+++ b/locales-et-EE.xml
@@ -57,9 +57,25 @@
     <term name="circa">umbes</term>
     <term name="circa" form="short">u</term>
     <term name="cited">tsiteeritud</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>väljaanne</single>
       <multiple>väljaanded</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">tr</term>
     <term name="et-al">et al.</term>
@@ -82,6 +98,8 @@
       <single>viide</single>
       <multiple>viited</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">salvestatud</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -266,6 +284,31 @@
       <single>lehekülg</single>
       <multiple>leheküljed</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>lehekülg</single>
       <multiple>leheküljed</multiple>
@@ -281,6 +324,10 @@
     <term name="section">
       <single>alajaotis</single>
       <multiple>alajaotised</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -345,6 +392,20 @@
       <single>lk</single>
       <multiple>lk</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>lk</single>
       <multiple>lk</multiple>
@@ -352,6 +413,10 @@
     <term name="paragraph" form="short">lõik</term>
     <term name="part" form="short">osa</term>
     <term name="section" form="short">alajaot.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -370,12 +435,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -520,6 +601,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -541,6 +623,7 @@
     <term name="interviewer" form="verb">intervjueerinud</term>
     <term name="recipient" form="verb"></term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">tõlkinud</term>
     <term name="editortranslator" form="verb">toimetanud &amp; tõlkinud</term>
 

--- a/locales-eu.xml
+++ b/locales-eu.xml
@@ -60,9 +60,25 @@
     <term name="circa">inguru</term>
     <term name="circa" form="short">ing.</term>
     <term name="cited">aipatua</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>argitalpena</single>
       <multiple>argitalpenak</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">arg.</term>
     <term name="et-al">et al.</term>
@@ -85,6 +101,8 @@
       <single>aip.</single>
       <multiple>aip.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">berreskuratua</term>
     <term name="scale">scale</term>
     <term name="version">bertsioa</term>
@@ -269,6 +287,31 @@
       <single>orrialdea</single>
       <multiple>orrialdeak</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>orrialdea</single>
       <multiple>orrialdeak</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>atala</single>
       <multiple>atalak</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub voce</single>
@@ -348,6 +395,20 @@
       <single>or.</single>
       <multiple>or.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>or.</single>
       <multiple>or.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">zt.</term>
     <term name="section" form="short">atal.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.v.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">-(e)k elkarrizketatua</term>
     <term name="recipient" form="verb">-(r)entzat</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">-(e)k itzulia</term>
     <term name="editortranslator" form="verb">-(e)k argitaratu eta itzulia</term>
 

--- a/locales-fa-IR.xml
+++ b/locales-fa-IR.xml
@@ -60,9 +60,25 @@
     <term name="circa">تقریباً</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">ارجاع شده</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>ویرایش</single>
       <multiple>ویرایش‌های</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ویرایش</term>
     <term name="et-al">و همکاران</term>
@@ -85,6 +101,8 @@
       <single>مرجع</single>
       <multiple>مراجع</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">retrieved</term>
     <term name="scale">scale</term>
     <term name="version">نسخه</term>
@@ -269,6 +287,31 @@
       <single>صفحه</single>
       <multiple>صفحات</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>صفحه</single>
       <multiple>صفحات</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>قسمت</single>
       <multiple>قسمت‌های</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>در ذیلِ واژه</single>
@@ -348,6 +395,20 @@
       <single>ص</single>
       <multiple>صص</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>ص</single>
       <multiple>صص</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">پاراگراف</term>
     <term name="part" form="short">بخش</term>
     <term name="section" form="short">قسمت</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v</single>
       <multiple>s.vv</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">مصاحبه توسط</term>
     <term name="recipient" form="verb">به</term>
     <term name="reviewed-author" form="verb">بازبینی توسط</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">ترجمه‌ی</term>
     <term name="editortranslator" form="verb">ترجمه و ویراسته‌ی</term>
 

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -66,9 +66,25 @@
     <term name="circa">noin</term>
     <term name="circa" form="short">n.</term>
     <term name="cited">viitattu</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>painos</single>
       <multiple>painokset</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">p.</term>
     <term name="et-al">ym.</term>
@@ -91,6 +107,8 @@
       <single>viit.</single>
       <multiple>viit.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">noudettu</term>
     <term name="scale">mittakaava</term>
     <term name="version">versio</term>
@@ -275,6 +293,31 @@
       <single>sivu</single>
       <multiple>sivut</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>sivu</single>
       <multiple>sivut</multiple>
@@ -290,6 +333,10 @@
     <term name="section">
       <single>osa</single>
       <multiple>osat</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -354,6 +401,20 @@
       <single>s.</single>
       <multiple>ss.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>ss.</multiple>
@@ -361,6 +422,10 @@
     <term name="paragraph" form="short">kappale</term>
     <term name="part" form="short">osa</term>
     <term name="section" form="short">osa</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -379,12 +444,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -529,6 +610,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -550,6 +632,7 @@
     <term name="interviewer" form="verb">haastatellut</term>
     <term name="recipient" form="verb">vastaanottaja</term>
     <term name="reviewed-author" form="verb"></term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">kääntänyt</term>
     <term name="editortranslator" form="verb">toimittanut ja kääntänyt</term>
 

--- a/locales-fr-CA.xml
+++ b/locales-fr-CA.xml
@@ -57,9 +57,25 @@
     <term name="circa">vers</term>
     <term name="circa" form="short">v.</term>
     <term name="cited">cité</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition" gender="feminine">
       <single>édition</single>
       <multiple>éditions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">éd.</term>
     <term name="et-al">et al.</term>
@@ -82,6 +98,8 @@
       <single>réf.</single>
       <multiple>réf.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">consulté</term>
     <term name="scale">échelle</term>
     <term name="version">version</term>
@@ -268,6 +286,31 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>page</single>
       <multiple>pages</multiple>
@@ -283,6 +326,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -353,6 +400,20 @@
       <single>p.</single>
       <multiple>p.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
@@ -360,6 +421,10 @@
     <term name="paragraph" form="short">paragr.</term>
     <term name="part" form="short">part.</term>
     <term name="section" form="short">sect.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -378,12 +443,28 @@
       <single>§</single>
       <multiple>§</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -528,6 +609,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -549,6 +631,7 @@
     <term name="interviewer" form="verb">entretien réalisé par</term>
     <term name="recipient" form="verb">à</term>
     <term name="reviewed-author" form="verb">par</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traduit par</term>
     <term name="editortranslator" form="verb">édité et traduit par</term>
 

--- a/locales-fr-FR.xml
+++ b/locales-fr-FR.xml
@@ -60,9 +60,25 @@
     <term name="circa">vers</term>
     <term name="circa" form="short">v.</term>
     <term name="cited">cité</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition" gender="feminine">
       <single>édition</single>
       <multiple>éditions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">éd.</term>
     <term name="et-al">et al.</term>
@@ -85,6 +101,8 @@
       <single>réf.</single>
       <multiple>réf.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">consulté</term>
     <term name="scale">échelle</term>
     <term name="version">version</term>
@@ -271,6 +289,31 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>page</single>
       <multiple>pages</multiple>
@@ -286,6 +329,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -356,6 +403,20 @@
       <single>p.</single>
       <multiple>p.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
@@ -363,6 +424,10 @@
     <term name="paragraph" form="short">paragr.</term>
     <term name="part" form="short">part.</term>
     <term name="section" form="short">sect.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.&#160;v.</single>
       <multiple>s.&#160;vv.</multiple>
@@ -381,12 +446,28 @@
       <single>§</single>
       <multiple>§</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>président</single>
       <multiple>présidents</multiple>
@@ -531,6 +612,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">présidé par</term>
     <term name="compiler" form="verb">compilé par</term>
     <term name="contributor" form="verb">avec</term>
@@ -552,6 +634,7 @@
     <term name="interviewer" form="verb">entretien réalisé par</term>
     <term name="recipient" form="verb">à</term>
     <term name="reviewed-author" form="verb">par</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traduit par</term>
     <term name="editortranslator" form="verb">édité et traduit par</term>
 

--- a/locales-gl-ES.xml
+++ b/locales-gl-ES.xml
@@ -19,34 +19,105 @@
     <date-part name="year"/>
   </date>
   <terms>
+    <term name="advance-online-publication">advance online publication</term>
+    <term name="album">album</term>
     <term name="accessed">accedido</term>
     <term name="and">e</term>
     <term name="and others">e outros</term>
     <term name="anonymous">anónimo</term>
     <term name="anonymous" form="short">anón.</term>
+    <term name="audio-recording">audio recording</term>
     <term name="at">en</term>
     <term name="available at">dispoñíbel en</term>
     <term name="by">por</term>
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citado</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edición</single>
       <multiple>edicións</multiple>
     </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
     <term name="edition" form="short">ed.</term>
+    <term name="film">film</term>
     <term name="et-al">et al.</term>
     <term name="forthcoming">a publicar</term>
+    <term name="henceforth">henceforth</term>
     <term name="from">de</term>
     <term name="ibid">ibid.</term>
     <term name="in">en</term>
     <term name="in press">no prelo</term>
     <term name="internet">internet</term>
+    <term name="legal_case">legal case</term>
+    <term name="legislation">legislation</term>
+    <term name="manuscript">manuscript</term>
+    <term name="map">map</term>
+    <term name="motion_picture">video recording</term>
+    <term name="musical_score">musical score</term>
+    <term name="pamphlet">pamphlet</term>
+    <term name="paper-conference">conference paper</term>
+    <term name="patent">patent</term>
+    <term name="performance">performance</term>
+    <term name="periodical">periodical</term>
+    <term name="personal_communication">personal communication</term>
+    <term name="post">post</term>
+    <term name="post-weblog">blog post</term>
+    <term name="regulation">regulation</term>
+    <term name="report">report</term>
+    <term name="review">review</term>
+    <term name="review-book">book review</term>
+    <term name="software">software</term>
+    <term name="song">audio recording</term>
+    <term name="speech">presentation</term>
+    <term name="standard">standard</term>
+    <term name="thesis">thesis</term>
+    <term name="treaty">treaty</term>
+    <term name="webpage">webpage</term>
+
+    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-magazine" form="short">mag. art.</term>
+    <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="document" form="short">doc.</term>
+    <term name="graphic" form="short">graph.</term>
+    <term name="manuscript" form="short">MS</term>
+    <term name="motion_picture" form="short">video rec.</term>
+    <term name="report" form="short">rep.</term>
+    <term name="review" form="short">rev.</term>
+    <term name="review-book" form="short">bk. rev.</term>
+    <term name="song" form="short">audio rec.</term>
+
     <term name="interview">entrevista</term>
-    <term name="letter">carta</term>
+    <term name="loc-cit">loc. cit.</term> <term name="letter">carta</term>
     <term name="no date">sen data</term>
+    <term name="no-place">no place</term>
+    <term name="no-place" form="short">n.p.</term>
+    <term name="no-publisher">no publisher</term> <term name="no-publisher" form="short">n.p.</term>
+    <term name="on">on</term>
     <term name="no date" form="short">sen data</term>
+    <term name="op-cit">op. cit.</term> <term name="original-work-published">original work published</term>
+    <term name="personal-communication">personal communication</term>
+    <term name="podcast">podcast</term>
+    <term name="podcast-episode">podcast episode</term>
+    <term name="preprint">preprint</term>
     <term name="online">en liña</term>
+    <term name="radio-broadcast">radio broadcast</term>
+    <term name="radio-series">radio series</term>
+    <term name="radio-series-episode">radio series episode</term>
     <term name="presented at">presentado na</term>
     <term name="reference">
       <single>referencia</single>
@@ -56,12 +127,41 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">obtido</term>
+    <term name="special-issue">special issue</term>
+    <term name="special-section">special section</term>
+    <term name="television-broadcast">television broadcast</term>
+    <term name="television-series">television series</term>
+    <term name="television-series-episode">television series episode</term>
+    <term name="video">video</term>
+    <term name="working-paper">working paper</term>
+
+    <term name="article">preprint</term>
+    <term name="article-journal">journal article</term>
+    <term name="article-magazine">magazine article</term>
+    <term name="article-newspaper">newspaper article</term>
+    <term name="bill">bill</term>
+    <term name="broadcast">broadcast</term>
+    <term name="classic">classic</term>
+    <term name="collection">collection</term>
+    <term name="dataset">dataset</term>
+    <term name="document">document</term>
+    <term name="entry">entry</term>
+    <term name="entry-dictionary">dictionary entry</term>
+    <term name="entry-encyclopedia">encyclopedia entry</term>
+    <term name="event">event</term>
+    <term name="graphic">graphic</term>
+    <term name="hearing">hearing</term>
     <term name="scale">escala</term>
     <term name="version">versión</term>
 
     <!-- ANNO DOMINI; BEFORE CHRIST -->
     <term name="ad">D.C.</term>
+    <term name="bce">BCE</term>
+    <term name="ce">CE</term>
+
     <term name="bc">A.C.</term>
 
     <!-- PUNCTUATION -->
@@ -69,6 +169,10 @@
     <term name="close-quote">»</term>
     <term name="open-inner-quote">“</term>
     <term name="close-inner-quote">”</term>
+    <term name="colon">:</term>
+    <term name="comma">,</term>
+    <term name="semicolon">;</term>
+
     <term name="page-range-delimiter">–</term>
 
     <!-- ORDINALS -->
@@ -94,10 +198,26 @@
     <term name="long-ordinal-08" gender-form="feminine">oitava</term>
     <term name="long-ordinal-09" gender-form="masculine">nono</term>
     <term name="long-ordinal-09" gender-form="feminine">nona</term>
+    <term name="act">			 
+      <single>act</single>
+      <multiple>acts</multiple>						 
+    </term>
+    <term name="appendix">			 
+      <single>appendix</single>
+      <multiple>appendices</multiple>						 
+    </term>
+    <term name="article-locator">			 
+      <single>article</single>
+      <multiple>articles</multiple>						 
+    </term>
     <term name="long-ordinal-10" gender-form="masculine">décimo</term>
     <term name="long-ordinal-10" gender-form="feminine">décima</term>
 
     <!-- LONG LOCATOR FORMS -->
+    <term name="canon">			 
+      <single>c.</single>
+      <multiple>cc.</multiple>						 
+    </term>
     <term name="book">
       <single>libro</single>
       <multiple>libros</multiple>
@@ -105,6 +225,14 @@
     <term name="chapter">
       <single>capítulo</single>
       <multiple>capítulos</multiple>
+    </term>
+    <term name="elocation">			 
+      <single>location</single>
+      <multiple>locations</multiple>						 
+    </term>
+    <term name="equation">			 
+      <single>equation</single>
+      <multiple>equations</multiple>						 
     </term>
     <term name="column">
       <single>columna</single>
@@ -138,6 +266,31 @@
       <single>páxina</single>
       <multiple>páxinas</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>páxina</single>
       <multiple>páxinas</multiple>
@@ -145,6 +298,14 @@
     <term name="paragraph">
       <single>parágrafo</single>
       <multiple>parágrafos</multiple>
+    </term>
+    <term name="rule">			 
+      <single>rule</single>
+      <multiple>rules</multiple>						 
+    </term>
+    <term name="scene">			 
+      <single>scene</single>
+      <multiple>scenes</multiple>						 
     </term>
     <term name="part">
       <single>parte</single>
@@ -154,6 +315,22 @@
       <single>sección</single>
       <multiple>seccións</multiple>
     </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
+    </term>
+    <term name="table">			 
+      <single>table</single>
+      <multiple>tables</multiple>						 
+    </term>
+    <term name="timestamp"> <!-- generally blank -->
+      <single></single>
+      <multiple></multiple>						 
+    </term>
+    <term name="title-locator">			 
+      <single>title</single>
+      <multiple>titles</multiple>						 
+    </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
@@ -161,6 +338,14 @@
     <term name="verse">
       <single>versículo</single>
       <multiple>versículos</multiple>
+    </term>
+    <term name="appendix" form="short">			 
+      <single>app.</single>
+      <multiple>apps.</multiple>						 
+    </term>
+    <term name="article-locator" form="short">			 
+      <single>art.</single>
+      <multiple>arts.</multiple>
     </term>
     <term name="volume">
       <single>volume</single>
@@ -170,6 +355,14 @@
     <!-- SHORT LOCATOR FORMS -->
     <term name="book" form="short">lib.</term>
     <term name="chapter" form="short">cap.</term>
+    <term name="elocation" form="short">			 
+      <single>loc.</single>
+      <multiple>locs.</multiple>
+    </term>
+    <term name="equation" form="short">			 
+      <single>eq.</single>
+      <multiple>eqs.</multiple>
+    </term>
     <term name="column" form="short">col.</term>
     <term name="figure" form="short">fig.</term>
     <term name="folio" form="short">f.</term>
@@ -181,13 +374,67 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
+    <term name="chair">
+      <single>chair</single>
+      <multiple>chairs</multiple>
+    </term>
+    <term name="compiler">
+      <single>compiler</single>
+      <multiple>compilers</multiple>
+    </term>
+    <term name="contributor">
+      <single>contributor</single>
+      <multiple>contributors</multiple>
+    </term>
+    <term name="curator">
+      <single>curator</single>
+      <multiple>curators</multiple>
+    </term>
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
     <term name="paragraph" form="short">par.</term>
+    <term name="rule" form="short">			 
+      <single>r.</single>
+      <multiple>rr.</multiple>						 
+    </term>
+    <term name="scene" form="short">			 
+      <single>sc.</single>
+      <multiple>scs.</multiple>						 
+    </term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
+    <term name="table" form="short">			 
+      <single>tbl.</single>
+      <multiple>tbls.</multiple>						 
+    </term>
+    <term name="title-locator" form="short">			 
+      <single>tit.</single>
+      <multiple>tits.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -206,6 +453,18 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
@@ -220,13 +479,61 @@
       <single>editor</single>
       <multiple>editores</multiple>
     </term>
+    <term name="executive-producer">
+      <single>executive producer</single>
+      <multiple>executive producers</multiple>
+    </term>
+    <term name="guest">
+      <single>guest</single>
+      <multiple>guests</multiple>
+    </term>
+    <term name="host">
+      <single>host</single>
+      <multiple>hosts</multiple>
+    </term>
     <term name="editorial-director">
       <single>editor</single>
       <multiple>editores</multiple>
     </term>
+    <term name="narrator">
+      <single>narrator</single>
+      <multiple>narrators</multiple>
+    </term>
+    <term name="organizer">
+      <single>organizer</single>
+      <multiple>organizers</multiple>
+    </term>
+    <term name="performer">
+      <single>performer</single>
+      <multiple>performers</multiple>
+    </term>
+    <term name="producer">
+      <single>producer</single>
+      <multiple>producers</multiple>
+    </term>
+    <term name="script-writer">
+      <single>writer</single>
+      <multiple>writers</multiple>
+    </term>
+    <term name="series-creator">
+      <single>series creator</single>
+      <multiple>series creators</multiple>
+    </term>
     <term name="illustrator">
       <single>ilustrador</single>
       <multiple>ilustradores</multiple>
+    </term>
+    <term name="compiler" form="short">
+      <single>comp.</single>
+      <multiple>comps.</multiple>
+    </term>
+    <term name="contributor" form="short">
+      <single>contrib.</single>
+      <multiple>contribs.</multiple>
+    </term>
+    <term name="curator" form="short">
+      <single>cur.</single>
+      <multiple>curs.</multiple>
     </term>
     <term name="translator">
       <single>tradutor</single>
@@ -246,14 +553,45 @@
       <single>ed.</single>
       <multiple>eds.</multiple>
     </term>
+    <term name="executive-producer" form="short">
+      <single>exec. prod.</single>
+      <multiple>exec. prods.</multiple>
+    </term>
     <term name="editorial-director" form="short">
       <single>ed.</single>
       <multiple>eds.</multiple>
+    </term>
+    <term name="narrator" form="short">
+      <single>narr.</single>
+      <multiple>narrs.</multiple>
+    </term>
+    <term name="organizer" form="short">
+      <single>org.</single>
+      <multiple>orgs.</multiple>
+    </term>
+    <term name="performer" form="short">
+      <single>perf.</single>
+      <multiple>perfs.</multiple>
+    </term>
+    <term name="producer" form="short">
+      <single>prod.</single>
+      <multiple>prods.</multiple>
+    </term>
+    <term name="script-writer" form="short">
+      <single>writ.</single>
+      <multiple>writs.</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <single>cre.</single>
+      <multiple>cres.</multiple>
     </term>
     <term name="illustrator" form="short">
       <single>il.</single>
       <multiple>ils.</multiple>
     </term>
+    <term name="chair" form="verb">chaired by</term>
+    <term name="collection-editor" form="verb">edited by</term>
+    <term name="compiler" form="verb">compiled by</term>
     <term name="translator" form="short">
       <single>trad.</single>
       <multiple>trads.</multiple>
@@ -264,21 +602,44 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="contributor" form="verb">with</term>
+    <term name="curator" form="verb">curated by</term>
     <term name="container-author" form="verb">por</term>
     <term name="director" form="verb">dirixido por</term>
     <term name="editor" form="verb">editado por</term>
+    <term name="executive-producer" form="verb">executive produced by</term>
+    <term name="guest" form="verb">with guest</term>
+    <term name="host" form="verb">hosted by</term>
     <term name="editorial-director" form="verb">editorial de</term>
     <term name="illustrator" form="verb">ilustrado por</term>
+    <term name="narrator" form="verb">narrated by</term>
+    <term name="organizer" form="verb">organized by</term>
+    <term name="performer" form="verb">performed by</term>
+    <term name="producer" form="verb">produced by</term>
     <term name="interviewer" form="verb">entrevistado por</term>
     <term name="recipient" form="verb">para</term>
+    <term name="script-writer" form="verb">written by</term>
+    <term name="series-creator" form="verb">created by</term>
     <term name="reviewed-author" form="verb">revisado por</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
+    <term name="compiler" form="verb-short">comp. by</term>
+    <term name="contributor" form="verb-short">w.</term>
+    <term name="curator" form="verb-short">cur. by</term>
     <term name="translator" form="verb">traducido por</term>
     <term name="editortranslator" form="verb">editado &amp; traducido por</term>
 
     <!-- SHORT VERB ROLE FORMS -->
     <term name="director" form="verb-short">dir.</term>
     <term name="editor" form="verb-short">ed.</term>
+    <term name="executive-producer" form="verb-short">exec. prod. by</term>
+    <term name="guest" form="verb-short">w. guest</term>
     <term name="editorial-director" form="verb-short">ed.</term>
+    <term name="narrator" form="verb-short">narr. by</term>
+    <term name="organizer" form="verb-short">org. by</term>
+    <term name="performer" form="verb-short">perf. by</term>
+    <term name="producer" form="verb-short">prod. by</term>
+    <term name="script-writer" form="verb-short">writ. by</term>
+    <term name="series-creator" form="verb-short">cre. by</term>
     <term name="illustrator" form="verb-short">ilus.</term>
     <term name="translator" form="verb-short">trad.</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trad. por</term>

--- a/locales-he-IL.xml
+++ b/locales-he-IL.xml
@@ -57,9 +57,25 @@
     <term name="circa">לערך</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">מצוטט ב</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>מהדורה</single>
       <multiple>מהדורות</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">ואחרים</term>
@@ -82,6 +98,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">אוחזר</term>
     <term name="scale">scale</term>
     <term name="version">גירסה</term>
@@ -272,6 +290,31 @@
       <single>עמוד</single>
       <multiple>עמודים</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>עמוד</single>
       <multiple>עמודים</multiple>
@@ -287,6 +330,10 @@
     <term name="section">
       <single>סעיף</single>
       <multiple>סעיפים</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -351,6 +398,20 @@
       <single>'עמ</single>
       <multiple>'עמ</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>'עמ</single>
       <multiple>'עמ</multiple>
@@ -358,6 +419,10 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">ס'</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -376,12 +441,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -526,6 +607,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -547,6 +629,7 @@
     <term name="interviewer" form="verb">רואיין ע"י</term>
     <term name="recipient" form="verb">אל</term>
     <term name="reviewed-author" form="verb">ע"י</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">תורגם ע"י</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-hi-IN.xml
+++ b/locales-hi-IN.xml
@@ -58,9 +58,25 @@
     <term name="circa">सन </term>
     <term name="circa" form="short">सन.</term>
     <term name="cited">उल्लेखित</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>संस्करण</single>
       <multiple>संस्करण</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">इत्यादि</term>
@@ -83,6 +99,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">पुनर्प्राप्त</term>
     <term name="scale">scale</term>
     <term name="version">संस्करण</term>
@@ -282,6 +300,31 @@
       <single>पृष्ठ</single>
       <multiple>पृष्ठ</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>पृष्ठ संख्या</single>
       <multiple>पृष्ठों की संख्या</multiple>
@@ -297,6 +340,10 @@
     <term name="section">
       <single>अनुभाग</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -388,6 +435,20 @@
       <single>पृ.</single>
       <multiple>पृ.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>पृ. स.</single>
       <multiple>पृ. स.</multiple>
@@ -403,6 +464,10 @@
     <term name="section" form="short">
       <single>sec.</single>
       <multiple>secs.</multiple>
+    </term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
     </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
@@ -422,12 +487,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -572,6 +653,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -593,6 +675,7 @@
     <term name="interviewer" form="verb">साक्षात्कारकर्ता</term>
     <term name="recipient" form="verb">सेवा में</term>
     <term name="reviewed-author" form="verb">द्वारा</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">अनुवाद </term>
     <term name="editortranslator" form="verb">सम्पादन &amp; अनुवाद</term>
 

--- a/locales-hr-HR.xml
+++ b/locales-hr-HR.xml
@@ -57,9 +57,25 @@
     <term name="circa">oko</term>
     <term name="circa" form="short">oko</term>
     <term name="cited">citirano</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>izdanje</single>
       <multiple>izdanja</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">izd.</term>
     <term name="et-al">i sur.</term>
@@ -82,6 +98,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">preuzeto</term>
     <term name="scale">skala</term>
     <term name="version">verzija</term>
@@ -266,6 +284,31 @@
       <single>stranica</single>
       <multiple>stranice</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>stranica</single>
       <multiple>stranice</multiple>
@@ -281,6 +324,10 @@
     <term name="section">
       <single>odjeljak</single>
       <multiple>odjeljci</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -345,6 +392,20 @@
       <single>str.</single>
       <multiple>str.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>str.</single>
       <multiple>str.</multiple>
@@ -352,6 +413,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">dio</term>
     <term name="section" form="short">od.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -370,12 +435,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -520,6 +601,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -541,6 +623,7 @@
     <term name="interviewer" form="verb">intervjuirao</term>
     <term name="recipient" form="verb">primatelj</term>
     <term name="reviewed-author" form="verb">pregledao</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">preveo</term>
     <term name="editortranslator" form="verb">uredio &amp; preveo</term>
 

--- a/locales-hu-HU.xml
+++ b/locales-hu-HU.xml
@@ -57,9 +57,25 @@
     <term name="circa">körülbelül</term>
     <term name="circa" form="short">kb.</term>
     <term name="cited">idézi</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>kiadás</single>
       <multiple>kiadás</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">kiad.</term>
     <term name="et-al">és mtsai.</term>
@@ -82,6 +98,8 @@
       <single>hiv.</single>
       <multiple>hiv.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">elérés</term>
     <term name="scale">skála</term>
     <term name="version">verzió</term>
@@ -266,6 +284,31 @@
       <single>oldal</single>
       <multiple>oldal</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>oldal</single>
       <multiple>oldal</multiple>
@@ -281,6 +324,10 @@
     <term name="section">
       <single>szakasz</single>
       <multiple>szakasz</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -345,6 +392,20 @@
       <single>o.</single>
       <multiple>o.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>o.</single>
       <multiple>o.</multiple>
@@ -352,6 +413,10 @@
     <term name="paragraph" form="short">bek.</term>
     <term name="part" form="short">rész</term>
     <term name="section" form="short">szak.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s. v.</single>
       <multiple>s. vv.</multiple>
@@ -370,12 +435,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -520,6 +601,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -541,6 +623,7 @@
     <term name="interviewer" form="verb">interjúkészítő</term>
     <term name="recipient" form="verb">címzett</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">fordította</term>
     <term name="editortranslator" form="verb">szerkesztette &amp; fordította</term>
 

--- a/locales-id-ID.xml
+++ b/locales-id-ID.xml
@@ -63,9 +63,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">dikutip</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edisi</single>
       <multiple>edisi</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">dkk.</term>
@@ -88,6 +104,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">diambil</term>
     <term name="scale">skala</term>
     <term name="version">versi</term>
@@ -278,6 +296,31 @@
       <single>halaman</single>
       <multiple>halaman</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>halaman</single>
       <multiple>halaman</multiple>
@@ -293,6 +336,10 @@
     <term name="section">
       <single>bagian</single>
       <multiple>bagian</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -357,6 +404,20 @@
       <single>hlm.</single>
       <multiple>hlm.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>hlm.</single>
       <multiple>hlm.</multiple>
@@ -364,6 +425,10 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">bag.</term>
     <term name="section" form="short">bag.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -382,12 +447,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -532,6 +613,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -553,6 +635,7 @@
     <term name="interviewer" form="verb">diwawancara oleh</term>
     <term name="recipient" form="verb">kepada</term>
     <term name="reviewed-author" form="verb">oleh</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">diterjemahkan oleh</term>
     <term name="editortranslator" form="verb">disunting &amp; diterjemahkan oleh</term>
 

--- a/locales-is-IS.xml
+++ b/locales-is-IS.xml
@@ -60,9 +60,25 @@
     <term name="circa">sirka</term>
     <term name="circa" form="short">u.þ.b.</term>
     <term name="cited">tilvitnun</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>útgáfa</single>
       <multiple>útgáfur</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">útg.</term>
     <term name="et-al">o.fl.</term>
@@ -85,6 +101,8 @@
       <single>tilv.</single>
       <multiple>tilv.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">sótt</term>
     <term name="scale">scale</term>
     <term name="version">útgáfa</term>
@@ -269,6 +287,31 @@
       <single>blaðsíða</single>
       <multiple>blaðsíður</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>blaðsíða</single>
       <multiple>blaðsíður</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>hluti</single>
       <multiple>hlutar</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>bls.</single>
       <multiple>bls.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>bls.</single>
       <multiple>bls.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">málsgr.</term>
     <term name="part" form="short">hl.</term>
     <term name="section" form="short">hl.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">viðtal tók</term>
     <term name="recipient" form="verb">til</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">þýddi</term>
     <term name="editortranslator" form="verb">ritstýrt og þýtt af</term>
 

--- a/locales-it-IT.xml
+++ b/locales-it-IT.xml
@@ -59,9 +59,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citato</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition" gender="feminine">
       <single>edizione</single>
       <multiple>edizioni</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et al.</term>
@@ -85,6 +101,8 @@
       <single>rif.</single>
       <multiple>rif.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperato</term>
     <term name="scale">scala</term>
     <term name="version">versione</term>
@@ -291,6 +309,31 @@
       <single>pagina</single>
       <multiple>pagine</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>pagina</single>
       <multiple>pagine</multiple>
@@ -306,6 +349,10 @@
     <term name="section">
       <single>sezione</single>
       <multiple>sezioni</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -373,6 +420,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -380,6 +441,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sez.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -398,12 +463,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>presidente</single>
       <multiple>presidenti</multiple>
@@ -548,6 +629,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">presieduto da</term>
     <term name="compiler" form="verb">compilato da</term>
     <term name="contributor" form="verb">con un contributo di</term>
@@ -569,6 +651,7 @@
     <term name="interviewer" form="verb">intervista di</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">di</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">tradotto da</term>
     <term name="editortranslator" form="verb">a cura di e tradotto da</term>
 

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -65,9 +65,25 @@
     <term name="circa">およそ</term>
     <term name="circa" form="short">およそ</term>
     <term name="cited">引用</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>版</single>
       <multiple>版</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">版</term>
     <term name="et-al">ほか</term>
@@ -90,6 +106,8 @@
       <single>参照</single>
       <multiple>参照</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">読み込み</term>
     <term name="scale">位</term>
     <term name="version">版</term>
@@ -280,6 +298,31 @@
       <single>ページ</single>
       <multiple>ページ</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>ページ</single>
       <multiple>ページ</multiple>
@@ -295,6 +338,10 @@
     <term name="section">
       <single>節</single>
       <multiple>節</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <!--
@@ -363,6 +410,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -370,6 +431,10 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -388,12 +453,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -538,6 +619,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -559,6 +641,7 @@
     <term name="interviewer" form="verb">面接者: </term>
     <term name="recipient" form="verb">受領者: </term>
     <term name="reviewed-author" form="verb">査読者: </term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">翻訳者: </term>
     <term name="editortranslator" form="verb">編集・翻訳者: </term>
 

--- a/locales-km-KH.xml
+++ b/locales-km-KH.xml
@@ -54,9 +54,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edition</single>
       <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et al.</term>
@@ -79,6 +95,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">retrieved</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -269,6 +287,31 @@
       <single>ទំព័រ</single>
       <multiple>ទំព័រ</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>ទំព័រ</single>
       <multiple>ទំព័រ</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>ផ្នែក</single>
       <multiple>ផ្នែក</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">para.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-ko-KR.xml
+++ b/locales-ko-KR.xml
@@ -54,9 +54,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edition</single>
       <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">기타</term>
@@ -79,6 +95,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">retrieved</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -269,6 +287,31 @@
       <single>페이지</single>
       <multiple>페이지</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>페이지</single>
       <multiple>페이지</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>p</single>
       <multiple>pp</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">sec</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">번역자：</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-la.xml
+++ b/locales-la.xml
@@ -57,9 +57,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citatus</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>editio</single>
       <multiple>editiones</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et al.</term>
@@ -82,6 +98,8 @@
       <single>rel.</single>
       <multiple>rell.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperatus</term>
     <term name="scale">scala</term>
     <term name="version">uersio</term>
@@ -266,6 +284,31 @@
       <single>pagina</single>
       <multiple>paginae</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>pagina</single>
       <multiple>paginae</multiple>
@@ -281,6 +324,10 @@
     <term name="section">
       <single>paragraphus</single>
       <multiple>paragraphi</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub uerbo</single>
@@ -345,6 +392,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -352,6 +413,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pr.</term>
     <term name="section" form="short">par.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.u.</single>
       <multiple>s.uu.</multiple>
@@ -370,12 +435,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -520,6 +601,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -541,6 +623,7 @@
     <term name="interviewer" form="verb">a congressione</term>
     <term name="recipient" form="verb">a</term>
     <term name="reviewed-author" form="verb">a</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">a interpretatione</term>
     <term name="editortranslator" form="verb">a cura et interpretatione</term>
 

--- a/locales-lt-LT.xml
+++ b/locales-lt-LT.xml
@@ -59,9 +59,25 @@
     <term name="circa">apie</term>
     <term name="circa" form="short">apie</term>
     <term name="cited">žiūrėta</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition" gender="masculine">
       <single>leidimas</single>
       <multiple>leidimai</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">leid.</term>
     <term name="et-al">ir kt.</term>
@@ -84,6 +100,8 @@
       <single>nuor.</single>
       <multiple>nuor.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">gauta</term>
     <term name="scale">mastelis</term>
     <term name="version">versija</term>
@@ -285,6 +303,31 @@
       <single>puslapis</single>
       <multiple>puslapiai</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages" gender="masculine">
       <single>puslapis</single>
       <multiple>puslapiai</multiple>
@@ -300,6 +343,10 @@
     <term name="section">
       <single>poskyris</single>
       <multiple>poskyriai</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>žiūrėk</single>
@@ -364,6 +411,20 @@
       <single>p.</single>
       <multiple>p.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
@@ -371,6 +432,10 @@
     <term name="paragraph" form="short">pastr.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">posk.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>žr.</single>
       <multiple>žr.</multiple>
@@ -389,12 +454,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -539,6 +620,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -560,6 +642,7 @@
     <term name="interviewer" form="verb">interviu ėmė</term>
     <term name="recipient" form="verb">gavo</term>
     <term name="reviewed-author" form="verb">recenzavo</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">vertė</term>
     <term name="editortranslator" form="verb">sudarė ir vertė</term>
 

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -59,9 +59,25 @@
     <term name="circa">apmēram</term>
     <term name="circa" form="short">apm.</term>
     <term name="cited">citēts</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition" gender="feminine">
       <single>redakcija</single>
       <multiple>redakcijas</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">red.</term>
     <term name="et-al">u.c.</term>
@@ -84,6 +100,8 @@
       <single>ats.</single>
       <multiple>ats.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">iegūts</term>
     <term name="scale">mērogs</term>
     <term name="version">versija</term>
@@ -280,6 +298,31 @@
       <single>lappuse</single>
       <multiple>lappuses</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>lappuse</single>
       <multiple>lappuses</multiple>
@@ -295,6 +338,10 @@
     <term name="section">
       <single>apakšnodaļa</single>
       <multiple>apakšnodaļas</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>skatīt</single>
@@ -359,6 +406,20 @@
       <single>lpp.</single>
       <multiple>lpp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>lpp.</single>
       <multiple>lpp.</multiple>
@@ -366,6 +427,10 @@
     <term name="paragraph" form="short">rindk.</term>
     <term name="part" form="short">d.</term>
     <term name="section" form="short">apakšnod.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>sk.</single>
       <multiple>sk.</multiple>
@@ -383,6 +448,18 @@
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>
+    </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
     </term>
     <term name="section" form="symbol">
       <single>§</single>

--- a/locales-mn-MN.xml
+++ b/locales-mn-MN.xml
@@ -54,9 +54,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edition</single>
       <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">et al.</term>
@@ -79,6 +95,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">retrieved</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -263,6 +281,31 @@
       <single>хуудас</single>
       <multiple>хуудаснууд</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>хуудас</single>
       <multiple>хуудаснууд</multiple>
@@ -278,6 +321,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -342,6 +389,20 @@
       <single>p</single>
       <multiple>pp</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p</single>
       <multiple>pp</multiple>
@@ -349,6 +410,10 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">pt</term>
     <term name="section" form="short">sec</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -367,12 +432,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -517,6 +598,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -538,6 +620,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-nb-NO.xml
+++ b/locales-nb-NO.xml
@@ -56,9 +56,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">sitert</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>utgave</single>
       <multiple>utgave</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">utg.</term>
     <term name="et-al">mfl.</term>
@@ -81,6 +97,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">hentet</term>
     <term name="scale">målestokk</term>
     <term name="version">versjon</term>
@@ -257,6 +275,31 @@
       <single>side</single>
       <multiple>side</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>side</single>
       <multiple>sider</multiple>
@@ -272,6 +315,10 @@
     <term name="section">
       <single>paragraf</single>
       <multiple>paragraf</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -309,12 +356,30 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
     <term name="paragraph" form="short">avsn.</term>
     <term name="section" form="short">pargr.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -333,12 +398,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>leder</single>
       <multiple>ledere</multiple>
@@ -455,6 +536,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">leda av</term>
     <term name="compiler" form="verb">kompilert av</term>
     <term name="contributor" form="verb">med</term>
@@ -476,6 +558,7 @@
     <term name="interviewer" form="verb">intervjuet av</term>
     <term name="recipient" form="verb">til</term>
     <term name="reviewed-author" form="verb">av</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">oversatt av</term>
     <term name="editortranslator" form="verb">redigert &amp; oversatt av</term>
 

--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -58,9 +58,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">geciteerd</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>druk</single>
       <multiple>drukken</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">dr.</term>
     <term name="et-al">e.a.</term>
@@ -83,6 +99,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">geraadpleegd</term>
     <term name="scale">schaal</term>
     <term name="version">versie</term>
@@ -285,6 +303,31 @@
       <single>pagina</single>
       <multiple>pagina's</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>pagina</single>
       <multiple>pagina's</multiple>
@@ -300,6 +343,10 @@
     <term name="section">
       <single>sectie</single>
       <multiple>secties</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -364,6 +411,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -371,6 +432,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">deel</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -389,12 +454,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -539,6 +620,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -560,6 +642,7 @@
     <term name="interviewer" form="verb">geïnterviewd door</term>
     <term name="recipient" form="verb">ontvangen door</term>
     <term name="reviewed-author" form="verb">door</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">vertaald door</term>
     <term name="editortranslator" form="verb">bewerkt &amp; vertaald door</term>
 

--- a/locales-nn-NO.xml
+++ b/locales-nn-NO.xml
@@ -56,9 +56,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">ca.</term>
     <term name="cited">sitert</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>utgåve</single>
       <multiple>utgåve</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">utg.</term>
     <term name="et-al">mfl.</term>
@@ -81,6 +97,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">henta</term>
     <term name="scale">målestokk</term>
     <term name="version">versjon</term>
@@ -257,6 +275,31 @@
       <single>side</single>
       <multiple>side</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>side</single>
       <multiple>sider</multiple>
@@ -272,6 +315,10 @@
     <term name="section">
       <single>paragraf</single>
       <multiple>paragraf</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -309,12 +356,30 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
     <term name="paragraph" form="short">avsn.</term>
     <term name="section" form="short">par.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -333,12 +398,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>leiar</single>
       <multiple>leiarar</multiple>
@@ -455,6 +536,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">leia av</term>
     <term name="compiler" form="verb">kompilert av</term>
     <term name="contributor" form="verb">med</term>
@@ -476,6 +558,7 @@
     <term name="interviewer" form="verb">intervjua av</term>
     <term name="recipient" form="verb">til</term>
     <term name="reviewed-author" form="verb">av</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">omsett av</term>
     <term name="editortranslator" form="verb">redigert &amp; omsett av</term>
 

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -63,9 +63,25 @@
     <term name="circa">około</term>
     <term name="circa" form="short">ok</term>
     <term name="cited">cytowane</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>wydanie</single>
       <multiple>wydania</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">wyd.</term>
     <term name="et-al">i in.</term>
@@ -88,6 +104,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">pobrano</term>
     <term name="scale">skala</term>
     <term name="version">wersja</term>
@@ -272,6 +290,31 @@
       <single>strona</single>
       <multiple>strony</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>strona</single>
       <multiple>strony</multiple>
@@ -287,6 +330,10 @@
     <term name="section">
       <single>sekcja</single>
       <multiple>sekcje</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -351,6 +398,20 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>ss.</multiple>
@@ -358,6 +419,10 @@
     <term name="paragraph" form="short">akap.</term>
     <term name="part" form="short">cz.</term>
     <term name="section" form="short">sekc.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -376,12 +441,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -526,6 +607,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -547,6 +629,7 @@
     <term name="interviewer" form="verb">przeprowadzony przez</term>
     <term name="recipient" form="verb">dla</term>
     <term name="reviewed-author" form="verb">przez</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">przetłumaczone przez</term>
     <term name="editortranslator" form="verb">zredagowane i przetłumaczone przez</term>
 

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -63,9 +63,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citado</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edição</single>
       <multiple>edições</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">et al.</term>
@@ -88,6 +104,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">recuperado</term>
     <term name="scale">escala</term>
     <term name="version">versão</term>
@@ -167,7 +185,7 @@
     <term name="close-quote">”</term>
     <term name="open-inner-quote">‘</term>
     <term name="close-inner-quote">’</term>
-    <term name="page-range-delimiter">&#8211;</term>
+    <term name="page-range-delimiter">–</term>
     <term name="colon">:</term>
     <term name="comma">,</term>
     <term name="semicolon">;</term>
@@ -284,6 +302,31 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>página</single>
       <multiple>páginas</multiple>
@@ -299,6 +342,10 @@
     <term name="section">
       <single>seção</single>
       <multiple>seções</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -363,6 +410,20 @@
       <single>p.</single>
       <multiple>p.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>p.</multiple>
@@ -370,6 +431,10 @@
     <term name="paragraph" form="short">parag.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">seç.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -388,12 +453,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -538,6 +619,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -559,6 +641,7 @@
     <term name="interviewer" form="verb">entrevista de</term>
     <term name="recipient" form="verb">para</term>
     <term name="reviewed-author" form="verb">por</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traduzido por</term>
     <term name="editortranslator" form="verb">editado e traduzido por</term>
 

--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -57,9 +57,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">citado</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>edição</single>
       <multiple>edições</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed.</term>
     <term name="et-al">et al.</term>
@@ -82,6 +98,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">obtido</term>
     <term name="scale">escala</term>
     <term name="version">versão</term>
@@ -277,6 +295,31 @@
       <single>página</single>
       <multiple>páginas</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>página</single>
       <multiple>páginas</multiple>
@@ -292,6 +335,10 @@
     <term name="section">
       <single>secção</single>
       <multiple>secções</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -356,6 +403,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -363,6 +424,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">pt.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -381,12 +446,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>cadeira</single>
       <multiple>cadeiras</multiple>
@@ -531,6 +612,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">presidido por</term>
     <term name="compiler" form="verb">compilado por</term>
     <term name="contributor" form="verb">com</term>
@@ -552,6 +634,7 @@
     <term name="interviewer" form="verb">entrevistado por</term>
     <term name="recipient" form="verb">para</term>
     <term name="reviewed-author" form="verb">revisto por</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traduzido por</term>
     <term name="editortranslator" form="verb">editado e traduzido por</term>
 

--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -58,9 +58,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">cca.</term>
     <term name="cited">citat</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>ediția</single>
       <multiple>edițiile</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">ed</term>
     <term name="et-al">et al.</term>
@@ -83,6 +99,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">preluat în</term>
     <term name="scale">scală</term>
     <term name="version">versiunea</term>
@@ -268,6 +286,31 @@
       <single>pagina</single>
       <multiple>paginile</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>pagina</single>
       <multiple>paginile</multiple>
@@ -283,6 +326,10 @@
     <term name="section">
       <single>secțiunea</single>
       <multiple>secțiunile</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -347,6 +394,20 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>p.</single>
       <multiple>pp.</multiple>
@@ -354,6 +415,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">part.</term>
     <term name="section" form="short">sec.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -372,12 +437,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -522,6 +603,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -543,6 +625,7 @@
     <term name="interviewer" form="verb">interviu de</term>
     <term name="recipient" form="verb">în</term>
     <term name="reviewed-author" form="verb">de</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">traducere de</term>
     <term name="editortranslator" form="verb">ediție și traducere de</term>
 

--- a/locales-ru-RU.xml
+++ b/locales-ru-RU.xml
@@ -59,9 +59,25 @@
     <term name="circa" form="short">ок.</term>
     <term name="cited">цитируется по</term>
     <term name="cited" form="short">цит. по</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition"> <!-- gender="neuter" -->
       <single>издание</single>
       <multiple>издания</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">изд.</term>
     <term name="et-al">и др.</term>
@@ -86,6 +102,8 @@
       <single>ссылка</single>
       <multiple>ссылки</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">извлечено</term>
     <term name="scale">масштаб</term>
     <term name="version">версия</term>
@@ -293,6 +311,31 @@
       <multiple>страницы</multiple>
     </term>
     <!-- для однообразности здесь тоже указали род, но использование кол-ва страниц с порядковым числительным маловероятно -->
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages" gender="feminine">
       <single>страница</single>
       <multiple>страницы</multiple>
@@ -308,6 +351,10 @@
     <term name="section">
       <single>раздел</single>
       <multiple>разделы</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">смотри</term>
     <term name="verse">
@@ -373,6 +420,20 @@
       <single>с.</single>
       <multiple>сс.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>с.</single>
       <multiple>сс.</multiple>
@@ -386,6 +447,10 @@
       <multiple>чч.</multiple>
     </term>
     <term name="section" form="short">разд.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">см.</term>
     <term name="verse" form="short">ст.</term>
     <term name="volume" form="short">
@@ -398,12 +463,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -530,6 +611,7 @@
     <term name="editortranslator" form="short">ред. и пер.</term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -552,6 +634,7 @@
     <term name="interviewer" form="verb">интервью проведено</term>
     <term name="recipient" form="verb">к</term>
     <term name="reviewed-author" form="verb"></term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">переведено</term>
     <term name="editortranslator" form="verb">под редакцией и переведено</term>
 

--- a/locales-sk-SK.xml
+++ b/locales-sk-SK.xml
@@ -60,9 +60,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">cca.</term>
     <term name="cited">cit</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>vydanie</single>
       <multiple>vydania</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">vyd.</term>
     <term name="et-al">et al.</term>
@@ -85,6 +101,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">cit</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -275,6 +293,31 @@
       <single>strana</single>
       <multiple>strany</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>strana</single>
       <multiple>strany</multiple>
@@ -290,6 +333,10 @@
     <term name="section">
       <single>sekcia</single>
       <multiple>sekcie</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -354,6 +401,20 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
@@ -361,6 +422,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">č.</term>
     <term name="section" form="short">sek.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -379,12 +444,28 @@
       <single>¶</single>
       <multiple>¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -529,6 +610,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -550,6 +632,7 @@
     <term name="interviewer" form="verb">rozhovor urobil</term>
     <term name="recipient" form="verb">adresát</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">preložil</term>
     <term name="editortranslator" form="verb">zostavil &amp; preložil</term>
 

--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -60,9 +60,25 @@
     <term name="circa">približno</term>
     <term name="circa" form="short">prib.</term>
     <term name="cited">citirano</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>izdaja</single>
       <multiple>izdaje</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">izd.</term>
     <term name="et-al">idr.</term>
@@ -85,6 +101,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">pridobljeno</term>
     <term name="scale">merilo</term>
     <term name="version">različica</term>
@@ -269,6 +287,31 @@
       <single>stran</single>
       <multiple>strani</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>stran</single>
       <multiple>strani</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>odsek</single>
       <multiple>odseki</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>str.</single>
       <multiple>str.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>str.</single>
       <multiple>str.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">odst.</term>
     <term name="part" form="short">del</term>
     <term name="section" form="short">ods.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s. v.</single>
       <multiple>s. v.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">intervjuval</term>
     <term name="recipient" form="verb">za</term>
     <term name="reviewed-author" form="verb">od</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">prevedel</term>
     <term name="editortranslator" form="verb">uredil &amp; prevedel</term>
 

--- a/locales-sr-RS.xml
+++ b/locales-sr-RS.xml
@@ -54,9 +54,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">цитирано</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>издање</single>
       <multiple>издања</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">изд.</term>
     <term name="et-al">и остали</term>
@@ -79,6 +95,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">преузето</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -269,6 +287,31 @@
       <single>страница</single>
       <multiple>странице</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>страница</single>
       <multiple>странице</multiple>
@@ -284,6 +327,10 @@
     <term name="section">
       <single>одељак</single>
       <multiple>одељака</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -348,6 +395,20 @@
       <single>стр.</single>
       <multiple>стр.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>стр.</single>
       <multiple>стр.</multiple>
@@ -355,6 +416,10 @@
     <term name="paragraph" form="short">пар.</term>
     <term name="part" form="short">део</term>
     <term name="section" form="short">од.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -373,12 +438,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -523,6 +604,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -544,6 +626,7 @@
     <term name="interviewer" form="verb">интервјуисао</term>
     <term name="recipient" form="verb">прима</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">превео</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-sv-SE.xml
+++ b/locales-sv-SE.xml
@@ -66,9 +66,25 @@
     <term name="circa">cirka</term>
     <term name="circa" form="short">ca</term>
     <term name="cited">citerad</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>upplaga</single>
       <multiple>upplagor</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">uppl.</term>
     <term name="et-al">m.fl.</term>
@@ -91,6 +107,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">hämtad</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -279,6 +297,31 @@
       <single>sida</single>
       <multiple>sidor</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>sida</single>
       <multiple>sidor</multiple>
@@ -294,6 +337,10 @@
     <term name="section">
       <single>avsnitt</single>
       <multiple>avsnitt</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -358,6 +405,20 @@
       <single>s.</single>
       <multiple>s.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>s.</multiple>
@@ -365,6 +426,10 @@
     <term name="paragraph" form="short">st.</term>
     <term name="part" form="short">del</term>
     <term name="section" form="short">avs.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -383,12 +448,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -533,6 +614,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -554,6 +636,7 @@
     <term name="interviewer" form="verb">intervjuad av</term>
     <term name="recipient" form="verb">till</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">översatt av</term>
     <term name="editortranslator" form="verb">redigerad &amp; översatt av</term>
 

--- a/locales-th-TH.xml
+++ b/locales-th-TH.xml
@@ -57,9 +57,25 @@
     <term name="circa">โดยประมาณ</term>
     <term name="circa" form="short">ประมาณ</term>
     <term name="cited">อ้างถึง</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>พิมพ์ครั้งที่</single>
       <multiple>พิมพ์ครั้งที่</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">พิมพ์ครั้งที่</term>
     <term name="et-al">และคณะ</term>
@@ -82,6 +98,8 @@
       <single>อ้างอิง</single>
       <multiple>อ้างอิง</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">สืบค้น</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -266,6 +284,31 @@
       <single>หน้า</single>
       <multiple>หน้า</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>หน้า</single>
       <multiple>หน้า</multiple>
@@ -281,6 +324,10 @@
     <term name="section">
       <single>หมวด</single>
       <multiple>หมวด</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>ใต้คำ</single>
@@ -345,6 +392,20 @@
       <single>น.</single>
       <multiple>น.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>น.</single>
       <multiple>น.</multiple>
@@ -352,6 +413,10 @@
     <term name="paragraph" form="short">ย่อหน้า</term>
     <term name="part" form="short">ส่วนย่อย</term>
     <term name="section" form="short">หมวด</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>ใต้คำ</single>
       <multiple>ใต้คำ</multiple>
@@ -370,12 +435,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -520,6 +601,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -541,6 +623,7 @@
     <term name="interviewer" form="verb">สัมภาษณ์โดย</term>
     <term name="recipient" form="verb">ถึง</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">แปลโดย</term>
     <term name="editortranslator" form="verb">แปลและเรียบเรียงโดย</term>
 

--- a/locales-tr-TR.xml
+++ b/locales-tr-TR.xml
@@ -67,9 +67,25 @@
     <term name="circa">yaklaşık</term>
     <term name="circa" form="short">yakl.</term>
     <term name="cited">a.yer</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>baskı</single>
       <multiple>baskı</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">bs</term>
     <term name="et-al">vd.</term>
@@ -92,6 +108,8 @@
       <single>kay.</single>
       <multiple>kay.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">geliş tarihi</term>
     <term name="scale">ölçek</term>
     <term name="version">versiyon</term>
@@ -276,6 +294,31 @@
       <single>sayfa</single>
       <multiple>sayfalar</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>sayfa sayısı</single>
       <multiple>sayfa sayıları</multiple>
@@ -291,6 +334,10 @@
     <term name="section">
       <single>bölüm</single>
       <multiple>bölümler</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>madde</single>
@@ -355,6 +402,20 @@
       <single>s.</single>
       <multiple>ss.</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>s.</single>
       <multiple>ss.</multiple>
@@ -362,6 +423,10 @@
     <term name="paragraph" form="short">par.</term>
     <term name="part" form="short">ksm.</term>
     <term name="section" form="short">blm.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>md.</single>
       <multiple>md.</multiple>
@@ -380,12 +445,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -530,6 +611,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -551,6 +633,7 @@
     <term name="interviewer" form="verb">röportaj yapan</term>
     <term name="recipient" form="verb">alıcı</term>
     <term name="reviewed-author" form="verb">tanıtım yazarı</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">çeviren</term>
     <term name="editortranslator" form="verb">düzenleyen &amp; çeviren by</term>
 

--- a/locales-uk-UA.xml
+++ b/locales-uk-UA.xml
@@ -54,7 +54,23 @@
     <term name="circa">близько</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">цит. за</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">видання</term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
     <term name="edition" form="short">вид.</term>
     <term name="et-al">et al.</term>
     <term name="forthcoming">майбутній</term>
@@ -70,6 +86,8 @@
     <term name="presented at">представлена на</term>
     <term name="reference">список використаних джерел</term>
     <term name="reference" form="short">джерела</term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">вилучено</term>
     <term name="scale">масштаб</term>
     <term name="version">версія</term>
@@ -248,6 +266,31 @@
       <multiple>opera</multiple>
     </term>
     <term name="page">С.</term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">с.</term>
     <term name="paragraph">
       <single>параграф</single>
@@ -260,6 +303,10 @@
     <term name="section">
       <single>розділ</single>
       <multiple>розділи</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -321,10 +368,28 @@
     <term name="note" form="short">прим.</term>
     <term name="opus" form="short">оп.</term>
     <term name="page" form="short">с.</term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">с.</term>
     <term name="paragraph" form="short">пар.</term>
     <term name="part" form="short">ч.</term>
     <term name="section" form="short">сек.</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -337,12 +402,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -460,6 +541,7 @@
     <term name="editortranslator" form="short">ред. &amp; пер.</term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -481,6 +563,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
 

--- a/locales-vi-VN.xml
+++ b/locales-vi-VN.xml
@@ -57,9 +57,25 @@
     <term name="circa">circa</term>
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">
       <single>ấn bản</single>
       <multiple>ấn bản</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
     </term>
     <term name="edition" form="short">a.b</term>
     <term name="et-al">và c.s.</term>
@@ -82,6 +98,8 @@
       <single>ref.</single>
       <multiple>refs.</multiple>
     </term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">truy vấn</term>
     <term name="scale">scale</term>
     <term name="version">version</term>
@@ -272,6 +290,31 @@
       <single>trang</single>
       <multiple>trang</multiple>
     </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">
       <single>trang</single>
       <multiple>trang</multiple>
@@ -287,6 +330,10 @@
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
@@ -351,6 +398,20 @@
       <single>tr</single>
       <multiple>tr</multiple>
     </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">
       <single>tr</single>
       <multiple>tr</multiple>
@@ -358,6 +419,10 @@
     <term name="paragraph" form="short">para</term>
     <term name="part" form="short">ph</term>
     <term name="section" form="short">sec</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
@@ -376,12 +441,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -526,6 +607,7 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -547,6 +629,7 @@
     <term name="interviewer" form="verb">interview by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">bởi</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">biên dịch bởi</term>
     <term name="editortranslator" form="verb">biên tập &amp; biên dịch bởi</term>
 

--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -63,7 +63,23 @@
     <term name="circa">介于</term>
     <term name="circa" form="short">约</term>
     <term name="cited">见引于</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">版本</term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
     <term name="edition" form="short">本</term>
     <term name="et-al">等</term>
     <term name="forthcoming">即将出版</term>
@@ -79,6 +95,8 @@
     <term name="presented at">发表于</term>
     <term name="reference">参考</term>
     <term name="reference" form="short">参</term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">取读于</term>
     <term name="scale">比例</term>
     <term name="version">版</term>
@@ -233,10 +251,39 @@
     <term name="note">注脚</term>
     <term name="opus">作品</term>      
     <term name="page">页</term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages"> 总页数</term>      
     <term name="paragraph">段落</term>
     <term name="part">部分</term>     
     <term name="section">节</term>         
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
+    </term>
     <term name="sub-verbo">另见</term>    
     <term name="verse">篇</term>    
     <term name="volume">卷</term>
@@ -288,10 +335,28 @@
     <term name="note" form="short">注</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">页</term>   
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">共</term>    
     <term name="paragraph" form="short">段</term>
     <term name="part" form="short">部</term>
     <term name="section" form="short">节</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">另见</term>   
     <term name="verse" form="short">篇</term>      
     <term name="volume" form="short">卷</term>
@@ -301,12 +366,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
@@ -415,6 +496,7 @@
     <term name="editortranslator" form="short">编译</term>    
 
     <!-- VERB ROLE FORMS -->
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="compiler" form="verb">compiled by</term>
     <term name="contributor" form="verb">with</term>
@@ -436,6 +518,7 @@
     <term name="interviewer" form="verb">采访</term>
     <term name="recipient" form="verb">受函</term>
     <term name="reviewed-author" form="verb">校订</term>
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="translator" form="verb">翻译</term>
     <term name="editortranslator" form="verb">编译</term>
 

--- a/locales-zh-TW.xml
+++ b/locales-zh-TW.xml
@@ -57,7 +57,23 @@
     <term name="circa">介於</term>
     <term name="circa" form="short">約</term>
     <term name="cited">見引於</term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
     <term name="edition">版本</term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
     <term name="edition" form="short">本</term>
     <term name="et-al">等</term>
     <term name="forthcoming">即將出版</term>
@@ -73,6 +89,8 @@
     <term name="presented at">發表於</term>
     <term name="reference">參考</term>
     <term name="reference" form="short">參</term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">讀取於</term>
     <term name="scale">比例</term>
     <term name="version">版</term>
@@ -227,10 +245,39 @@
     <term name="note">註腳</term>
     <term name="opus">作品</term>      
     <term name="page">頁</term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>coll.</single>
+      <multiple>colls.</multiple>
+    </term>
     <term name="number-of-pages">總頁數</term>      
     <term name="paragraph">段落</term>
     <term name="part">部分</term>     
     <term name="section">節</term>         
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
+    </term>
     <term name="sub-verbo">另見</term>    
     <term name="verse">篇</term>    
     <term name="volume">卷</term>
@@ -281,10 +328,28 @@
     <term name="note" form="short">註</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">頁</term>   
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints.</multiple>
+    </term>
+    
+
     <term name="number-of-pages" form="short">共</term>    
     <term name="paragraph" form="short">段</term>
     <term name="part" form="short">部</term>
     <term name="section" form="short">節</term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
     <term name="sub-verbo" form="short">另見</term>   
     <term name="verse" form="short">篇</term>      
     <term name="volume" form="short">卷</term>
@@ -294,12 +359,28 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>collection</single>
+      <multiple>collections</multiple>
+    </term>
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
+    <term name="collection-editor">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>

--- a/util/add-locale-terms.py
+++ b/util/add-locale-terms.py
@@ -1,0 +1,114 @@
+# MIT license
+
+# Copy new terms of `locales-en-US.xml` to other locals.
+
+# Step 1: Add new terms in `locales-en-US.xml`. Make sure the "short", "verb", 
+#         "verb-short" forms of each new term are also included.
+# Step 2: Run `python3 add-locale-terms.py`
+
+
+import glob
+import os
+import re
+
+from lxml import etree
+
+
+LOCALES_DIR = '.'
+NSMAP = {'cs': 'http://purl.org/net/xbiblio/csl'}
+
+
+def get_term_id(term) -> str:
+    # e.g., `editor|short`
+    term_id = term.attrib['name']
+    if 'form' in term.attrib:
+        term_id += '|' + term.attrib['form']
+    # ignore "gender" and "gender-form"
+    return term_id
+
+
+def add_new_terms_to_locale(path, element_tree, new_terms, english_term_ids,
+                            english_term_dict, locale_terms_el,
+                            locale_term_ids, locale_term_list):
+    for term_id in new_terms:
+        common_terms = [
+            tid for tid in english_term_ids if tid in locale_term_ids
+        ]
+
+        previous_terms = english_term_ids[:english_term_ids.index(term_id)]
+        previous_common_term = [
+            tid for tid in previous_terms if tid in common_terms
+        ][-1]
+        insert_index = locale_terms_el.index(
+            locale_term_list[locale_term_ids.index(previous_common_term)])
+        locale_terms_el.insert(insert_index, english_term_dict[term_id])
+
+    et_str = etree.tostring(element_tree,
+                            pretty_print=True,
+                            xml_declaration=True,
+                            encoding='utf-8').decode('utf-8')
+                
+    # https://github.com/citation-style-language/utilities/blob/master/csl-reindenting-and-info-reordering.py
+    et_str = et_str.replace("'", '"', 4)  # replace quotes on XML declaration
+
+    et_str = et_str.replace(' ', '&#160;')  # no-break space
+    # et_str = et_str.replace('ᵉ', '&#7497;')
+    et_str = et_str.replace(' ', '&#8195;')  # em space
+    et_str = et_str.replace(' ', '&#8201;')  # thin space
+    et_str = et_str.replace('‑', '&#8209;')  # non-breaking hyphen
+    # # et_str = et_str.replace('–', "&#8211;")  # en dash
+    # et_str = et_str.replace('—', '&#8212;')  # em dash
+    et_str = et_str.replace(' ', '&#8239;')  # narrow no-break space
+
+    et_str = re.sub(r'<term (.*?)/>', r'<term \1></term>', et_str)
+    et_str = et_str.replace('<single/>', '<single></single>')
+    et_str = et_str.replace('<multiple/>', '<multiple></multiple>')
+
+    with open(path, 'w') as f:
+        f.write(et_str.strip())
+        f.write('\n')
+
+
+def main():
+    english_locale = 'locales-en-US.xml'
+    english_path = os.path.join(LOCALES_DIR, english_locale)
+    english_term_dict = dict()
+    english_term_ids = []
+
+    for term in etree.parse(english_path).findall('.//cs:term', NSMAP):
+        term_id = get_term_id(term)
+        english_term_ids.append(term_id)
+        english_term_dict[term_id] = term
+
+    for path in sorted(glob.glob(os.path.join(LOCALES_DIR, 'locales-*.xml'))):
+        locale_file = os.path.split(path)[1]
+        if locale_file == english_locale:
+            continue
+
+        element_tree = etree.parse(path)
+        locale_terms_el = element_tree.find('.//cs:terms', NSMAP)
+
+        locale_term_ids = []
+        locale_term_list = []
+        for term in locale_terms_el.findall('.//cs:term', NSMAP):
+            term_id = get_term_id(term)
+            locale_term_ids.append(term_id)
+            locale_term_list.append(term)
+
+        new_terms = [
+            term_id for term_id in english_term_ids
+            if term_id not in locale_term_ids and 'ordinal-' not in term_id
+        ]
+        new_terms = [
+            term_id for term_id in new_terms
+            if term_id.split('|')[0] in new_terms
+        ]
+        if new_terms:
+            add_new_terms_to_locale(path, element_tree, new_terms,
+                                    english_term_ids, english_term_dict,
+                                    locale_terms_el, locale_term_ids,
+                                    locale_term_list)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes https://github.com/citation-style-language/locales/issues/282

Added missing terms to en-US and alphabetized the file. It will ultimately be easier to keep the other locales updated if things are alphabetized vs. separating out 1.0.2 terms vs. others