### PR TITLE
Update en-US abbreviations and give provenance

### DIFF
--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -152,7 +152,7 @@
     <term name="webpage">webpage</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-journal" form="short">jour. art.</term> <!-- ODWE -->
     <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -425,7 +425,7 @@
     <term name="title-locator" form="short">
       <!-- from Oxford Dictionary for Writers and Editors -->
       <single>tit.</single>
-      <multiple>tits.</multiple>
+      <multiple>titt.</multiple> <!-- source unknown for plural -->
     </term>
     <term name="verse" form="short">
       <single>v.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
+  <!-- This file follows the The Chicago Manual of Style, 18th ed. (2024), especially the list of scholarly abbreviations in sec. 10.48; additional abbreviations are from the Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>. -->
   <info>
     <translator>
       <name>Andrew Dunning</name>
@@ -44,7 +45,7 @@
     <term name="available at">available at</term>
     <term name="by">by</term>
     <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term>
+    <term name="circa" form="short">ca.</term>
     <term name="cited">cited</term>
     <term name="et-al">et al.</term>
     <term name="film">film</term>
@@ -146,20 +147,22 @@
 
     <!-- SHORT ITEM TYPE FORMS -->
     <term name="article-journal" form="short">journal art.</term>
-    <term name="article-magazine" form="short">mag. art.</term>
+    <term name="article-magazine" form="short">mag. art.</term> <!-- from ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
+    <term name="classic" form="short">class.</term> <!-- from ODWE -->
     <term name="document" form="short">doc.</term>
+    <term name="entry-dictionary">dict. entry</term>
+    <term name="entry-encyclopedia">ency. entry</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graph.</term>
-    <term name="interview" form="short">interv.</term>
+    <term name="interview" form="short">interv.</term> <!-- source unknown -->
     <term name="manuscript" form="short">MS</term>
-    <term name="motion_picture" form="short">video rec.</term>
-    <term name="report" form="short">rep.</term>
+    <term name="motion_picture" form="short">video rec.</term> <!-- from ODWE -->
+    <term name="report" form="short">rep.</term> <!-- from ODWE -->
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk. rev.</term>
-    <term name="song" form="short">audio rec.</term>
+    <term name="song" form="short">audio rec.</term> <!-- from ODWE -->
 
     <!-- VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->
@@ -337,8 +340,9 @@
       <multiple>bks.</multiple>
     </term>
     <term name="canon" form="short">
-      <single>c.</single>
-      <multiple>cc.</multiple>
+      <!-- from Oxford Dictionary for Writers and Editors -->
+      <single>can.</single>
+      <multiple>cans.</multiple>
     </term>
     <term name="chapter" form="short">
       <single>chap.</single>
@@ -354,7 +358,7 @@
     </term>
     <term name="equation" form="short">
       <single>eq.</single>
-      <multiple>eqs.</multiple>
+      <multiple>eqq.</multiple>
     </term>
     <term name="figure" form="short">
       <single>fig.</single>
@@ -393,6 +397,7 @@
       <multiple>pts.</multiple>
     </term>
     <term name="rule" form="short">
+      <!-- from Oxford Guide to Style, legal abbreviations, 13.2.1 -->
       <single>r.</single>
       <multiple>rr.</multiple>
     </term>
@@ -413,10 +418,12 @@
       <multiple>supps.</multiple>
     </term>
     <term name="table" form="short">
+      <!-- source unknown -->
       <single>tbl.</single>
       <multiple>tbls.</multiple>
     </term>
     <term name="title-locator" form="short">
+      <!-- from Oxford Dictionary for Writers and Editors -->
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>
@@ -426,7 +433,7 @@
     </term>
     <term name="version" form="short">
       <single>v.</single>
-      <multiple>v.</multiple>
+      <multiple>v.</multiple> <!-- not pluralized -->
     </term>
     <term name="volume" form="short">
       <single>vol.</single>
@@ -523,8 +530,9 @@
       <multiple>pp.</multiple>
     </term>
     <term name="printing" form="short">
-      <single>print.</single>
-      <multiple>prints.</multiple>
+      <!-- from Oxford Dictionary for Writers and Editors -->
+      <single>ptg.</single>
+      <multiple>ptgs.</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
@@ -618,7 +626,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, composer, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -629,10 +637,12 @@
       <multiple>comps.</multiple>
     </term>
     <term name="contributor" form="short">
+      <!-- source unknown -->
       <single>contrib.</single>
       <multiple>contribs.</multiple>
     </term>
     <term name="curator" form="short">
+      <!-- source unknown -->
       <single>cur.</single>
       <multiple>curs.</multiple>
     </term>
@@ -657,6 +667,7 @@
       <multiple>ed. dirs.</multiple>
     </term>
     <term name="executive-producer" form="short">
+      <!-- source unknown -->
       <single>exec. prod.</single>
       <multiple>exec. prods.</multiple>
     </term>
@@ -665,31 +676,37 @@
       <multiple>ills.</multiple>
     </term>
     <term name="narrator" form="short">
+      <!-- source unknown -->
       <single>narr.</single>
       <multiple>narrs.</multiple>
     </term>
     <term name="organizer" form="short">
+      <!-- source unknown -->
       <single>org.</single>
       <multiple>orgs.</multiple>
     </term>
     <term name="performer" form="short">
+      <!-- source unknown -->
       <single>perf.</single>
       <multiple>perfs.</multiple>
     </term>
     <term name="producer" form="short">
+      <!-- source unknown -->
       <single>prod.</single>
       <multiple>prods.</multiple>
     </term>
     <term name="script-writer" form="short">
+      <!-- source unknown -->
       <single>writ.</single>
       <multiple>writs.</multiple>
     </term>
     <term name="series-creator" form="short">
+      <!-- source unknown -->
       <single>cre.</single>
       <multiple>cres.</multiple>
     </term>
     <term name="translator" form="short">
-      <single>tran.</single>
+      <single>trans.</single>
       <multiple>trans.</multiple>
     </term>
 
@@ -724,27 +741,25 @@
 
     <!-- SHORT VERB ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, container-author, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
-    <term name="composer" form="verb-short">comp. by</term>
-    <term name="contributor" form="verb-short">w.</term>
-    <term name="curator" form="verb-short">cur. by</term>
+    <term name="composer" form="verb-short">comp. by</term> <!-- from ODWE --
+    <term name="curator" form="verb-short">cur. by</term> <!-- source unknown -->
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editorial-director" form="verb-short">ed. dir. by</term>
-    <term name="executive-producer" form="verb-short">exec. prod. by</term>
-    <term name="guest" form="verb-short">w. guest</term>
-    <term name="illustrator" form="verb-short">illus. by</term>
-    <term name="narrator" form="verb-short">narr. by</term>
-    <term name="organizer" form="verb-short">org. by</term>
-    <term name="performer" form="verb-short">perf. by</term>
-    <term name="producer" form="verb-short">prod. by</term>
-    <term name="script-writer" form="verb-short">writ. by</term>
-    <term name="series-creator" form="verb-short">cre. by</term>
+    <term name="executive-producer" form="verb-short">exec. prod. by</term> <!-- source unknown -->
+    <term name="illustrator" form="verb-short">ill. by</term>
+    <term name="narrator" form="verb-short">narr. by</term> <!-- source unknown -->
+    <term name="organizer" form="verb-short">org. by</term> <!-- source unknown -->
+    <term name="performer" form="verb-short">perf. by</term> <!-- source unknown -->
+    <term name="producer" form="verb-short">prod. by</term> <!-- source unknown -->
+    <term name="script-writer" form="verb-short">writ. by</term> <!-- source unknown -->
+    <term name="series-creator" form="verb-short">cre. by</term> <!-- source unknown -->
     <term name="translator" form="verb-short">trans. by</term>
 
     <!-- LONG MONTH FORMS -->
