### PR TITLE
Patch 1

### DIFF
--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -11,7 +11,7 @@
       <name>Pendzoncymisio</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2012-07-04T23:31:02+00:00</updated>
+    <updated>2024-06-27T15:28:46+02:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -106,7 +106,7 @@
     </term>
     <term name="review-of">review of</term>
     <term name="review-of" form="short">rev. of</term>
-    <term name="retrieved">pobrano</term>
+    <term name="retrieved">pobrane</term>
     <term name="scale">skala</term>
     <term name="version">wersja</term>
 
@@ -657,19 +657,19 @@
     <term name="editortranslator" form="verb-short">red.tłum.</term>
 
     <!-- LONG MONTH FORMS -->
-    <term name="month-01">styczeń</term>
-    <term name="month-02">luty</term>
-    <term name="month-03">marzec</term>
-    <term name="month-04">kwiecień</term>
-    <term name="month-05">maj</term>
-    <term name="month-06">czerwiec</term>
-    <term name="month-07">lipiec</term>
-    <term name="month-08">sierpień</term>
-    <term name="month-09">wrzesień</term>
-    <term name="month-10">październik</term>
-    <term name="month-11">listopad</term>
-    <term name="month-12">grudzień</term>
-
+    <term name="month-01">stycznia</term>
+    <term name="month-02">lutego</term>
+    <term name="month-03">marca</term>
+    <term name="month-04">kwietnia</term>
+    <term name="month-05">maja</term>
+    <term name="month-06">czerwca</term>
+    <term name="month-07">lipca</term>
+    <term name="month-08">sierpnia</term>
+    <term name="month-09">września</term>
+    <term name="month-10">października</term>
+    <term name="month-11">listopada</term>
+    <term name="month-12">grudnia</term>
+    
     <!-- SHORT MONTH FORMS -->
     <term name="month-01" form="short">sty.</term>
     <term name="month-02" form="short">luty</term>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -10,6 +10,9 @@
     <translator>
       <name>Pendzoncymisio</name>
     </translator>
+    <translator>
+      <name>Natalia L</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2024-06-27T15:28:46+02:00</updated>
   </info>

--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -86,7 +86,7 @@
     <term name="edition" form="short">wyd.</term>
     <term name="et-al">i in.</term>
     <term name="forthcoming">w przygotowaniu</term>
-    <term name="from">z</term>
+    <term name="from">z:</term>
     <term name="ibid">ibid.</term>
     <term name="in">w</term>
     <term name="in press">w druku</term>


### PR DESCRIPTION
### Description

The changes I'm proposing are based on APA7 standards for Polish language:

Skimina, E., Harasimczuk, J., Cieciuch, J. (2022). Podstawowe standardy edytorskie naukowych tekstów psychologicznych w języku polskim na podstawie reguł APA 7. Wydawnictwo Liberi Libri. https://doi.org/10.47943/lib.9788363487560 

according to that resouce for websites the correct format is instead of: 
`Doe, J. (b.d.). Article title. Pobrano 27 czerwiec 2022, z https://mywebsite.org/my-article`
it should be:

`Doe, J. (b.d.). Article title. Pobrane 27 czerwca 2022, z: https://mywebsite.org/my-article`

therefore I needed to fix long month forms, `from` and `retrieved` fields.


### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
