### PR TITLE
312 finnish localisation page range string

### DIFF
--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -13,6 +13,9 @@
     <translator>
       <name>Juhana Venäläinen</name>
     </translator>
+    <translator>
+      <name>Santtu Söderholm</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -402,7 +402,7 @@
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
       <single>s.</single>
-      <multiple>ss.</multiple>
+      <multiple>s.</multiple>
     </term>
     <term name="number-of-volumes" form="short">
       <single>vol.</single>
@@ -420,7 +420,7 @@
 
     <term name="number-of-pages" form="short">
       <single>s.</single>
-      <multiple>ss.</multiple>
+      <multiple>s.</multiple>
     </term>
     <term name="paragraph" form="short">kappale</term>
     <term name="part" form="short">osa</term>

--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -215,49 +215,49 @@
     <term name="long-ordinal-10">kymmenes</term>
 
     <!-- LONG LOCATOR FORMS -->
-    <term name="act">			 
+    <term name="act">
       <single>act</single>
-      <multiple>acts</multiple>						 
+      <multiple>acts</multiple>
     </term>
-    <term name="appendix">			 
+    <term name="appendix">
       <single>appendix</single>
-      <multiple>appendices</multiple>						 
+      <multiple>appendices</multiple>
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator">
       <single>article</single>
-      <multiple>articles</multiple>						 
+      <multiple>articles</multiple>
     </term>
-    <term name="canon">			 
+    <term name="canon">
       <single>canon</single>
-      <multiple>canons</multiple>						 
+      <multiple>canons</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation">
       <single>location</single>
-      <multiple>locations</multiple>						 
+      <multiple>locations</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation">
       <single>equation</single>
-      <multiple>equations</multiple>						 
+      <multiple>equations</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule">
       <single>rule</single>
-      <multiple>rules</multiple>						 
+      <multiple>rules</multiple>
     </term>
-    <term name="scene">			 
+    <term name="scene">
       <single>scene</single>
-      <multiple>scenes</multiple>						 
+      <multiple>scenes</multiple>
     </term>
-    <term name="table">			 
+    <term name="table">
       <single>table</single>
-      <multiple>tables</multiple>						 
+      <multiple>tables</multiple>
     </term>
     <term name="timestamp"> <!-- generally blank -->
       <single></single>
-      <multiple></multiple>						 
+      <multiple></multiple>
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator">
       <single>title</single>
-      <multiple>titles</multiple>						 
+      <multiple>titles</multiple>
     </term>
     <term name="book">
       <single>kirja</single>
@@ -355,39 +355,39 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix" form="short">			 
+    <term name="appendix" form="short">
       <single>app.</single>
-      <multiple>apps.</multiple>						 
+      <multiple>apps.</multiple>
     </term>
-    <term name="article-locator" form="short">			 
+    <term name="article-locator" form="short">
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
-    <term name="elocation" form="short">			 
+    <term name="elocation" form="short">
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation" form="short">			 
+    <term name="equation" form="short">
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
-    <term name="rule" form="short">			 
+    <term name="rule" form="short">
       <single>r.</single>
-      <multiple>rr.</multiple>						 
+      <multiple>rr.</multiple>
     </term>
-    <term name="scene" form="short">			 
+    <term name="scene" form="short">
       <single>sc.</single>
-      <multiple>scs.</multiple>						 
+      <multiple>scs.</multiple>
     </term>
-    <term name="table" form="short">			 
+    <term name="table" form="short">
       <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
+      <multiple>tbls.</multiple>
     </term>
     <term name="timestamp" form="short"> <!-- generally blank -->
       <single></single>
-      <multiple></multiple>						 
+      <multiple></multiple>
     </term>
-    <term name="title-locator" form="short">			 
+    <term name="title-locator" form="short">
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>
@@ -416,7 +416,7 @@
       <single>print.</single>
       <multiple>prints.</multiple>
     </term>
-    
+
 
     <term name="number-of-pages" form="short">
       <single>s.</single>


### PR DESCRIPTION
## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.

In addition, please fill out the pull request template below.

### Description

Changed page range strings of Finnish localization file from `ss.` to `s.`, when here are multiple pages in the range. This is according to the latest guidelines set by the Finnish Center for Domestic Languages at <https://kielitoimistonohjepankki.fi/ohje/lahdeluettelo/>.

Also removed a *lot* of unnecessary trailing whitespace from the file in the first attached commit. My editor is set to do that automatically.

Closes #312.

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