@@ -762,15 +777,16 @@
     <term name="month-12">December</term>
 
     <!-- SHORT MONTH FORMS -->
+    <!-- Chicago Manual of Style, sec. 10.44 -->
     <term name="month-01" form="short">Jan.</term>
     <term name="month-02" form="short">Feb.</term>
     <term name="month-03" form="short">Mar.</term>
     <term name="month-04" form="short">Apr.</term>
     <term name="month-05" form="short">May</term>
-    <term name="month-06" form="short">Jun.</term>
-    <term name="month-07" form="short">Jul.</term>
+    <term name="month-06" form="short">June</term>
+    <term name="month-07" form="short">July</term>
     <term name="month-08" form="short">Aug.</term>
-    <term name="month-09" form="short">Sep.</term>
+    <term name="month-09" form="short">Sept.</term>
     <term name="month-10" form="short">Oct.</term>
     <term name="month-11" form="short">Nov.</term>
     <term name="month-12" form="short">Dec.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -653,7 +653,7 @@
     </term>
     <term name="editorial-director" form="short">
       <single>ed. dir.</single>
-      <multiple>ed dirs.</multiple>
+      <multiple>ed. dirs.</multiple>
     </term>
     <term name="executive-producer" form="short">
       <single>exec. prod.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -269,8 +269,8 @@
       <multiple>folios</multiple>
     </term>
     <term name="issue">
-      <single>number</single>
-      <multiple>numbers</multiple>
+      <single>issue</single>
+      <multiple>issues</multiple>
     </term>
     <term name="line">
       <single>line</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -320,7 +320,7 @@
       <single>table</single>
       <multiple>tables</multiple>
     </term>
-    <term name="timestamp">at</term>
+    <term name="timestamp"/> <!-- no label in many styles -->
     <term name="title-locator">
       <single>title</single>
       <multiple>titles</multiple>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -68,6 +68,7 @@
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
     <term name="personal-communication">personal communication</term>
+    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
@@ -154,7 +155,6 @@
     <term name="interview" form="short">interv.</term>
     <term name="manuscript" form="short">MS</term>
     <term name="motion_picture" form="short">video rec.</term>
-    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="report" form="short">rep.</term>
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk. rev.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -18,7 +18,7 @@
       <name>Brenton M. Wiernik</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2025-06-23T00:00:00+00:00</updated>
+    <updated>2025-06-24T00:00:00+00:00</updated>
   </info>
   <style-options punctuation-in-quote="true"/>
   <date form="text">
@@ -745,7 +745,7 @@
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
-    <term name="composer" form="verb-short">comp. by</term> <!-- from ODWE --
+    <term name="composer" form="verb-short">comp. by</term> <!-- from ODWE -->
     <term name="curator" form="verb-short">cur. by</term> <!-- source unknown -->
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -45,12 +45,14 @@
     <term name="available at">available at</term>
     <term name="by">by</term>
     <term name="circa">circa</term>
-    <term name="circa" form="short">ca.</term>
+    <!-- CMOS 10.48 recommends ca. for circa but also allows 'c.', which CSL has always used -->
+    <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
     <term name="et-al">et al.</term>
     <term name="film">film</term>
     <term name="forthcoming">forthcoming</term>
     <term name="from">from</term>
+    <term name="from" form="short">fr.</term>
     <term name="henceforth">henceforth</term>
     <term name="ibid">ibid.</term>
     <term name="in">in</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -356,9 +356,9 @@
       <multiple>bks.</multiple>
     </term>
     <term name="canon" form="short">
-      <!-- James A. Brundage, 'The Romano-Canonical Citation System', app. 1 to Medieval Canon Law (Routledge, 1995), https://doi.org/10.4324/9781003156734 -->
-      <single>c.</single>
-      <multiple>cc.</multiple>
+      <!-- Oxford Dictionary for Writers and Editors -->
+      <single>can.</single>
+      <multiple>cann.</multiple>
     </term>
     <term name="chapter" form="short">
       <single>chap.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -153,6 +153,7 @@
     <term name="webpage">webpage</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
+    <!-- Omitted short forms: article, bill, broadcast, entry, event, graphic, hearing, legal_case, legislation, map, performance, periodical, regulation, software, speech, standard, thesis, treaty, webpage -->
     <term name="article-journal" form="short">jour. art.</term> <!-- ODWE -->
     <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
@@ -320,7 +321,7 @@
       <single>table</single>
       <multiple>tables</multiple>
     </term>
-    <term name="timestamp"/> <!-- no label in many styles -->
+    <term name="timestamp">at</term>
     <term name="title-locator">
       <single>title</single>
       <multiple>titles</multiple>
@@ -339,7 +340,7 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <!-- Omitted short forms: act, timestamp -->
+    <!-- Omitted short form: act -->
     <term name="appendix" form="short">
       <single>app.</single>
       <multiple>apps.</multiple>
@@ -430,6 +431,7 @@
       <single>supp.</single>
       <multiple>supps.</multiple>
     </term>
+    <term name="timestamp"/> <!-- no label in most styles -->
     <term name="table" form="short">
       <!-- source unknown -->
       <single>tbl.</single>
@@ -444,10 +446,7 @@
       <single>v.</single>
       <multiple>vv.</multiple>
     </term>
-    <term name="version" form="short">
-      <single>v.</single>
-      <multiple>v.</multiple> <!-- not pluralized -->
-    </term>
+    <term name="version" form="short">v.</term> <!-- no plural -->
     <term name="volume" form="short">
       <single>vol.</single>
       <multiple>vols.</multiple>
@@ -718,10 +717,7 @@
       <single>cre.</single>
       <multiple>cres.</multiple>
     </term>
-    <term name="translator" form="short">
-      <single>trans.</single>
-      <multiple>trans.</multiple>
-    </term>
+    <term name="translator" form="short">trans.</term> <!-- no plural -->
 
     <!-- VERB ROLE FORMS -->
     <term name="chair" form="verb">chaired by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -321,7 +321,8 @@
       <single>table</single>
       <multiple>tables</multiple>
     </term>
-    <term name="timestamp">at</term>
+    <!-- A timestamp is a composite of hours, minutes, etc. and therefore has no default label. -->
+    <term name="timestamp"/>
     <term name="title-locator">
       <single>title</single>
       <multiple>titles</multiple>
@@ -340,7 +341,7 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <!-- Omitted short form: act -->
+    <!-- Omitted short forms: act, timestamp -->
     <term name="appendix" form="short">
       <single>app.</single>
       <multiple>apps.</multiple>
@@ -431,7 +432,6 @@
       <single>supp.</single>
       <multiple>supps.</multiple>
     </term>
-    <term name="timestamp"/> <!-- no label in most styles -->
     <term name="table" form="short">
       <!-- source unknown -->
       <single>tbl.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -342,7 +342,7 @@
     <term name="canon" form="short">
       <!-- from Oxford Dictionary for Writers and Editors -->
       <single>can.</single>
