### PR TITLE
Resolve duplicate terms

### DIFF
--- a/locales-bg-BG.xml
+++ b/locales-bg-BG.xml
@@ -2,7 +2,7 @@
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="bg-BG">
   <info>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2018-02-15T04:14:02+00:00</updated>
+    <updated>2024-03-12T14:00:50+00:00</updated>
     <translator>
       <name>Valeriya Simeonova</name>
       <email>simeonova@fmi.uni-sofia.bg</email>
@@ -353,7 +353,6 @@
       <single>cit.</single>
       <multiple>cits.</multiple>
     </term>
-    <term name="issue" form="short">бр.</term>
     <term name="number-of-pages">брой страници</term>
     <term name="paragraph">
       <single>абзац</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -17,7 +17,7 @@
       <name>Brenton M. Wiernik</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2015-10-10T23:31:02+00:00</updated>
+    <updated>2024-03-12T13:41:31+00:00</updated>
   </info>
   <style-options punctuation-in-quote="true"/>
   <date form="text">
@@ -334,7 +334,7 @@
       <single>bk.</single>
       <multiple>bks.</multiple>
     </term>
-    <term name="canon">			 
+    <term name="canon" form="short">
       <single>c.</single>
       <multiple>cc.</multiple>						 
     </term>
@@ -453,10 +453,6 @@
     <term name="collection-number">
       <single>number</single>
       <multiple>numbers</multiple>
-    </term>
-    <term name="edition">
-      <single>edition</single>
-      <multiple>editions</multiple>
     </term>
     <term name="edition">
       <single>edition</single>
@@ -619,7 +615,7 @@
     <!-- Omitted roles: 
          author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author 
     -->
-    <term name="collection-editor">
+    <term name="collection-editor" form="short">
       <single>ed.</single>
       <multiple>eds.</multiple>
     </term>

--- a/locales-ja-JP.xml
+++ b/locales-ja-JP.xml
@@ -8,7 +8,7 @@
       <name>cmplstofB</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2023-09-21T23:31:02+00:00</updated>
+    <updated>2024-03-12T14:01:18+00:00</updated>
     <!--
       日本語化にあたって参考にした文献
       * SIST 02:2007「参照文献の書き方」
@@ -168,7 +168,7 @@
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic" form="short">graph.</term>
-    <term name="interview">面接</term>
+    <term name="interview" form="short">面接</term>
     <term name="manuscript" form="short">MS</term>
     <term name="motion_picture" form="short">video rec.</term>
     <term name="report" form="short">rep.</term>

--- a/locales-pt-BR.xml
+++ b/locales-pt-BR.xml
@@ -11,7 +11,7 @@
       <name>Renato Cirino</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2016-05-16T00:00:00+03:00</updated>
+    <updated>2024-03-12T14:06:50+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false" limit-day-ordinals-to-day-1="true"/>
   <date form="text">
@@ -116,9 +116,9 @@
     <term name="article-magazine">artigo de revista</term>
     <term name="article-newspaper">artigo de jornal</term>
     <term name="bill">lei</term>
-    <term name="book">livro</term>
+    <!-- book is in the list of locator terms -->
     <term name="broadcast">transmissão</term>
-    <term name="chapter">capítulo de livro</term>
+    <!-- chapter is in the list of locator terms -->
     <term name="classic">clássico</term>
     <term name="collection">coleção</term>
     <term name="dataset">dataset</term>


### PR DESCRIPTION
Fixed two missing `form="short"` and one duplicate `edition` term in `en-US` locale.