### PR TITLE
Update locales-nl-NL.xml

### DIFF
--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -182,10 +182,10 @@
     <term name="ce">CE</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">‘</term>
-    <term name="close-quote">’</term>
-    <term name="open-inner-quote">“</term>
-    <term name="close-inner-quote">”</term>
+    <term name="open-quote">“</term>
+    <term name="close-quote">”</term>
+    <term name="open-inner-quote">‘</term>
+    <term name="close-inner-quote">’</term>
     <term name="page-range-delimiter">-</term>
     <term name="colon">:</term>
     <term name="comma">,</term>


### PR DESCRIPTION
In Chicago 17th (full note) in the Dutch locale, single quotation marks are returned, but they should be double. This issue is both in the notes and the bibliography.

I propose this change, which brings the nl locale in line with the en-US version.

Example: John H. Hanson, ‘Jihad and the Ahmadiyya Muslim Community: Nonviolent Efforts to Promote Islam in the Contemporary World’, Nova Religio: The Journal of Alternative and Emergent Religions 11, nr. 2 (2007): 85, https://doi.org/10.1525/nr.2007.11.2.77.

## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Briefly describe the changes you're proposing.

### Checklist

- [ ] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