-      <multiple>cans.</multiple>
+      <multiple>cann.</multiple>
     </term>
     <term name="chapter" form="short">
       <single>chap.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -127,7 +127,7 @@
     <term name="special-section" form="short">spec. sec.</term> <!-- ODA/CMOS -->
     <term name="television-broadcast" form="short">TV bdcst.</term> <!-- ODA -->
     <term name="television-series" form="short">TV ser.</term> <!-- ODA -->
-    <term name="television-series-episode" form="short">TV. ser. ep.</term> <!-- ODA -->
+    <term name="television-series-episode" form="short">TV ser. ep.</term> <!-- ODA -->
     <term name="video" form="short">vid.</term> <!-- ODA -->
     <term name="working-paper" form="short">wkg. paper</term> <!-- ODA -->
 

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -320,10 +320,7 @@
       <single>table</single>
       <multiple>tables</multiple>
     </term>
-    <term name="timestamp"> <!-- generally blank -->
-      <single/>
-      <multiple/>
-    </term>
+    <term name="timestamp">at</term>
     <term name="title-locator">
       <single>title</single>
       <multiple>titles</multiple>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -112,7 +112,7 @@
     <term name="no-publisher" form="short">n.p.</term>
     <term name="original-work-published" form="short">orig. pub.</term> <!-- Oxford Guide to Style -->
     <term name="personal-communication" form="short">pers. comm.</term>
-    <term name="podcast-episode" form="short>podcast ep.</term>
+    <term name="podcast-episode" form="short">podcast ep.</term>
     <term name="radio-broadcast" form="short">radio bdcst.</term> <!-- ODA -->
     <term name="radio-series" form="short">radio ser.</term> <!-- ODA -->
     <term name="radio-series-episode" form="short">radio ser. ep.</term> <!-- ODA -->

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -17,7 +17,7 @@
       <name>Brenton M. Wiernik</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2024-03-12T13:41:31+00:00</updated>
+    <updated>2025-06-23T00:00:00+00:00</updated>
   </info>
   <style-options punctuation-in-quote="true"/>
   <date form="text">

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -342,9 +342,9 @@
       <multiple>bks.</multiple>
     </term>
     <term name="canon" form="short">
-      <!-- from Oxford Dictionary for Writers and Editors -->
-      <single>can.</single>
-      <multiple>cann.</multiple>
+      <!-- James A. Brundage, 'The Romano-Canonical Citation System', app. 1 to Medieval Canon Law (Routledge, 1995), https://doi.org/10.4324/9781003156734 -->
+      <single>c.</single>
+      <multiple>cc.</multiple>
     </term>
     <term name="chapter" form="short">
       <single>chap.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -109,7 +109,7 @@
     <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">classic</term>
+    <term name="classic">classical work</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
     <term name="document">document</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -70,7 +70,7 @@
     <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="original-work-published" form="short">orig. pub.</term> <!-- from Oxford Guide to Style -->
+    <term name="original-work-published" form="short">orig. pub.</term> <!-- Oxford Guide to Style -->
     <term name="personal-communication">personal communication</term>
     <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
@@ -149,22 +149,22 @@
 
     <!-- SHORT ITEM TYPE FORMS -->
     <term name="article-journal" form="short">journal art.</term>
-    <term name="article-magazine" form="short">mag. art.</term> <!-- from ODWE -->
+    <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="classic" form="short">class.</term> <!-- from ODWE -->
+    <term name="classic" form="short">class. wk.</term> <!-- ODWE -->
     <term name="document" form="short">doc.</term>
     <term name="entry-dictionary">dict. entry</term>
     <term name="entry-encyclopedia">ency. entry</term>
     <!-- figure is in the list of locator terms -->
     <term name="interview" form="short">interv.</term> <!-- source unknown -->
     <term name="manuscript" form="short">MS</term>
-    <term name="motion_picture" form="short">video rec.</term> <!-- from ODWE -->
-    <term name="report" form="short">rep.</term> <!-- from ODWE -->
+    <term name="motion_picture" form="short">video rec.</term> <!-- ODWE -->
+    <term name="report" form="short">rep.</term> <!-- ODWE -->
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk. rev.</term>
-    <term name="song" form="short">audio rec.</term> <!-- from ODWE -->
+    <term name="song" form="short">audio rec.</term> <!-- ODWE -->
 
     <!-- VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->
@@ -425,9 +425,9 @@
       <multiple>tbls.</multiple>
     </term>
     <term name="title-locator" form="short">
-      <!-- from Oxford Dictionary for Writers and Editors -->
+      <!-- Oxford Dictionary for Writers and Editors -->
       <single>tit.</single>
-      <multiple>titt.</multiple> <!-- source unknown for plural -->
+      <multiple>titt.</multiple>
     </term>
     <term name="verse" form="short">
       <single>v.</single>
@@ -532,7 +532,7 @@
       <multiple>pp.</multiple>
     </term>
     <term name="printing" form="short">
-      <!-- from Oxford Dictionary for Writers and Editors -->
+      <!-- Oxford Dictionary for Writers and Editors -->
       <single>ptg.</single>
       <multiple>ptgs.</multiple>
     </term>
@@ -747,7 +747,7 @@
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
-    <term name="composer" form="verb-short">comp. by</term> <!-- from ODWE -->
+    <term name="composer" form="verb-short">comp. by</term> <!-- ODWE -->
     <term name="curator" form="verb-short">cur. by</term> <!-- source unknown -->
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -2,6 +2,7 @@
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
   <!-- Where not otherwise stated, the scholarly abbreviations in this file are from The Chicago Manual of Style, 18th ed. (2024), sec. 10.48. -->
   <!-- Additional abbreviations are from the Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>. -->
+  <!-- Oxford Dictionary of Abbreviations (ODA) <https://doi.org/10.1093/acref/9780199698295.001.0001> helps to verify the meanings of abbreviations but is not a guide to usage. -->
   <info>
     <translator>
       <name>Andrew Dunning</name>
@@ -165,7 +166,7 @@
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
-    <term name="interview" form="short">intvw.</term> <!-- Free Dictionary -->
+    <term name="interview" form="short">int.</term> <!-- ODA -->
     <term name="manuscript" form="short">
       <single>MS</single>
       <multiple>MSS</multiple>
@@ -433,7 +434,7 @@
       <multiple>supps.</multiple>
     </term>
     <term name="table" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>tbl.</single>
       <multiple>tbls.</multiple>
     </term>
@@ -638,7 +639,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author, series-creator
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -649,12 +650,12 @@
       <multiple>comps.</multiple>
     </term>
     <term name="contributor" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>contrib.</single>
       <multiple>contribs.</multiple>
     </term>
     <term name="curator" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Art Online <https://www.oxfordartonline.com/page/1661> -->
       <single>cur.</single>
       <multiple>curs.</multiple>
     </term>
@@ -679,7 +680,7 @@
       <multiple>eds.</multiple>
     </term>
     <term name="executive-producer" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>exec. prod.</single>
       <multiple>exec. prods.</multiple>
     </term>
@@ -688,34 +689,29 @@
       <multiple>ills.</multiple>
     </term>
     <term name="narrator" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>narr.</single>
       <multiple>narrs.</multiple>
     </term>
     <term name="organizer" form="short">
