### PR TITLE
Wrong translation for "Online" pt-PT

### DIFF
--- a/locales-pt-PT.xml
+++ b/locales-pt-PT.xml
@@ -88,7 +88,7 @@
     <term name="letter">carta</term>
     <term name="no date">sem data</term>
     <term name="no date" form="short">sem data</term>
-    <term name="online">em linha</term>
+    <term name="online">online</term>
     <term name="presented at">apresentado na</term>
     <term name="reference">
       <single>referência</single>


### PR DESCRIPTION
### Description

The translation found in https://github.com/citation-style-language/locales/blob/master/locales-pt-PT.xml#L91 for "Online" is "Em linha" which is wrong. "Em linha" is the literal translation for "On line", but there is no translation for many foreign words, including "Online".
