### PR TITLE
fix(fi-FI): change "vuosikerta" to "volyymi"

### DIFF
--- a/locales-fi-FI.xml
+++ b/locales-fi-FI.xml
@@ -16,6 +16,9 @@
     <translator>
       <name>Tuomas Hietala</name>
     </translator>
+    <translator>
+      <name>Luukas Pörtfors</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>
@@ -353,8 +356,8 @@
       <multiple>säkeistöt</multiple>
     </term>
     <term name="volume">
-      <single>vuosikerta</single>
-      <multiple>vuosikerrat</multiple>
+      <single>volyymi</single>
+      <multiple>volyymit</multiple>
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
@@ -441,8 +444,8 @@
       <multiple>säk.</multiple>
     </term>
     <term name="volume" form="short">
-      <single>vsk.</single>
-      <multiple>vsk.</multiple>
+      <single>vol.</single>
+      <multiple>vol.</multiple>
     </term>
 
     <!-- SYMBOL LOCATOR FORMS -->


### PR DESCRIPTION
### Description

Translating volume to "vuosikerta" could be problematic for journals that are published more frequently than once a year.

I suggest using the word "volyymi" instead.


### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