-      <!-- source unknown -->
+      <!-- possibly misleading: Oxford Dictionary of Abbreviations only defines this as organization or organized -->
       <single>org.</single>
       <multiple>orgs.</multiple>
     </term>
     <term name="performer" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>perf.</single>
       <multiple>perfs.</multiple>
     </term>
     <term name="producer" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>prod.</single>
       <multiple>prods.</multiple>
     </term>
     <term name="script-writer" form="short">
-      <!-- source unknown -->
-      <single>writ.</single>
-      <multiple>writs.</multiple>
-    </term>
-    <term name="series-creator" form="short">
-      <!-- source unknown -->
-      <single>cre.</single>
-      <multiple>cres.</multiple>
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>wrtr.</single>
+      <multiple>wrtrs.</multiple>
     </term>
     <term name="translator" form="short">trans.</term> <!-- no plural -->
 
@@ -750,25 +746,24 @@
 
     <!-- SHORT VERB ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author, series-creator
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
     <term name="composer" form="verb-short">comp. by</term> <!-- ODWE -->
-    <term name="curator" form="verb-short">cur. by</term> <!-- source unknown -->
+    <term name="curator" form="verb-short">cur. by</term> <!-- Oxford Art Online -->
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editorial-director" form="verb-short">ed. by</term>
-    <term name="executive-producer" form="verb-short">exec. prod. by</term> <!-- source unknown -->
+    <term name="executive-producer" form="verb-short">exec. prod. by</term> <!-- ODA -->
     <term name="illustrator" form="verb-short">ill. by</term>
-    <term name="narrator" form="verb-short">narr. by</term> <!-- source unknown -->
-    <term name="organizer" form="verb-short">org. by</term> <!-- source unknown -->
-    <term name="performer" form="verb-short">perf. by</term> <!-- source unknown -->
-    <term name="producer" form="verb-short">prod. by</term> <!-- source unknown -->
-    <term name="script-writer" form="verb-short">writ. by</term> <!-- source unknown -->
-    <term name="series-creator" form="verb-short">cre. by</term> <!-- source unknown -->
+    <term name="narrator" form="verb-short">narr. by</term> <!-- ODA -->
+    <term name="organizer" form="verb-short">org. by</term> <!-- ODA -->
+    <term name="performer" form="verb-short">perfd. by</term> <!-- ODA -->
+    <term name="producer" form="verb-short">prod. by</term> <!-- ODA -->
+    <term name="script-writer" form="verb-short">writ. by</term> <!-- ODA -->
     <term name="translator" form="verb-short">trans. by</term>
 
     <!-- LONG MONTH FORMS -->

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -67,6 +67,7 @@
     <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
+    <term name="original-work-published" form="short">orig. pub.</term>
     <term name="personal-communication">personal communication</term>
     <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -639,7 +639,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author, series-creator
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -712,6 +712,10 @@
       <!-- Oxford Dictionary of Abbreviations -->
       <single>wrtr.</single>
       <multiple>wrtrs.</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <single>ser. creator</single>
+      <multiple>ser. creators</multiple>
     </term>
     <term name="translator" form="short">trans.</term> <!-- no plural -->
 

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -786,7 +786,7 @@
     <term name="month-12">December</term>
 
     <!-- SHORT MONTH FORMS -->
