### PR TITLE
Correct folio forms per Romanian DOOM 2021 (https://doom.lingv.ro/cautare/q/folio?); add symbol locator form for folio

### DIFF
--- a/locales-ro-RO.xml
+++ b/locales-ro-RO.xml
@@ -9,6 +9,10 @@
       <name>Alin Andrei Bălașa</name>
       <email>alin.andrei.balasa@blsalin.dev</email>
     </translator>
+    <translator>
+      <name>Dorin Jorea</name>
+      <email>dorin.jorea@gmail.com</email>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2012-07-04T23:31:02+00:00</updated>
   </info>
@@ -267,8 +271,8 @@
       <multiple>figurile</multiple>
     </term>
     <term name="folio">
-      <single>foliul</single>
-      <multiple>foliile</multiple>
+      <single>folioul</single>
+      <multiple>foliourile</multiple>
     </term>
     <term name="issue">
       <single>numărul</single>
@@ -450,6 +454,10 @@
     <term name="section" form="symbol">
       <single>§</single>
       <multiple>§§</multiple>
+    </term>
+    <term name="folio" form="symbol">
+      <single>ƒ</single>
+      <multiple>ƒƒ</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->


### PR DESCRIPTION
## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Folio forms corrected in accordance with Romanian DOOM 2021; symbol locator form added for ‘folio’.

### Checklist

- [ ] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
