### PR TITLE
Remove verb forms of "author" term

### DIFF
--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -685,7 +685,6 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="author" form="verb">by</term>
     <term name="chair" form="verb">chaired by</term>
     <term name="collection-editor" form="verb">edited by</term>
     <term name="compiler" form="verb">compiled by</term>

--- a/locales-pa-PK.xml
+++ b/locales-pa-PK.xml
@@ -440,7 +440,6 @@
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="author" form="verb">بقلم</term>
     <term name="chair" form="verb">چیر نال</term>
     <term name="collection-editor" form="verb">سودھی نال</term>
     <term name="compiler" form="verb">مرتب نال</term>


### PR DESCRIPTION
Styles are generally written expecting these terms to be empty. (cf. https://forums.zotero.org/discussion/116703/zotero-7-inserting-by-into-subsequent-cites#latest)

@adamsmith The author terms were added to zh-TW before they were added to the en-US locale, so I'm not sure whether to keep them. They are not included in the zh-CN locale. What do you think? https://github.com/citation-style-language/locales/commit/3f25b0c9e3c5958fdf054765d05f4f707784f59a