-    <!-- Chicago Manual of Style, sec. 10.44 -->
+    <!-- Chicago Manual of Style, 18th ed., sec. 10.44 (identical to New Hart's Rules, 2nd ed., sec. 10.2.6) -->
     <term name="month-01" form="short">Jan.</term>
     <term name="month-02" form="short">Feb.</term>
     <term name="month-03" form="short">Mar.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -628,7 +628,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -164,7 +164,7 @@
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
-    <term name="interview" form="short">interv.</term> <!-- source unknown -->
+    <term name="interview" form="short">intvw.</term> <!-- Free Dictionary -->
     <term name="manuscript" form="short">
       <single>MS</single>
       <multiple>MSS</multiple>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -229,9 +229,9 @@
 
     <!-- SHORT VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->
-    <term name="hearing" form="verb" form="short">test. of</term> <!-- ODA -->
-    <term name="review" form="verb" form="short">rev. of</term>
-    <term name="review-book" form="verb" form="short">rev. of the bk.</term>
+    <term name="hearing" form="verb-short">test. of</term> <!-- ODA -->
+    <term name="review" form="verb-short">rev. of</term>
+    <term name="review-book" form="verb-short">rev. of the bk.</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">AD</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -74,7 +74,6 @@
     <term name="personal-communication">personal communication</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
-    <term name="podcast-episode" form="short>podcast ep.</term>
     <term name="preprint">preprint</term>
     <term name="presented at">presented at the</term>
     <term name="radio-broadcast">radio broadcast</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -114,7 +114,7 @@
     <term name="broadcast">broadcast</term>
     <!-- chapter is in the list of locator terms -->
     <term name="classic">classical work</term>
-    <term name="collection">collection</term>
+    <term name="collection">archival collection</term>
     <term name="dataset">dataset</term>
     <term name="document">document</term>
     <term name="entry">entry</term>
@@ -158,7 +158,7 @@
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="classic" form="short">class. wk.</term> <!-- ODWE -->
-    <term name="collection" form="short">coll.</term> <!-- ODWE -->
+    <term name="collection" form="short">archival coll.</term> <!-- ODWE -->
     <term name="document" form="short">doc.</term>
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -158,13 +158,22 @@
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="classic" form="short">class. wk.</term> <!-- ODWE -->
+    <term name="collection" form="short">coll.</term> <!-- ODWE -->
     <term name="document" form="short">doc.</term>
-    <term name="entry-dictionary">dict. entry</term>
-    <term name="entry-encyclopedia">ency. entry</term>
+    <term name="entry-dictionary" form="short">dict. entry</term>
+    <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
     <term name="interview" form="short">interv.</term> <!-- source unknown -->
-    <term name="manuscript" form="short">MS</term>
+    <term name="manuscript" form="short">
+      <single>MS</single>
+      <multiple>MSS</multiple>
+    </term>
     <term name="motion_picture" form="short">video rec.</term> <!-- ODWE -->
+    <term name="musical_score" form="short">mus. score</term> <!-- ODWE -->
+    <term name="pamphlet" form="short">pam.</term> <!-- ODWE -->
+    <term name="paper-conference" form="short">conf. paper</term> <!-- ODWE -->
+    <term name="patent" form="short">pat.</term> <!-- ODWE -->
+    <term name="personal_communication" form="short">pers. comm.</term>
     <term name="report" form="short">rep.</term> <!-- ODWE -->
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk. rev.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
-  <!-- Where not otherwise stated, the scholarly abbreviations in this file are from The Chicago Manual of Style, 18th ed. (2024), sec. 10.48. -->
-  <!-- Additional abbreviations are from the Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>. -->
-  <!-- Oxford Dictionary of Abbreviations (ODA) <https://doi.org/10.1093/acref/9780199698295.001.0001> helps to verify the meanings of abbreviations but is not a guide to usage. -->
+  <!-- Where not otherwise stated, the abbreviations in this file follow the recommendations of The Chicago Manual of Style (CMOS), 18th ed. (2024), sec. 10.48. -->
+  <!-- Additional abbreviations are from:
+        - Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>
+        - Oxford Dictionary of Abbreviations (ODA) <https://doi.org/10.1093/acref/9780199698295.001.0001>
+  -->
   <info>
     <translator>
       <name>Andrew Dunning</name>
@@ -48,12 +50,15 @@
     <term name="anonymous" form="short">anon.</term>
     <term name="at">at</term>
     <term name="audio-recording">audio recording</term>
+    <term name="audio-recording" form="short">au. rec.</term> <!-- ODA -->
     <term name="available at">available at</term>
+    <term name="available at" form="short">avail. at</term> <!-- ODA -->
     <term name="by">by</term>
     <term name="circa">circa</term>
     <!-- CMOS 10.48 recommends ca. for circa but also allows c., which CSL has always used -->
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
+    <term name="cited" form="short">cit.</term> <!-- ODA -->
     <term name="et-al">et al.</term>
     <term name="film">film</term>
     <term name="forthcoming">forthcoming</term>
@@ -65,12 +70,13 @@
     <term name="in press">in press</term>
     <term name="internet">internet</term>
     <term name="letter">letter</term>
+    <term name="letter" form="short">let.</term> <!-- ODA -->
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="no date">no date</term>
     <term name="no date" form="short">n.d.</term>
     <term name="no-place">no place</term>
     <term name="no-place" form="short">n.p.</term>
-    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
+    <term name="no-publisher">no publisher</term>
     <term name="no-publisher" form="short">n.p.</term>
     <term name="on">on</term>
     <term name="online">online</term>
@@ -81,11 +87,16 @@
     <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
+    <term name="podcast-episode" form="short>podcast ep.</term>
     <term name="preprint">preprint</term>
     <term name="presented at">presented at the</term>
+    <term name="presented at" form="short">pres. at the</term> <!-- ODA -->
     <term name="radio-broadcast">radio broadcast</term>
+    <term name="radio-broadcast" form="short">radio bdcst.</term> <!-- ODA -->
     <term name="radio-series">radio series</term>
+    <term name="radio-series" form="short">radio ser.</term>
     <term name="radio-series-episode">radio series episode</term>
+    <term name="radio-series-episode" form="short">radio ser. ep.</term>
     <term name="reference">
       <single>reference</single>
       <multiple>references</multiple>
@@ -98,6 +109,7 @@
     <term name="review-of">review of</term>
     <term name="review-of" form="short">rev. of</term>
     <term name="scale">scale</term>
+    <term name="scale" form="short">sc.</term> <!-- ODA -->
     <term name="special-issue">special issue</term>
     <term name="special-section">special section</term>
     <term name="television-broadcast">television broadcast</term>
@@ -162,7 +174,7 @@
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="classic" form="short">class. wk.</term> <!-- ODWE -->
-    <term name="collection" form="short">archival coll.</term> <!-- ODWE -->
+    <term name="collection" form="short">arch. coll.</term> <!-- ODA -->
     <term name="document" form="short">doc.</term>
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>
@@ -195,8 +207,11 @@
     <!-- VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->
     <term name="hearing" form="verb">testimony of</term>
+    <term name="hearing" form="verb" form="short">test. of</term> <!-- ODA -->
     <term name="review" form="verb">review of</term>
+    <term name="review" form="verb" form="short">rev. of</term>
     <term name="review-book" form="verb">review of the book</term>
+    <term name="review-book" form="verb" form="short">rev. of the bk.</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">AD</term>
@@ -775,7 +790,7 @@
     <term name="illustrator" form="verb-short">ill. by</term>
     <term name="narrator" form="verb-short">narr. by</term> <!-- ODA -->
     <term name="organizer" form="verb-short">org. by</term> <!-- ODA -->
-    <term name="performer" form="verb-short">perfd. by</term> <!-- ODA -->
+    <term name="performer" form="verb-short">perf. by</term> <!-- ODA -->
     <term name="producer" form="verb-short">prod. by</term> <!-- ODA -->
     <term name="script-writer" form="verb-short">writ. by</term> <!-- ODA -->
     <term name="translator" form="verb-short">trans. by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -679,8 +679,8 @@
       <multiple>eds. &amp; trans.</multiple>
     </term>
     <term name="editorial-director" form="short">
-      <single>ed. dir.</single>
-      <multiple>ed. dirs.</multiple>
+      <single>ed.</single>
+      <multiple>eds.</multiple>
     </term>
     <term name="executive-producer" form="short">
       <!-- source unknown -->
@@ -738,7 +738,7 @@
     <term name="editor" form="verb">edited by</term>
     <term name="editor-translator" form="verb">edited &amp; translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
-    <term name="editorial-director" form="verb">editorial direction by</term>
+    <term name="editorial-director" form="verb">edited by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
     <term name="guest" form="verb">with guest</term>
     <term name="host" form="verb">hosted by</term>
@@ -767,7 +767,7 @@
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
-    <term name="editorial-director" form="verb-short">ed. dir. by</term>
+    <term name="editorial-director" form="verb-short">ed. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term> <!-- source unknown -->
     <term name="illustrator" form="verb-short">ill. by</term>
     <term name="narrator" form="verb-short">narr. by</term> <!-- source unknown -->

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
-  <!-- Where not otherwise stated, the abbreviations in this file follow the recommendations of The Chicago Manual of Style (CMOS), 18th ed. (2024), sec. 10.48. -->
+  <!-- The abbreviations in this file follow the recommendations of The Chicago Manual of Style, 18th ed. (2024), sec. 10.48 (cited hereafter as CMOS), unless stated otherwise. -->
   <!-- Additional abbreviations are from:
-        - Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>
-        - Oxford Dictionary of Abbreviations (ODA) <https://doi.org/10.1093/acref/9780199698295.001.0001>
+        1. Oxford Dictionary for Writers and Editors (2000), https://archive.org/details/oxfordstylemanua0000unse (cited hereafter as ODWE): reference has also been made to the New Oxford Dictionary for Writers and Editors (NODWE), but periods must be added to contractions in these later editions to reflect US English usage
+        2. Oxford Dictionary of Abbreviations (2011), https://doi.org/10.1093/acref/9780199698295.001.0001 (cited hereafter as ODA)
   -->
   <info>
     <translator>
@@ -40,76 +40,53 @@
     <date-part name="year"/>
   </date>
   <terms>
-    <!-- GENERAL TERMS -->
+    <!-- LONG GENERAL TERMS -->
     <term name="accessed">accessed</term>
     <term name="advance-online-publication">advance online publication</term>
     <term name="album">album</term>
     <term name="and">and</term>
     <term name="and others">and others</term>
     <term name="anonymous">anonymous</term>
-    <term name="anonymous" form="short">anon.</term>
     <term name="at">at</term>
     <term name="audio-recording">audio recording</term>
-    <term name="audio-recording" form="short">au. rec.</term> <!-- ODA -->
     <term name="available at">available at</term>
-    <term name="available at" form="short">avail. at</term> <!-- ODA -->
     <term name="by">by</term>
     <term name="circa">circa</term>
-    <!-- CMOS 10.48 recommends ca. for circa but also allows c., which CSL has always used -->
-    <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
-    <term name="cited" form="short">cit.</term> <!-- ODA -->
     <term name="et-al">et al.</term>
     <term name="film">film</term>
     <term name="forthcoming">forthcoming</term>
     <term name="from">from</term>
-    <term name="from" form="short">fr.</term>
     <term name="henceforth">henceforth</term>
     <term name="ibid">ibid.</term>
     <term name="in">in</term>
     <term name="in press">in press</term>
     <term name="internet">internet</term>
     <term name="letter">letter</term>
-    <term name="letter" form="short">let.</term> <!-- ODA -->
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="no date">no date</term>
-    <term name="no date" form="short">n.d.</term>
     <term name="no-place">no place</term>
-    <term name="no-place" form="short">n.p.</term>
     <term name="no-publisher">no publisher</term>
-    <term name="no-publisher" form="short">n.p.</term>
     <term name="on">on</term>
     <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="original-work-published" form="short">orig. pub.</term> <!-- Oxford Guide to Style -->
     <term name="personal-communication">personal communication</term>
-    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="podcast-episode" form="short>podcast ep.</term>
     <term name="preprint">preprint</term>
     <term name="presented at">presented at the</term>
-    <term name="presented at" form="short">pres. at the</term> <!-- ODA -->
     <term name="radio-broadcast">radio broadcast</term>
-    <term name="radio-broadcast" form="short">radio bdcst.</term> <!-- ODA -->
     <term name="radio-series">radio series</term>
-    <term name="radio-series" form="short">radio ser.</term>
     <term name="radio-series-episode">radio series episode</term>
-    <term name="radio-series-episode" form="short">radio ser. ep.</term>
     <term name="reference">
       <single>reference</single>
       <multiple>references</multiple>
     </term>
-    <term name="reference" form="short">
-      <single>ref.</single>
-      <multiple>refs.</multiple>
-    </term>
     <term name="retrieved">retrieved</term>
     <term name="review-of">review of</term>
-    <term name="review-of" form="short">rev. of</term>
     <term name="scale">scale</term>
-    <term name="scale" form="short">sc.</term> <!-- ODA -->
     <term name="special-issue">special issue</term>
     <term name="special-section">special section</term>
     <term name="television-broadcast">television broadcast</term>
@@ -117,6 +94,47 @@
     <term name="television-series-episode">television series episode</term>
     <term name="video">video</term>
     <term name="working-paper">working paper</term>
+
+    <!-- SHORT GENERAL TERMS -->
+    <!-- Omitted short forms: accessed, album, and (symbol), and others, at (symbol), forthcoming, henceforth, ibid, in, in press, internet, loc-cit, on, online, op-cit, podcast, preprint, presented at -->
+    <term name="advance-online-publication" form="short">adv. online pub.</term> <!-- ODA -->
+    <term name="anonymous" form="short">anon.</term>
+    <term name="audio-recording" form="short">au. rec.</term> <!-- ODA -->
+    <term name="available at" form="short">avail. at</term> <!-- ODA -->
+    <term name="circa" form="short">c.</term>
+    <!-- CMOS 10.48 recommends "ca." for "circa" but also allows "c.", which CSL has used historically -->
+    <term name="cited" form="short">cit.</term> <!-- ODA -->
+    <term name="et-al" form="short">et al.</term>
+    <term name="film" form="short">flm.</term> <!-- ODA -->
+    <term name="from" form="short">fr.</term>
+    <term name="letter" form="short">let.</term> <!-- ODA -->
+    <term name="no date" form="short">n.d.</term>
+    <term name="no-place" form="short">n.p.</term>
+    <term name="no-publisher" form="short">n.p.</term>
+    <term name="original-work-published" form="short">orig. pub.</term> <!-- Oxford Guide to Style -->
+    <term name="personal-communication" form="short">pers. comm.</term>
+    <term name="podcast-episode" form="short>podcast ep.</term>
+    <term name="radio-broadcast" form="short">radio bdcst.</term> <!-- ODA -->
+    <term name="radio-series" form="short">radio ser.</term> <!-- ODA -->
+    <term name="radio-series-episode" form="short">radio ser. ep.</term> <!-- ODA -->
+    <term name="reference" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="retrieved" form="short">rtvd.</term> <!-- ODA -->
+    <term name="review-of" form="short">rev. of</term>
+    <term name="scale" form="short">sc.</term> <!-- ODA -->
+    <term name="special-issue" form="short">spec. iss.</term> <!-- ODA -->
+    <term name="special-section" form="short">spec. sec.</term> <!-- ODA/CMOS -->
+    <term name="television-broadcast" form="short">TV bdcst.</term> <!-- ODA -->
+    <term name="television-series" form="short">TV ser.</term> <!-- ODA -->
+    <term name="television-series-episode" form="short">TV. ser. ep.</term> <!-- ODA -->
+    <term name="video" form="short">vid.</term> <!-- ODA -->
+    <term name="working-paper" form="short">wkg. paper</term> <!-- ODA -->
+
+    <!-- SYMBOLIC GENERAL FORMS -->
+    <term name="and" form="symbol">&amp;</term>
+    <term name="at" form="symbol">@</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">preprint</term>
@@ -166,7 +184,7 @@
     <term name="webpage">webpage</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <!-- Omitted short forms: article, bill, entry, event, graphic, hearing, map, periodical, speech, treaty -->
+    <!-- Omitted short forms: article, bill, entry, event, hearing, map, periodical, speech, treaty -->
     <term name="article-journal" form="short">jour. art.</term> <!-- ODWE -->
     <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
@@ -204,13 +222,16 @@
     <term name="thesis" form="short">thes.</term> <!-- ODA -->
     <term name="webpage" form="short">webpg.</term> <!-- ODA -->
 
-    <!-- VERB ITEM TYPE FORMS -->
+    <!-- LONG VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->
     <term name="hearing" form="verb">testimony of</term>
-    <term name="hearing" form="verb" form="short">test. of</term> <!-- ODA -->
     <term name="review" form="verb">review of</term>
-    <term name="review" form="verb" form="short">rev. of</term>
     <term name="review-book" form="verb">review of the book</term>
+
+    <!-- SHORT VERB ITEM TYPE FORMS -->
+    <!-- Only where applicable -->
+    <term name="hearing" form="verb" form="short">test. of</term> <!-- ODA -->
+    <term name="review" form="verb" form="short">rev. of</term>
     <term name="review-book" form="verb" form="short">rev. of the bk.</term>
 
     <!-- HISTORICAL ERA TERMS -->
@@ -478,7 +499,7 @@
       <multiple>vols.</multiple>
     </term>
 
-    <!-- SYMBOL LOCATOR FORMS -->
+    <!-- SYMBOLIC LOCATOR FORMS -->
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -154,10 +154,11 @@
     <term name="webpage">webpage</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <!-- Omitted short forms: article, bill, broadcast, entry, event, graphic, hearing, legal_case, legislation, map, performance, periodical, regulation, software, speech, standard, thesis, treaty, webpage -->
+    <!-- Omitted short forms: article, bill, entry, event, graphic, hearing, map, periodical, speech, treaty -->
     <term name="article-journal" form="short">jour. art.</term> <!-- ODWE -->
     <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="broadcast" form="short">bdcst.</term> <!-- ODA -->
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="classic" form="short">class. wk.</term> <!-- ODWE -->
@@ -166,21 +167,30 @@
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
+    <term name="graphic" form="short">gr.</term> <!-- ODA -->
     <term name="interview" form="short">int.</term> <!-- ODA -->
+    <term name="legal_case" form="short">leg. case</term> <!-- ODA -->
+    <term name="legislation" form="short">legis.</term> <!-- ODA -->
     <term name="manuscript" form="short">
       <single>MS</single>
       <multiple>MSS</multiple>
     </term>
-    <term name="motion_picture" form="short">video rec.</term> <!-- ODWE -->
+    <term name="motion_picture" form="short">vid. rec.</term> <!-- ODA -->
     <term name="musical_score" form="short">mus. score</term> <!-- ODWE -->
     <term name="pamphlet" form="short">pam.</term> <!-- ODWE -->
-    <term name="paper-conference" form="short">conf. paper</term> <!-- ODWE -->
+    <term name="paper-conference" form="short">conf. paper</term> <!-- ODA -->
     <term name="patent" form="short">pat.</term> <!-- ODWE -->
+    <term name="performance" form="short">prfm.</term> <!-- ODA -->
     <term name="personal_communication" form="short">pers. comm.</term>
+    <term name="regulation" form="short">reg.</term> <!-- ODA -->
     <term name="report" form="short">rep.</term> <!-- ODWE -->
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk. rev.</term>
-    <term name="song" form="short">audio rec.</term> <!-- ODWE -->
+    <term name="software" form="short">sftw.</term> <!-- ODA -->
+    <term name="song" form="short">au. rec.</term> <!-- ODA -->
+    <term name="standard" form="short">std.</term> <!-- ODA -->
+    <term name="thesis" form="short">thes.</term> <!-- ODA -->
+    <term name="webpage" form="short">webpg.</term> <!-- ODA -->
 
     <!-- VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -70,7 +70,7 @@
     <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="original-work-published" form="short">orig. pub.</term>
+    <term name="original-work-published" form="short">orig. pub.</term> <!-- from Oxford Guide to Style -->
     <term name="personal-communication">personal communication</term>
     <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -45,7 +45,7 @@
     <term name="available at">available at</term>
     <term name="by">by</term>
     <term name="circa">circa</term>
-    <!-- CMOS 10.48 recommends ca. for circa but also allows 'c.', which CSL has always used -->
+    <!-- CMOS 10.48 recommends ca. for circa but also allows c., which CSL has always used -->
     <term name="circa" form="short">c.</term>
     <term name="cited">cited</term>
     <term name="et-al">et al.</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -399,7 +399,7 @@
       <multiple>pts.</multiple>
     </term>
     <term name="rule" form="short">
-      <!-- from Oxford Guide to Style, legal abbreviations, 13.2.1 -->
+      <!-- legal abbreviations in the Oxford Guide to Style, sec. 13.2.1 -->
       <single>r.</single>
       <multiple>rr.</multiple>
     </term>
@@ -657,11 +657,11 @@
       <multiple>eds.</multiple>
     </term>
     <term name="editor-translator" form="short">
-      <single>ed. &amp; tran.</single>
+      <single>ed. &amp; trans.</single>
       <multiple>eds. &amp; trans.</multiple>
     </term>
     <term name="editortranslator" form="short">
-      <single>ed. &amp; tran.</single>
+      <single>ed. &amp; trans.</single>
       <multiple>eds. &amp; trans.</multiple>
     </term>
     <term name="editorial-director" form="short">

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -4,18 +4,22 @@
   <info>
     <translator>
       <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
     </translator>
     <translator>
       <name>Sebastian Karcher</name>
+      <uri>https://orcid.org/0000-0001-8249-7388</uri>
     </translator>
     <translator>
       <name>Rintze M. Zelle</name>
+      <uri>https://orcid.org/0000-0003-1779-8883</uri>
     </translator>
     <translator>
       <name>Denis Meier</name>
     </translator>
     <translator>
       <name>Brenton M. Wiernik</name>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2025-06-24T00:00:00+00:00</updated>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -154,6 +154,7 @@
     <term name="interview" form="short">interv.</term>
     <term name="manuscript" form="short">MS</term>
     <term name="motion_picture" form="short">video rec.</term>
+    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="report" form="short">rep.</term>
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk. rev.</term>
@@ -203,25 +204,25 @@
     <term name="long-ordinal-10">tenth</term>
 
     <!-- LONG LOCATOR FORMS -->
-    <term name="act">			 
+    <term name="act">
       <single>act</single>
-      <multiple>acts</multiple>						 
+      <multiple>acts</multiple>
     </term>
-    <term name="appendix">			 
+    <term name="appendix">
       <single>appendix</single>
-      <multiple>appendices</multiple>						 
+      <multiple>appendices</multiple>
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator">
       <single>article</single>
-      <multiple>articles</multiple>						 
+      <multiple>articles</multiple>
     </term>
     <term name="book">
       <single>book</single>
       <multiple>books</multiple>
     </term>
-    <term name="canon">			 
+    <term name="canon">
       <single>canon</single>
-      <multiple>canons</multiple>						 
+      <multiple>canons</multiple>
     </term>
     <term name="chapter">
       <single>chapter</single>
@@ -231,13 +232,13 @@
       <single>column</single>
       <multiple>columns</multiple>
     </term>
-    <term name="elocation">			 
+    <term name="elocation">
       <single>location</single>
-      <multiple>locations</multiple>						 
+      <multiple>locations</multiple>
     </term>
-    <term name="equation">			 
+    <term name="equation">
       <single>equation</single>
-      <multiple>equations</multiple>						 
+      <multiple>equations</multiple>
     </term>
     <term name="figure">
       <single>figure</single>
@@ -275,13 +276,13 @@
       <single>part</single>
       <multiple>parts</multiple>
     </term>
-    <term name="rule">			 
+    <term name="rule">
       <single>rule</single>
-      <multiple>rules</multiple>						 
+      <multiple>rules</multiple>
     </term>
-    <term name="scene">			 
+    <term name="scene">
       <single>scene</single>
-      <multiple>scenes</multiple>						 
+      <multiple>scenes</multiple>
     </term>
     <term name="section">
       <single>section</single>
@@ -295,17 +296,17 @@
       <single>supplement</single>
       <multiple>supplements</multiple>
     </term>
-    <term name="table">			 
+    <term name="table">
       <single>table</single>
-      <multiple>tables</multiple>						 
+      <multiple>tables</multiple>
     </term>
     <term name="timestamp"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
+      <single/>
+      <multiple/>
     </term>
-    <term name="title-locator">			 
+    <term name="title-locator">
       <single>title</single>
-      <multiple>titles</multiple>						 
+      <multiple>titles</multiple>
     </term>
     <term name="verse">
       <single>verse</single>
@@ -322,11 +323,11 @@
 
     <!-- SHORT LOCATOR FORMS -->
     <!-- Omitted short forms: act, timestamp -->
-    <term name="appendix" form="short">			 
+    <term name="appendix" form="short">
       <single>app.</single>
-      <multiple>apps.</multiple>						 
+      <multiple>apps.</multiple>
     </term>
-    <term name="article-locator" form="short">			 
+    <term name="article-locator" form="short">
       <single>art.</single>
       <multiple>arts.</multiple>
     </term>
@@ -336,7 +337,7 @@
     </term>
     <term name="canon" form="short">
       <single>c.</single>
-      <multiple>cc.</multiple>						 
+      <multiple>cc.</multiple>
     </term>
     <term name="chapter" form="short">
       <single>chap.</single>
@@ -346,11 +347,11 @@
       <single>col.</single>
       <multiple>cols.</multiple>
     </term>
-    <term name="elocation" form="short">			 
+    <term name="elocation" form="short">
       <single>loc.</single>
       <multiple>locs.</multiple>
     </term>
-    <term name="equation" form="short">			 
+    <term name="equation" form="short">
       <single>eq.</single>
       <multiple>eqs.</multiple>
     </term>
@@ -390,13 +391,13 @@
       <single>pt.</single>
       <multiple>pts.</multiple>
     </term>
-    <term name="rule" form="short">			 
+    <term name="rule" form="short">
       <single>r.</single>
-      <multiple>rr.</multiple>						 
+      <multiple>rr.</multiple>
     </term>
-    <term name="scene" form="short">			 
+    <term name="scene" form="short">
       <single>sc.</single>
-      <multiple>scs.</multiple>						 
+      <multiple>scs.</multiple>
     </term>
     <term name="section" form="short">
       <single>sec.</single>
@@ -410,11 +411,11 @@
       <single>supp.</single>
       <multiple>supps.</multiple>
     </term>
-    <term name="table" form="short">			 
+    <term name="table" form="short">
       <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
+      <multiple>tbls.</multiple>
     </term>
-    <term name="title-locator" form="short">			 
+    <term name="title-locator" form="short">
       <single>tit.</single>
       <multiple>tits.</multiple>
     </term>
@@ -524,11 +525,10 @@
       <single>print.</single>
       <multiple>prints.</multiple>
     </term>
-    
 
     <!-- LONG ROLE FORMS -->
-    <!-- Omitted roles: 
-         author, composer, container-author, interviewer, original-author, recipient, reviewed-author 
+    <!-- Omitted roles:
+         author, composer, container-author, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="chair">
       <single>chair</single>
@@ -557,6 +557,10 @@
     <term name="editor">
       <single>editor</single>
       <multiple>editors</multiple>
+    </term>
+    <term name="editor-translator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
     </term>
     <term name="editortranslator">
       <single>editor &amp; translator</single>
@@ -612,8 +616,8 @@
     </term>
 
     <!-- SHORT ROLE FORMS -->
-    <!-- Omitted roles: 
-         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author 
+    <!-- Omitted roles:
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -639,13 +643,17 @@
       <single>ed.</single>
       <multiple>eds.</multiple>
     </term>
+    <term name="editor-translator" form="short">
+      <single>ed. &amp; tran.</single>
+      <multiple>eds. &amp; trans.</multiple>
+    </term>
     <term name="editortranslator" form="short">
       <single>ed. &amp; tran.</single>
       <multiple>eds. &amp; trans.</multiple>
     </term>
     <term name="editorial-director" form="short">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
+      <single>ed. dir.</single>
+      <multiple>ed dirs.</multiple>
     </term>
     <term name="executive-producer" form="short">
       <single>exec. prod.</single>
@@ -694,8 +702,9 @@
     <term name="curator" form="verb">curated by</term>
     <term name="director" form="verb">directed by</term>
     <term name="editor" form="verb">edited by</term>
+    <term name="editor-translator" form="verb">edited &amp; translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
-    <term name="editorial-director" form="verb">edited by</term>
+    <term name="editorial-director" form="verb">editorial direction by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
     <term name="guest" form="verb">with guest</term>
     <term name="host" form="verb">hosted by</term>
@@ -713,7 +722,7 @@
     <term name="translator" form="verb">translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <!-- Omitted roles: 
+    <!-- Omitted roles:
          author, chair, container-author, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
@@ -723,8 +732,9 @@
     <term name="curator" form="verb-short">cur. by</term>
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
+    <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
-    <term name="editorial-director" form="verb-short">ed. by</term>
+    <term name="editorial-director" form="verb-short">ed. dir. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term>
     <term name="guest" form="verb-short">w. guest</term>
     <term name="illustrator" form="verb-short">illus. by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
-  <!-- This file follows the The Chicago Manual of Style, 18th ed. (2024), especially the list of scholarly abbreviations in sec. 10.48; additional abbreviations are from the Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>. -->
+  <!-- Where not otherwise stated, the scholarly abbreviations in this file are from The Chicago Manual of Style, 18th ed. (2024), sec. 10.48. -->
+  <!-- Additional abbreviations are from the Oxford Dictionary for Writers and Editors (ODWE) <https://archive.org/details/oxfordstylemanua0000unse>. -->
   <info>
     <translator>
       <name>Andrew Dunning</name>


### PR DESCRIPTION
This update expands CSL's default scholarly abbreviations in `en-US` and ensures that they follow current usage. It does this by checking the provenance of abbreviations in this locale, which is based on the *Chicago Manual of Style*.

Additional abbreviations, especially for short item types, draw first on the [*Oxford Dictionary for Writers and Editors* (*ODWE*)](https://archive.org/details/oxfordstylemanua0000unse), a prescriptive dictionary of which editions before 2005 match US English usage for contractions. Where *ODWE* does not provide guidance, the file draws on the [*Oxford Dictionary of Abbreviations* (*ODA*)](https://doi.org/10.1093/acref/9780199698295.001.0001), a descriptive work.

- Ensure that short forms match the list of scholarly abbreviations in [*The Chicago Manual of Style*, 18th ed. (2024), sec. 10.48](https://www.chicagomanualofstyle.org/book/ed18/part2/ch10/psec048.html):
    - The only prominent change resulting from this is 'trans.' rather than 'tran.' as a singular for `translator`. I cannot any style or dictionary that calls for this: searching for this abbreviation mostly turns up complaints about it from CSL users.
    - Chicago also recommends 'eqq.' as the plural abbreviation for `equation`, which results on one less difference between the `en-US` and `en-GB` localizations.
    - Chicago advocates for 'ca.' rather than 'c.' to abbreviate `circa`, but it seems safer to leave this alone, since they still allow the latter form, and a number of CSL styles use this term; it is unclear how many actively expect the former abbreviation.
    -  Consistently use 'ill.' as the abbreviation for illustrator/illustrated rather than mixing it with 'illus.' The latter is also common, such as in APA and *ODWE*, it would thus also be legitimate to standardize on 'illus.'.
- Remove 'w.' as an abbreviation for 'with', previously used in the `contributor` and `guest` short forms. Styles are likely to call these inadvertently when adding a blanket representation of contributor labels in short forms. This seems too specialized to be a default, since many dictionaries do not give a definition for 'w.' I cannot find a style manual that calls for it.
- Use the recommended month abbreviations from *CMOS* 10.44, which is also _ODWE_ usage.
- Provide missing `editor-translator`. More styles probably need 'ed. and trans.' than 'ed. & trans.', but this is probably not something that CSL can easily change at this point.
- Provide more short forms of general terms and item types, mostly based on _ODA_, and within their own sections of the file for internal consistency.
- Change unclear 'print.' abbreviation to 'ptg.', from the *Oxford Dictionary for Writers and Editors* (no CSL styles yet use it).
- Use terms for `collection` that better describe its use in the CSL specification (from APA).
- Abbreviate `canon` using the less specialized 'can.' rather than 'c.' (*ODWE*).
- Use 'issue' rather than 'number' as long text for `issue`.
- Remove unclear 'cre.' abbreviation for `series-creator`; I cannot find either a source for this or an alternative.
- Provide more descriptive labels for `classic` (classical work) and `collection` (archival collection) to follow the CSL specification.
- Trim whitespace and add contributor IDs.