### PR TITLE
Improvements to German-language locales

### DIFF
--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -297,8 +297,8 @@
       <multiple>Zeilen</multiple>
     </term>
     <term name="note">
-      <single>Note</single>
-      <multiple>Noten</multiple>
+      <single>Anmerkung</single>
+      <multiple>Anmerkungen</multiple>
     </term>
     <term name="opus">
       <single>Opus</single>
@@ -408,7 +408,7 @@
     <term name="folio" form="short">Fol.</term>
     <term name="issue" form="short">Nr.</term>
     <term name="line" form="short">Z.</term>
-    <term name="note" form="short">N.</term>
+    <term name="note" form="short">Anm.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
       <single>S.</single>

--- a/locales-de-AT.xml
+++ b/locales-de-AT.xml
@@ -22,6 +22,9 @@
     <translator>
       <name>Patrick O'Brien</name>
     </translator>
+    <translator>
+      <name>Nicolas Chachereau</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2023-03-28T23:31:02+00:00</updated>
   </info>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -16,6 +16,9 @@
     <translator>
       <name>Patrick O'Brien</name>
     </translator>
+    <translator>
+      <name>Nicolas Chachereau</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2023-03-28T23:31:02+00:00</updated>
   </info>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -294,8 +294,8 @@
       <multiple>Zeilen</multiple>
     </term>
     <term name="note">
-      <single>Note</single>
-      <multiple>Noten</multiple>
+      <single>Anmerkung</single>
+      <multiple>Anmerkungen</multiple>
     </term>
     <term name="opus">
       <single>Opus</single>
@@ -404,7 +404,7 @@
     <term name="folio" form="short">Fol.</term>
     <term name="issue" form="short">Nr.</term>
     <term name="line" form="short">Z.</term>
-    <term name="note" form="short">N.</term>
+    <term name="note" form="short">Anm.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
       <single>S.</single>

--- a/locales-de-CH.xml
+++ b/locales-de-CH.xml
@@ -113,7 +113,7 @@
     <term name="review-of">review of</term>
     <term name="review-of" form="short">rev. of</term>
     <term name="retrieved">abgerufen</term>
-    <term name="scale">Maßstab</term>
+    <term name="scale">Massstab</term>
     <term name="version">Version</term>
 
     <!-- LONG ITEM TYPE FORMS -->
@@ -193,10 +193,10 @@
     <term name="ce">CE</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">„</term>
-    <term name="close-quote">“</term>
-    <term name="open-inner-quote">‚</term>
-    <term name="close-inner-quote">‘</term>
+    <term name="open-quote">«</term>
+    <term name="close-quote">»</term>
+    <term name="open-inner-quote">‹</term>
+    <term name="close-inner-quote">›</term>
     <term name="page-range-delimiter">–</term>
     <term name="colon">:</term>
     <term name="comma">,</term>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -294,8 +294,8 @@
       <multiple>Zeilen</multiple>
     </term>
     <term name="note">
-      <single>Note</single>
-      <multiple>Noten</multiple>
+      <single>Anmerkung</single>
+      <multiple>Anmerkungen</multiple>
     </term>
     <term name="opus">
       <single>Opus</single>
@@ -404,7 +404,7 @@
     <term name="folio" form="short">Fol.</term>
     <term name="issue" form="short">Nr.</term>
     <term name="line" form="short">Z.</term>
-    <term name="note" form="short">N.</term>
+    <term name="note" form="short">Anm.</term>
     <term name="opus" form="short">op.</term>
     <term name="page" form="short">
       <single>S.</single>

--- a/locales-de-DE.xml
+++ b/locales-de-DE.xml
@@ -19,6 +19,9 @@
     <translator>
       <name>Patrick O'Brien</name>
     </translator>
+    <translator>
+      <name>Nicolas Chachereau</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2024-03-28T23:31:02+00:00</updated>
   </info>


### PR DESCRIPTION
### Description

This pull request reverts some changes made to the Swiss German locale in #294 but that were in all likelihood unintended (@POBrien333 could you confirm?). Only the translation of new CSL terms was intended, but some differences between `locales-de-CH.xml` and `locales-de-DE.xml` were erased. The current pull request asks to restore those (typographical) differences: the ß sign is not in use in Switzerland, and other quotation marks are most commonly used.

Note that I did not revert two other apparently unintended changes:
- the translation of the abbreviations of the locators   "line" and "note" (respectively "Z." and "N." instead of "l." and "n." (the new version seems better to me, it looks like the old abbreviations had simply been left untranslated);
- "Bde." for the abbreviated plural of "volume", rather than just "Bd."

@denismaier what do you think?

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.

