### PR TITLE
Synchronize en-GB with en-US and update abbreviations

### DIFF
--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -144,17 +144,28 @@
     <term name="webpage">webpage</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-journal" form="short">jour. art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">class. wk</term>
+    <term name="classic" form="short">class. wk</term>
+    <term name="collection" form="short">coll.</term>
     <term name="document" form="short">doc.</term>
+    <term name="entry-dictionary" form="short">dict. entry</term>
+    <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
-    <term name="interview" form="short">interv.</term>
-    <term name="manuscript" form="short">MS</term>
+    <term name="interview" form="short">interv.</term> <!-- source unknown -->
+    <term name="manuscript" form="short">
+      <single>MS</single>
+      <multiple>MSS</multiple>
+    </term>
     <term name="motion_picture" form="short">video rec.</term>
+    <term name="musical_score" form="short">mus. score</term>
+    <term name="pamphlet" form="short">pam.</term>
+    <term name="paper-conference" form="short">conf. paper</term>
+    <term name="patent" form="short">pat.</term>
+    <term name="personal_communication" form="short">pers. comm.</term>
     <term name="report" form="short">rep.</term>
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk rev.</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -106,7 +106,7 @@
     <term name="broadcast">broadcast</term>
     <!-- chapter is in the list of locator terms -->
     <term name="classic">classical work</term>
-    <term name="collection">collection</term>
+    <term name="collection">archival collection</term>
     <term name="dataset">dataset</term>
     <term name="document">document</term>
     <term name="entry">entry</term>
@@ -150,7 +150,7 @@
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
     <term name="classic" form="short">class. wk</term>
-    <term name="collection" form="short">coll.</term>
+    <term name="collection" form="short">archival coll.</term>
     <term name="document" form="short">doc.</term>
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -311,10 +311,8 @@
       <single>table</single>
       <multiple>tables</multiple>
     </term>
-    <term name="timestamp"> <!-- generally blank -->
-      <single/>
-      <multiple/>
-    </term>
+    <!-- A timestamp is a composite of hours, minutes, etc. and therefore has no default label. -->
+    <term name="timestamp"/>
     <term name="title-locator">
       <single>title</single>
       <multiple>titles</multiple>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -481,8 +481,8 @@
 
     <!-- SHORT NUMBER VARIABLE FORMS -->
     <term name="chapter-number" form="short">
-      <single>chap.</single>
-      <multiple>chaps</multiple>
+      <single>ch.</single>
+      <multiple>chs</multiple>
     </term>
     <term name="citation-number" form="short">
       <single>cit.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -624,7 +624,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, curator, guest, host, interviewer, original-author, performer, recipient, reviewed-author, script-writer, series-creator
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -635,8 +635,14 @@
       <multiple>comps</multiple>
     </term>
     <term name="contributor" form="short">
+      <!-- source unknown -->
       <single>contrib.</single>
-      <multiple>contribs</multiple>
+      <multiple>contribs.</multiple>
+    </term>
+    <term name="curator" form="short">
+      <!-- source unknown -->
+      <single>cur.</single>
+      <multiple>curs.</multiple>
     </term>
     <term name="director" form="short">
       <single>dir.</single>
@@ -659,21 +665,40 @@
       <multiple>eds</multiple>
     </term>
     <term name="executive-producer" form="short">
+      <!-- source unknown -->
       <single>exec. prod.</single>
-      <multiple>exec. prods</multiple>
+      <multiple>exec. prods.</multiple>
     </term>
     <term name="illustrator" form="short">illus.</term> <!-- no plural -->
     <term name="narrator" form="short">
+      <!-- source unknown -->
       <single>narr.</single>
       <multiple>narrs</multiple>
     </term>
     <term name="organizer" form="short">
+      <!-- source unknown -->
       <single>org.</single>
-      <multiple>orgs</multiple>
+      <multiple>orgs.</multiple>
+    </term>
+    <term name="performer" form="short">
+      <!-- source unknown -->
+      <single>perf.</single>
+      <multiple>perfs.</multiple>
     </term>
     <term name="producer" form="short">
+      <!-- source unknown -->
       <single>prod.</single>
-      <multiple>prods</multiple>
+      <multiple>prods.</multiple>
+    </term>
+    <term name="script-writer" form="short">
+      <!-- source unknown -->
+      <single>writ.</single>
+      <multiple>writs.</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <!-- source unknown -->
+      <single>cre.</single>
+      <multiple>cres.</multiple>
     </term>
     <term name="translator" form="short">trans.</term> <!-- no plural -->
 
@@ -708,11 +733,12 @@
 
     <!-- SHORT VERB ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, container-author, contributor, curator, guest, host, interviewer, original-author, performer, recipient, reviewed-author, series-creator
+         author, chair, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
     <term name="composer" form="verb-short">comp. by</term>
+    <term name="curator" form="verb-short">cur. by</term> <!-- source unknown -->
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
@@ -720,10 +746,12 @@
     <term name="editorial-director" form="verb-short">ed. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term>
     <term name="illustrator" form="verb-short">illus. by</term>
-    <term name="narrator" form="verb-short">narr. by</term>
-    <term name="organizer" form="verb-short">org. by</term>
-    <term name="producer" form="verb-short">prod. by</term>
-    <term name="script-writer" form="verb-short">writ. by</term>
+    <term name="narrator" form="verb-short">narr. by</term> <!-- source unknown -->
+    <term name="organizer" form="verb-short">org. by</term> <!-- source unknown -->
+    <term name="performer" form="verb-short">perf. by</term> <!-- source unknown -->
+    <term name="producer" form="verb-short">prod. by</term> <!-- source unknown -->
+    <term name="script-writer" form="verb-short">writ. by</term> <!-- source unknown -->
+    <term name="series-creator" form="verb-short">cre. by</term> <!-- source unknown -->
     <term name="translator" form="verb-short">trans. by</term>
 
     <!-- LONG MONTH FORMS -->

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -155,7 +155,7 @@
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
-    <term name="interview" form="short">interv.</term> <!-- source unknown -->
+    <term name="interview" form="short">intvw</term> <!-- Free Dictionary -->
     <term name="manuscript" form="short">
       <single>MS</single>
       <multiple>MSS</multiple>
@@ -660,8 +660,8 @@
       <multiple>eds &amp; trans.</multiple>
     </term>
     <term name="editorial-director" form="short">
-      <single>ed. dir.</single>
-      <multiple>ed. dirs</multiple>
+      <single>ed.</single>
+      <multiple>eds</multiple>
     </term>
     <term name="executive-producer" form="short">
       <single>exec. prod.</single>
@@ -700,7 +700,7 @@
     <term name="editor" form="verb">edited by</term>
     <term name="editor-translator" form="verb">edited &amp; translated by</term>
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
-    <term name="editorial-director" form="verb">editorial direction by</term>
+    <term name="editorial-director" form="verb">edited by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
     <term name="guest" form="verb">with guest</term>
     <term name="host" form="verb">hosted by</term>
@@ -728,7 +728,7 @@
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
-    <term name="editorial-director" form="verb-short">ed. dir. by</term>
+    <term name="editorial-director" form="verb-short">ed. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term>
     <term name="illustrator" form="verb-short">illus. by</term>
     <term name="narrator" form="verb-short">narr. by</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -410,7 +410,7 @@
     </term>
     <term name="title-locator" form="short">
       <single>tit.</single>
-      <multiple>tits</multiple>
+      <multiple>titt.</multiple> <!-- source unknown for plural -->
     </term>
     <term name="verse" form="short">
       <single>v.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -638,12 +638,12 @@
     <term name="contributor" form="short">
       <!-- source unknown -->
       <single>contrib.</single>
-      <multiple>contribs.</multiple>
+      <multiple>contribs</multiple>
     </term>
     <term name="curator" form="short">
       <!-- source unknown -->
       <single>cur.</single>
-      <multiple>curs.</multiple>
+      <multiple>curs</multiple>
     </term>
     <term name="director" form="short">
       <single>dir.</single>
@@ -668,7 +668,7 @@
     <term name="executive-producer" form="short">
       <!-- source unknown -->
       <single>exec. prod.</single>
-      <multiple>exec. prods.</multiple>
+      <multiple>exec. prods</multiple>
     </term>
     <term name="illustrator" form="short">illus.</term> <!-- no plural -->
     <term name="narrator" form="short">
@@ -679,27 +679,27 @@
     <term name="organizer" form="short">
       <!-- source unknown -->
       <single>org.</single>
-      <multiple>orgs.</multiple>
+      <multiple>orgs</multiple>
     </term>
     <term name="performer" form="short">
       <!-- source unknown -->
       <single>perf.</single>
-      <multiple>perfs.</multiple>
+      <multiple>perfs</multiple>
     </term>
     <term name="producer" form="short">
       <!-- source unknown -->
       <single>prod.</single>
-      <multiple>prods.</multiple>
+      <multiple>prods</multiple>
     </term>
     <term name="script-writer" form="short">
       <!-- source unknown -->
       <single>writ.</single>
-      <multiple>writs.</multiple>
+      <multiple>writs</multiple>
     </term>
     <term name="series-creator" form="short">
       <!-- source unknown -->
       <single>cre.</single>
-      <multiple>cres.</multiple>
+      <multiple>cres</multiple>
     </term>
     <term name="translator" form="short">trans.</term> <!-- no plural -->
 

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -383,7 +383,7 @@
       <multiple>paras</multiple>
     </term>
     <term name="part" form="short">
-      <single>pt.</single>
+      <single>pt</single>
       <multiple>pts</multiple>
     </term>
     <term name="rule" form="short">
@@ -612,7 +612,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, curator, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -627,8 +627,8 @@
       <multiple>contribs</multiple>
     </term>
     <term name="curator" form="short">
-      <single>cur.</single>
-      <multiple>curs</multiple>
+      <single>curat.</single>
+      <multiple>curators</multiple>
     </term>
     <term name="director" form="short">
       <single>dir.</single>
@@ -656,7 +656,7 @@
     </term>
     <term name="illustrator" form="short">
       <single>illus.</single>
-      <multiple>illus.</multiple>
+      <multiple>illus</multiple>
     </term>
     <term name="narrator" form="short">
       <single>narr.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -327,7 +327,7 @@
       <multiple>arts</multiple>
     </term>
     <term name="book" form="short">
-      <single>bk.</single>
+      <single>bk</single>
       <multiple>bks</multiple>
     </term>
     <term name="canon" form="short">
@@ -395,8 +395,8 @@
       <multiple>scs</multiple>
     </term>
     <term name="section" form="short">
-      <single>sec.</single>
-      <multiple>secs</multiple>
+      <single>sect.</single>
+      <multiple>sects</multiple>
     </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-GB">
   <info>
-    <!-- Where it provides guidance, this file follows the New Oxford Dictionary for Writers and Editors, 2nd edn (Oxford, 2014), based on the Oxford Dictionary of English. -->
+    <!-- This file follows the New Oxford Dictionary for Writers and Editors, 2nd edn (Oxford, 2014). The edition of this work from 2000 is available via <https://archive.org/details/isbn_0199690944> or <https://archive.org/details/oxfordstylemanua0000unse>, still a useful resource for more obscure abbreviations. This dictionary adopted the British English convention of rendering contractions without full stops in 2005: the earlier edition needs to be adapted for this. -->
     <translator>
       <name>Andrew Dunning</name>
     </translator>
@@ -39,7 +39,7 @@
     <term name="available at">available at</term>
     <term name="by">by</term>
     <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term>
+    <term name="circa" form="short">c.</term> <!-- should be italicized -->
     <term name="cited">cited</term>
     <term name="et-al">et al.</term>
     <term name="film">film</term>
@@ -63,7 +63,6 @@
     <term name="original-work-published">original work published</term>
     <term name="original-work-published" form="short">orig. pub.</term>
     <term name="personal-communication">personal communication</term>
-    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
@@ -144,15 +143,14 @@
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
+    <term name="classic">class.</term>
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">graph.</term>
-    <term name="interview" form="short">interv.</term>
     <term name="manuscript" form="short">MS</term>
     <term name="motion_picture" form="short">video rec.</term>
     <term name="report" form="short">rep.</term>
     <term name="review" form="short">rev.</term>
-    <term name="review-book" form="short">bk. rev.</term>
+    <term name="review-book" form="short">bk rev.</term>
     <term name="song" form="short">audio rec.</term>
 
     <!-- VERB ITEM TYPE FORMS -->
@@ -331,8 +329,8 @@
       <multiple>bks</multiple>
     </term>
     <term name="canon" form="short">
-      <single>c.</single>
-      <multiple>cc.</multiple>
+      <single>can.</single>
+      <multiple>cans</multiple>
     </term>
     <term name="chapter" form="short">
       <single>ch.</single>
@@ -420,7 +418,7 @@
     </term>
     <term name="version" form="short">
       <single>v.</single>
-      <multiple>v.</multiple>
+      <multiple>v.</multiple> <!-- no plural -->
     </term>
     <term name="volume" form="short">
       <single>vol.</single>
@@ -612,7 +610,7 @@
 
     <!-- SHORT ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, composer, container-author, curator, guest, host, interviewer, original-author, performer, recipient, reviewed-author, script-writer, series-creator
     -->
     <term name="collection-editor" form="short">
       <single>ed.</single>
@@ -625,10 +623,6 @@
     <term name="contributor" form="short">
       <single>contrib.</single>
       <multiple>contribs</multiple>
-    </term>
-    <term name="curator" form="short">
-      <single>curat.</single>
-      <multiple>curators</multiple>
     </term>
     <term name="director" form="short">
       <single>dir.</single>
@@ -656,7 +650,7 @@
     </term>
     <term name="illustrator" form="short">
       <single>illus.</single>
-      <multiple>illus</multiple>
+      <multiple>illus.</multiple> <!-- no plural -->
     </term>
     <term name="narrator" form="short">
       <single>narr.</single>
@@ -666,25 +660,13 @@
       <single>org.</single>
       <multiple>orgs</multiple>
     </term>
-    <term name="performer" form="short">
-      <single>perf.</single>
-      <multiple>perfs</multiple>
-    </term>
     <term name="producer" form="short">
       <single>prod.</single>
       <multiple>prods</multiple>
     </term>
-    <term name="script-writer" form="short">
-      <single>writ.</single>
-      <multiple>writs</multiple>
-    </term>
-    <term name="series-creator" form="short">
-      <single>ser. creat.</single>
-      <multiple>ser. creats</multiple>
-    </term>
     <term name="translator" form="short">
       <single>trans.</single>
-      <multiple>trans.</multiple>
+      <multiple>trans.</multiple> <!-- no plural -->
     </term>
 
     <!-- VERB ROLE FORMS -->
@@ -718,27 +700,22 @@
 
     <!-- SHORT VERB ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, container-author, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, container-author, contributor, curator, guest, host, interviewer, original-author, performer, recipient, reviewed-author, series-creator
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
     <term name="composer" form="verb-short">comp. by</term>
-    <term name="contributor" form="verb-short">with</term>
-    <term name="curator" form="verb-short">cur. by</term>
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editorial-director" form="verb-short">ed. dir. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term>
-    <term name="guest" form="verb-short">with guest</term>
     <term name="illustrator" form="verb-short">illus. by</term>
     <term name="narrator" form="verb-short">narr. by</term>
     <term name="organizer" form="verb-short">org. by</term>
-    <term name="performer" form="verb-short">perf. by</term>
     <term name="producer" form="verb-short">prod. by</term>
     <term name="script-writer" form="verb-short">writ. by</term>
-    <term name="series-creator" form="verb-short">ser. creat. by</term>
     <term name="translator" form="verb-short">trans. by</term>
 
     <!-- LONG MONTH FORMS -->
@@ -761,10 +738,10 @@
     <term name="month-03" form="short">Mar.</term>
     <term name="month-04" form="short">Apr.</term>
     <term name="month-05" form="short">May</term>
-    <term name="month-06" form="short">Jun.</term>
-    <term name="month-07" form="short">Jul.</term>
+    <term name="month-06" form="short">June</term>
+    <term name="month-07" form="short">July</term>
     <term name="month-08" form="short">Aug.</term>
-    <term name="month-09" form="short">Sep.</term>
+    <term name="month-09" form="short">Sept.</term>
     <term name="month-10" form="short">Oct.</term>
     <term name="month-11" form="short">Nov.</term>
     <term name="month-12" form="short">Dec.</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -345,8 +345,9 @@
       <multiple>locs</multiple>
     </term>
     <term name="equation" form="short">
-      <single>eqn</single>
-      <multiple>eqns</multiple>
+      <!-- from Chicago Manual of Style -->
+      <single>eq.</single>
+      <multiple>eqq.</multiple>
     </term>
     <term name="figure" form="short">
       <single>fig.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -50,7 +50,7 @@
     <term name="ibid">ibid.</term>
     <term name="in">in</term>
     <term name="in press">in press</term>
-    <term name="internet">Internet</term>
+    <term name="internet">internet</term>
     <term name="letter">letter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="no date">no date</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -4,12 +4,15 @@
     <!-- This file follows the New Oxford Dictionary for Writers and Editors, 2nd edn (Oxford, 2014). The edition of this work from 2000 is available via <https://archive.org/details/isbn_0199690944> or <https://archive.org/details/oxfordstylemanua0000unse>, still a useful resource for more obscure abbreviations. This dictionary adopted the British English convention of rendering contractions without full stops in 2005: the earlier edition needs to be adapted for this. -->
     <translator>
       <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
     </translator>
     <translator>
       <name>Sebastian Karcher</name>
+      <uri>https://orcid.org/0000-0001-8249-7388</uri>
     </translator>
     <translator>
       <name>Rintze M. Zelle</name>
+      <uri>https://orcid.org/0000-0003-1779-8883</uri>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2025-06-23T00:00:00+00:00</updated>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -517,8 +517,8 @@
       <multiple>pp.</multiple>
     </term>
     <term name="printing" form="short">
-      <single>print.</single>
-      <multiple>prints</multiple>
+      <single>ptg</single>
+      <multiple>ptgs</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -99,7 +99,7 @@
     <!-- book is in the list of locator terms -->
     <term name="broadcast">broadcast</term>
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">classic</term>
+    <term name="classic">classical work</term>
     <term name="collection">collection</term>
     <term name="dataset">dataset</term>
     <term name="document">document</term>
@@ -143,7 +143,7 @@
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">class.</term>
+    <term name="classic">class. wk.</term>
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="manuscript" form="short">MS</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-GB">
   <info>
+    <!-- Where it provides guidance, this file follows the New Oxford Dictionary for Writers and Editors, 2nd edn (Oxford, 2014), based on the Oxford Dictionary of English. -->
     <translator>
       <name>Andrew Dunning</name>
     </translator>
@@ -11,7 +12,7 @@
       <name>Rintze M. Zelle</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2015-10-10T23:31:02+00:00</updated>
+    <updated>2025-06-23T00:00:00+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -25,26 +26,63 @@
     <date-part name="year"/>
   </date>
   <terms>
+    <!-- GENERAL TERMS -->
+    <term name="accessed">accessed</term>
     <term name="advance-online-publication">advance online publication</term>
     <term name="album">album</term>
+    <term name="and">and</term>
+    <term name="and others">and others</term>
+    <term name="anonymous">anonymous</term>
+    <term name="anonymous" form="short">anon.</term>
+    <term name="at">at</term>
     <term name="audio-recording">audio recording</term>
+    <term name="available at">available at</term>
+    <term name="by">by</term>
+    <term name="circa">circa</term>
+    <term name="circa" form="short">c.</term>
+    <term name="cited">cited</term>
+    <term name="et-al">et al.</term>
     <term name="film">film</term>
+    <term name="forthcoming">forthcoming</term>
+    <term name="from">from</term>
     <term name="henceforth">henceforth</term>
+    <term name="ibid">ibid.</term>
+    <term name="in">in</term>
+    <term name="in press">in press</term>
+    <term name="internet">Internet</term>
+    <term name="letter">letter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="no date">no date</term>
+    <term name="no date" form="short">n.d.</term>
     <term name="no-place">no place</term>
     <term name="no-place" form="short">n.p.</term>
     <term name="no-publisher">no publisher</term> <!-- sine nomine -->
-    <term name="no-publisher" form="short">n.p.</term>
     <term name="on">on</term>
+    <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
+    <term name="original-work-published" form="short">orig. pub.</term>
     <term name="personal-communication">personal communication</term>
+    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
+    <term name="presented at">presented at the</term>
     <term name="radio-broadcast">radio broadcast</term>
     <term name="radio-series">radio series</term>
     <term name="radio-series-episode">radio series episode</term>
+    <term name="reference">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="reference" form="short">
+      <single>ref.</single>
+      <multiple>refs</multiple>
+    </term>
+    <term name="retrieved">retrieved</term>
+    <term name="review-of">review of</term>
+    <term name="review-of" form="short">rev. of</term>
+    <term name="scale">scale</term>
     <term name="special-issue">special issue</term>
     <term name="special-section">special section</term>
     <term name="television-broadcast">television broadcast</term>
@@ -52,63 +90,6 @@
     <term name="television-series-episode">television series episode</term>
     <term name="video">video</term>
     <term name="working-paper">working paper</term>
-    <term name="accessed">accessed</term>
-    <term name="and">and</term>
-    <term name="and others">and others</term>
-    <term name="anonymous">anonymous</term>
-    <term name="anonymous" form="short">anon.</term>
-    <term name="at">at</term>
-    <term name="available at">available at</term>
-    <term name="by">by</term>
-    <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term>
-    <term name="cited">cited</term>
-    <term name="first-reference-note-number">
-      <single>reference</single>
-      <multiple>references</multiple>
-    </term>
-    <term name="number">
-      <single>number</single>
-      <multiple>numbers</multiple>
-    </term>
-    <term name="edition">
-      <single>edition</single>
-      <multiple>editions</multiple>
-    </term>
-    <term name="first-reference-note-number" form="short">
-      <single>ref.</single>
-      <multiple>refs.</multiple>
-    </term>
-    <term name="number" form="short">
-      <single>no.</single>
-      <multiple>nos.</multiple>
-    </term>
-    <term name="edition" form="short">ed.</term>
-    <term name="et-al">et al.</term>
-    <term name="forthcoming">forthcoming</term>
-    <term name="from">from</term>
-    <term name="ibid">ibid.</term>
-    <term name="in">in</term>
-    <term name="in press">in press</term>
-    <term name="internet">internet</term>
-    <term name="letter">letter</term>
-    <term name="no date">no date</term>
-    <term name="no date" form="short">n.d.</term>
-    <term name="online">online</term>
-    <term name="presented at">presented at the</term>
-    <term name="reference">
-      <single>reference</single>
-      <multiple>references</multiple>
-    </term>
-    <term name="reference" form="short">
-      <single>ref.</single>
-      <multiple>refs.</multiple>
-    </term>
-    <term name="review-of">review of</term>
-    <term name="review-of" form="short">rev. of</term>
-    <term name="retrieved">retrieved</term>
-    <term name="scale">scale</term>
-    <term name="version">version</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">preprint</term>
@@ -218,53 +199,25 @@
     <term name="long-ordinal-10">tenth</term>
 
     <!-- LONG LOCATOR FORMS -->
-    <term name="act">			 
+    <term name="act">
       <single>act</single>
-      <multiple>acts</multiple>						 
+      <multiple>acts</multiple>
     </term>
-    <term name="appendix">			 
+    <term name="appendix">
       <single>appendix</single>
-      <multiple>appendices</multiple>						 
+      <multiple>appendices</multiple>
     </term>
-    <term name="article-locator">			 
+    <term name="article-locator">
       <single>article</single>
-      <multiple>articles</multiple>						 
-    </term>
-    <term name="canon">			 
-      <single>canon</single>
-      <multiple>canons</multiple>						 
-    </term>
-    <term name="elocation">	
-      <single>location</single>
-      <multiple>locations</multiple>						 
-    </term>
-    <term name="equation">			 
-      <single>equation</single>
-      <multiple>equations</multiple>						 
-    </term>
-    <term name="rule">			 
-      <single>rule</single>
-      <multiple>rules</multiple>						 
-    </term>
-    <term name="scene">			 
-      <single>scene</single>
-      <multiple>scenes</multiple>						 
-    </term>
-    <term name="table">			 
-      <single>table</single>
-      <multiple>tables</multiple>						 
-    </term>
-    <term name="timestamp"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
-    </term>
-    <term name="title-locator">			 
-      <single>title</single>
-      <multiple>titles</multiple>						 
+      <multiple>articles</multiple>
     </term>
     <term name="book">
       <single>book</single>
       <multiple>books</multiple>
+    </term>
+    <term name="canon">
+      <single>canon</single>
+      <multiple>canons</multiple>
     </term>
     <term name="chapter">
       <single>chapter</single>
@@ -273,6 +226,14 @@
     <term name="column">
       <single>column</single>
       <multiple>columns</multiple>
+    </term>
+    <term name="elocation">
+      <single>location</single>
+      <multiple>locations</multiple>
+    </term>
+    <term name="equation">
+      <single>equation</single>
+      <multiple>equations</multiple>
     </term>
     <term name="figure">
       <single>figure</single>
@@ -302,35 +263,6 @@
       <single>page</single>
       <multiple>pages</multiple>
     </term>
-    <term name="number-of-volumes">
-      <single>volume</single>
-      <multiple>volumes</multiple>
-    </term>
-    <term name="page-first">
-      <single>page</single>
-      <multiple>pages</multiple>
-    </term>
-    <term name="printing">
-      <single>printing</single>
-      <multiple>printings</multiple>
-    </term>
-
-    <term name="chapter-number" form="short">
-      <single>chap.</single>
-      <multiple>chaps.</multiple>
-    </term>
-    <term name="citation-number" form="short">
-      <single>cit.</single>
-      <multiple>cits.</multiple>
-    </term>
-    <term name="collection-number" form="short">
-      <single>no.</single>
-      <multiple>nos.</multiple>
-    </term>
-    <term name="number-of-pages">
-      <single>page</single>
-      <multiple>pages</multiple>
-    </term>
     <term name="paragraph">
       <single>paragraph</single>
       <multiple>paragraphs</multiple>
@@ -339,21 +271,45 @@
       <single>part</single>
       <multiple>parts</multiple>
     </term>
+    <term name="rule">
+      <single>rule</single>
+      <multiple>rules</multiple>
+    </term>
+    <term name="scene">
+      <single>scene</single>
+      <multiple>scenes</multiple>
+    </term>
     <term name="section">
       <single>section</single>
       <multiple>sections</multiple>
-    </term>
-    <term name="supplement">
-      <single>supplement</single>
-      <multiple>supplements</multiple>
     </term>
     <term name="sub-verbo">
       <single>sub verbo</single>
       <multiple>sub verbis</multiple>
     </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
+    </term>
+    <term name="table">
+      <single>table</single>
+      <multiple>tables</multiple>
+    </term>
+    <term name="timestamp"> <!-- generally blank -->
+      <single/>
+      <multiple/>
+    </term>
+    <term name="title-locator">
+      <single>title</single>
+      <multiple>titles</multiple>
+    </term>
     <term name="verse">
       <single>verse</single>
       <multiple>verses</multiple>
+    </term>
+    <term name="version">
+      <single>version</single>
+      <multiple>versions</multiple>
     </term>
     <term name="volume">
       <single>volume</single>
@@ -361,53 +317,38 @@
     </term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix" form="short">			 
+    <!-- Omitted short forms: act, timestamp -->
+    <term name="appendix" form="short">
       <single>app.</single>
-      <multiple>apps.</multiple>						 
+      <multiple>apps</multiple>
     </term>
-    <term name="article-locator" form="short">			 
+    <term name="article-locator" form="short">
       <single>art.</single>
-      <multiple>arts.</multiple>
-    </term>
-    <term name="elocation" form="short">
-      <single>loc.</single>
-      <multiple>locs.</multiple>
-    </term>
-    <term name="equation" form="short">			 
-      <single>eq.</single>
-      <multiple>eqs.</multiple>
-    </term>
-    <term name="rule" form="short">			 
-      <single>r.</single>
-      <multiple>rr.</multiple>						 
-    </term>
-    <term name="scene" form="short">			 
-      <single>sc.</single>
-      <multiple>scs.</multiple>						 
-    </term>
-    <term name="table" form="short">			 
-      <single>tbl.</single>
-      <multiple>tbls.</multiple>						 
-    </term>
-    <term name="timestamp" form="short"> <!-- generally blank -->
-      <single></single>
-      <multiple></multiple>						 
-    </term>
-    <term name="title-locator" form="short">			 
-      <single>tit.</single>
-      <multiple>tits.</multiple>
+      <multiple>arts</multiple>
     </term>
     <term name="book" form="short">
       <single>bk.</single>
       <multiple>bks</multiple>
     </term>
+    <term name="canon" form="short">
+      <single>c.</single>
+      <multiple>cc.</multiple>
+    </term>
     <term name="chapter" form="short">
-      <single>chap.</single>
-      <multiple>chaps</multiple>
+      <single>ch.</single>
+      <multiple>chs</multiple>
     </term>
     <term name="column" form="short">
       <single>col.</single>
       <multiple>cols</multiple>
+    </term>
+    <term name="elocation" form="short">
+      <single>loc.</single>
+      <multiple>locs</multiple>
+    </term>
+    <term name="equation" form="short">
+      <single>eq.</single>
+      <multiple>eqs</multiple>
     </term>
     <term name="figure" form="short">
       <single>fig.</single>
@@ -419,7 +360,7 @@
     </term>
     <term name="issue" form="short">
       <single>no.</single>
-      <multiple>nos.</multiple>
+      <multiple>nos</multiple>
     </term>
     <term name="line" form="short">
       <single>l.</single>
@@ -437,24 +378,6 @@
       <single>p.</single>
       <multiple>pp.</multiple>
     </term>
-    <term name="number-of-volumes" form="short">
-      <single>vol.</single>
-      <multiple>vols.</multiple>
-    </term>
-    <term name="page-first" form="short">
-      <single>p.</single>
-      <multiple>pp.</multiple>
-    </term>
-    <term name="printing" form="short">
-      <single>print.</single>
-      <multiple>prints.</multiple>
-    </term>
-    
-
-    <term name="number-of-pages" form="short">
-      <single>p.</single>
-      <multiple>pp.</multiple>
-    </term>
     <term name="paragraph" form="short">
       <single>para.</single>
       <multiple>paras</multiple>
@@ -463,21 +386,41 @@
       <single>pt.</single>
       <multiple>pts</multiple>
     </term>
+    <term name="rule" form="short">
+      <single>r.</single>
+      <multiple>rr.</multiple>
+    </term>
+    <term name="scene" form="short">
+      <single>sc.</single>
+      <multiple>scs</multiple>
+    </term>
     <term name="section" form="short">
       <single>sec.</single>
       <multiple>secs</multiple>
-    </term>
-    <term name="supplement" form="short">
-      <single>supp.</single>
-      <multiple>supps.</multiple>
     </term>
     <term name="sub-verbo" form="short">
       <single>s.v.</single>
       <multiple>s.vv.</multiple>
     </term>
+    <term name="supplement" form="short">
+      <single>suppl.</single>
+      <multiple>suppls</multiple>
+    </term>
+    <term name="table" form="short">
+      <single>tbl.</single>
+      <multiple>tbls</multiple>
+    </term>
+    <term name="title-locator" form="short">
+      <single>tit.</single>
+      <multiple>tits</multiple>
+    </term>
     <term name="verse" form="short">
       <single>v.</single>
       <multiple>vv.</multiple>
+    </term>
+    <term name="version" form="short">
+      <single>v.</single>
+      <multiple>v.</multiple>
     </term>
     <term name="volume" form="short">
       <single>vol.</single>
@@ -489,6 +432,12 @@
       <single>¶</single>
       <multiple>¶¶</multiple>
     </term>
+    <term name="section" form="symbol">
+      <single>§</single>
+      <multiple>§§</multiple>
+    </term>
+
+    <!-- LONG NUMBER VARIABLE FORMS -->
     <term name="chapter-number">
       <single>chapter</single>
       <multiple>chapters</multiple>
@@ -501,19 +450,88 @@
       <single>number</single>
       <multiple>numbers</multiple>
     </term>
-    <term name="section" form="symbol">
-      <single>§</single>
-      <multiple>§§</multiple>
+    <term name="edition">
+      <single>edition</single>
+      <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <!-- SHORT NUMBER VARIABLE FORMS -->
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>no.</single>
+      <multiple>nos</multiple>
+    </term>
+    <term name="edition" form="short">
+      <single>edn</single>
+      <multiple>edns</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <single>print.</single>
+      <multiple>prints</multiple>
     </term>
 
     <!-- LONG ROLE FORMS -->
-    <term name="collection-editor">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
-    </term>
+    <!-- Omitted roles:
+         author, composer, container-author, interviewer, original-author, recipient, reviewed-author
+    -->
     <term name="chair">
       <single>chair</single>
       <multiple>chairs</multiple>
+    </term>
+    <term name="collection-editor">
+      <single>editor</single>
+      <multiple>editors</multiple>
     </term>
     <term name="compiler">
       <single>compiler</single>
@@ -527,6 +545,26 @@
       <single>curator</single>
       <multiple>curators</multiple>
     </term>
+    <term name="director">
+      <single>director</single>
+      <multiple>directors</multiple>
+    </term>
+    <term name="editor">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
+    <term name="editor-translator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+    <term name="editortranslator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+    <term name="editorial-director">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
     <term name="executive-producer">
       <single>executive producer</single>
       <multiple>executive producers</multiple>
@@ -538,6 +576,10 @@
     <term name="host">
       <single>host</single>
       <multiple>hosts</multiple>
+    </term>
+    <term name="illustrator">
+      <single>illustrator</single>
+      <multiple>illustrators</multiple>
     </term>
     <term name="narrator">
       <single>narrator</single>
@@ -563,143 +605,141 @@
       <single>series creator</single>
       <multiple>series creators</multiple>
     </term>
-    <term name="director">
-      <single>director</single>
-      <multiple>directors</multiple>
-    </term>
-    <term name="editor">
-      <single>editor</single>
-      <multiple>editors</multiple>
-    </term>
-    <term name="editorial-director">
-      <single>editor</single>
-      <multiple>editors</multiple>
-    </term>
-    <term name="illustrator">
-      <single>illustrator</single>
-      <multiple>illustrators</multiple>
-    </term>
     <term name="translator">
       <single>translator</single>
       <multiple>translators</multiple>
     </term>
-    <term name="editortranslator">
-      <single>editor &amp; translator</single>
-      <multiple>editors &amp; translators</multiple>
-    </term>
 
     <!-- SHORT ROLE FORMS -->
+    <!-- Omitted roles:
+         author, chair, composer, container-author, curator, guest, host, interviewer, original-author, recipient, reviewed-author
+    -->
+    <term name="collection-editor" form="short">
+      <single>ed.</single>
+      <multiple>eds</multiple>
+    </term>
     <term name="compiler" form="short">
       <single>comp.</single>
-      <multiple>comps.</multiple>
+      <multiple>comps</multiple>
     </term>
     <term name="contributor" form="short">
       <single>contrib.</single>
-      <multiple>contribs.</multiple>
+      <multiple>contribs</multiple>
     </term>
     <term name="curator" form="short">
       <single>cur.</single>
-      <multiple>curs.</multiple>
-    </term>
-    <term name="executive-producer" form="short">
-      <single>exec. prod.</single>
-      <multiple>exec. prods.</multiple>
-    </term>
-    <term name="narrator" form="short">
-      <single>narr.</single>
-      <multiple>narrs.</multiple>
-    </term>
-    <term name="organizer" form="short">
-      <single>org.</single>
-      <multiple>orgs.</multiple>
-    </term>
-    <term name="performer" form="short">
-      <single>perf.</single>
-      <multiple>perfs.</multiple>
-    </term>
-    <term name="producer" form="short">
-      <single>prod.</single>
-      <multiple>prods.</multiple>
-    </term>
-    <term name="script-writer" form="short">
-      <single>writ.</single>
-      <multiple>writs.</multiple>
-    </term>
-    <term name="series-creator" form="short">
-      <single>cre.</single>
-      <multiple>cres.</multiple>
+      <multiple>curs</multiple>
     </term>
     <term name="director" form="short">
       <single>dir.</single>
-      <multiple>dirs.</multiple>
+      <multiple>dirs</multiple>
     </term>
     <term name="editor" form="short">
       <single>ed.</single>
-      <multiple>eds.</multiple>
+      <multiple>eds</multiple>
     </term>
-    <term name="editorial-director" form="short">
-      <single>ed.</single>
-      <multiple>eds.</multiple>
-    </term>
-    <term name="illustrator" form="short">
-      <single>ill.</single>
-      <multiple>ills.</multiple>
-    </term>
-    <term name="translator" form="short">
-      <single>tran.</single>
-      <multiple>trans.</multiple>
+    <term name="editor-translator" form="short">
+      <single>ed. &amp; trans.</single>
+      <multiple>eds &amp; trans.</multiple>
     </term>
     <term name="editortranslator" form="short">
-      <single>ed. &amp; tran.</single>
-      <multiple>eds. &amp; trans.</multiple>
+      <single>ed. &amp; trans.</single>
+      <multiple>eds &amp; trans.</multiple>
+    </term>
+    <term name="editorial-director" form="short">
+      <single>ed. dir.</single>
+      <multiple>ed. dirs</multiple>
+    </term>
+    <term name="executive-producer" form="short">
+      <single>exec. prod.</single>
+      <multiple>exec. prods</multiple>
+    </term>
+    <term name="illustrator" form="short">
+      <single>illus.</single>
+      <multiple>illus.</multiple>
+    </term>
+    <term name="narrator" form="short">
+      <single>narr.</single>
+      <multiple>narrs</multiple>
+    </term>
+    <term name="organizer" form="short">
+      <single>org.</single>
+      <multiple>orgs</multiple>
+    </term>
+    <term name="performer" form="short">
+      <single>perf.</single>
+      <multiple>perfs</multiple>
+    </term>
+    <term name="producer" form="short">
+      <single>prod.</single>
+      <multiple>prods</multiple>
+    </term>
+    <term name="script-writer" form="short">
+      <single>writ.</single>
+      <multiple>writs</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <single>ser. creat.</single>
+      <multiple>ser. creats</multiple>
+    </term>
+    <term name="translator" form="short">
+      <single>trans.</single>
+      <multiple>trans.</multiple>
     </term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="collection-editor" form="verb">edited by</term>
     <term name="chair" form="verb">chaired by</term>
+    <term name="collection-editor" form="verb">edited by</term>
     <term name="compiler" form="verb">compiled by</term>
+    <term name="composer" form="verb">composed by</term>
+    <term name="container-author" form="verb">by</term>
     <term name="contributor" form="verb">with</term>
     <term name="curator" form="verb">curated by</term>
+    <term name="director" form="verb">directed by</term>
+    <term name="editor" form="verb">edited by</term>
+    <term name="editor-translator" form="verb">edited &amp; translated by</term>
+    <term name="editortranslator" form="verb">edited &amp; translated by</term>
+    <term name="editorial-director" form="verb">editorial direction by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
     <term name="guest" form="verb">with guest</term>
     <term name="host" form="verb">hosted by</term>
-    <term name="narrator" form="verb">narrated by</term>
-    <term name="organizer" form="verb">organized by</term>
-    <term name="performer" form="verb">performed by</term>
-    <term name="producer" form="verb">produced by</term>
-    <term name="script-writer" form="verb">written by</term>
-    <term name="series-creator" form="verb">created by</term>
-    <term name="container-author" form="verb">by</term>
-    <term name="director" form="verb">directed by</term>
-    <term name="editor" form="verb">edited by</term>
-    <term name="editorial-director" form="verb">edited by</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">interview by</term>
+    <term name="narrator" form="verb">narrated by</term>
+    <term name="organizer" form="verb">organized by</term>
+    <term name="original-author" form="verb">by</term>
+    <term name="performer" form="verb">performed by</term>
+    <term name="producer" form="verb">produced by</term>
     <term name="recipient" form="verb">to</term>
     <term name="reviewed-author" form="verb">by</term>
-    <term name="collection-editor" form="verb-short">ed. by</term>
+    <term name="script-writer" form="verb">written by</term>
+    <term name="series-creator" form="verb">created by</term>
     <term name="translator" form="verb">translated by</term>
-    <term name="editortranslator" form="verb">edited &amp; translated by</term>
 
     <!-- SHORT VERB ROLE FORMS -->
+    <!-- Omitted roles:
+         author, chair, container-author, host, interviewer, original-author, recipient, reviewed-author
+    -->
+    <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
-    <term name="contributor" form="verb-short">w.</term>
+    <term name="composer" form="verb-short">comp. by</term>
+    <term name="contributor" form="verb-short">with</term>
     <term name="curator" form="verb-short">cur. by</term>
+    <term name="director" form="verb-short">dir. by</term>
+    <term name="editor" form="verb-short">ed. by</term>
+    <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="editorial-director" form="verb-short">ed. dir. by</term>
     <term name="executive-producer" form="verb-short">exec. prod. by</term>
-    <term name="guest" form="verb-short">w. guest</term>
-    <term name="host" form="verb-short">hosted by</term>
+    <term name="guest" form="verb-short">with guest</term>
+    <term name="illustrator" form="verb-short">illus. by</term>
     <term name="narrator" form="verb-short">narr. by</term>
     <term name="organizer" form="verb-short">org. by</term>
     <term name="performer" form="verb-short">perf. by</term>
     <term name="producer" form="verb-short">prod. by</term>
     <term name="script-writer" form="verb-short">writ. by</term>
-    <term name="series-creator" form="verb-short">cre. by</term>
-    <term name="director" form="verb-short">dir. by</term>
-    <term name="editor" form="verb-short">ed. by</term>
-    <term name="editorial-director" form="verb-short">ed. by</term>
-    <term name="illustrator" form="verb-short">illus. by</term>
+    <term name="series-creator" form="verb-short">ser. creat. by</term>
     <term name="translator" form="verb-short">trans. by</term>
-    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
 
     <!-- LONG MONTH FORMS -->
     <term name="month-01">January</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -433,10 +433,7 @@
       <single>v.</single>
       <multiple>vv.</multiple>
     </term>
-    <term name="version" form="short">
-      <single>v.</single>
-      <multiple>v.</multiple> <!-- no plural -->
-    </term>
+    <term name="version" form="short">v.</term> <!-- no plural -->
     <term name="volume" form="short">
       <single>vol.</single>
       <multiple>vols</multiple>
@@ -665,10 +662,7 @@
       <single>exec. prod.</single>
       <multiple>exec. prods</multiple>
     </term>
-    <term name="illustrator" form="short">
-      <single>illus.</single>
-      <multiple>illus.</multiple> <!-- no plural -->
-    </term>
+    <term name="illustrator" form="short">illus.</term> <!-- no plural -->
     <term name="narrator" form="short">
       <single>narr.</single>
       <multiple>narrs</multiple>
@@ -681,10 +675,7 @@
       <single>prod.</single>
       <multiple>prods</multiple>
     </term>
-    <term name="translator" form="short">
-      <single>trans.</single>
-      <multiple>trans.</multiple> <!-- no plural -->
-    </term>
+    <term name="translator" form="short">trans.</term> <!-- no plural -->
 
     <!-- VERB ROLE FORMS -->
     <term name="chair" form="verb">chaired by</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -45,6 +45,7 @@
     <term name="film">film</term>
     <term name="forthcoming">forthcoming</term>
     <term name="from">from</term>
+    <term name="from" form="short">fr.</term>
     <term name="henceforth">henceforth</term>
     <term name="ibid">ibid.</term>
     <term name="in">in</term>
@@ -57,12 +58,14 @@
     <term name="no-place">no place</term>
     <term name="no-place" form="short">n.p.</term>
     <term name="no-publisher">no publisher</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">n.p.</term>
     <term name="on">on</term>
     <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
     <term name="original-work-published" form="short">orig. pub.</term>
     <term name="personal-communication">personal communication</term>
+    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
@@ -146,6 +149,7 @@
     <term name="classic">class. wk</term>
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
+    <term name="interview" form="short">interv.</term>
     <term name="manuscript" form="short">MS</term>
     <term name="motion_picture" form="short">video rec.</term>
     <term name="report" form="short">rep.</term>
@@ -411,7 +415,7 @@
     </term>
     <term name="title-locator" form="short">
       <single>tit.</single>
-      <multiple>titt.</multiple> <!-- source unknown for plural -->
+      <multiple>titt.</multiple>
     </term>
     <term name="verse" form="short">
       <single>v.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -345,8 +345,8 @@
       <multiple>locs</multiple>
     </term>
     <term name="equation" form="short">
-      <single>eq.</single>
-      <multiple>eqs</multiple>
+      <single>eqn</single>
+      <multiple>eqns</multiple>
     </term>
     <term name="figure" form="short">
       <single>fig.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -330,7 +330,7 @@
     </term>
     <term name="canon" form="short">
       <single>can.</single>
-      <multiple>cans</multiple>
+      <multiple>cann.</multiple>
     </term>
     <term name="chapter" form="short">
       <single>ch.</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-GB">
+  <!-- The abbreviations in this file follow the New Oxford Dictionary for Writers and Editors, 2nd edn (2014), unless stated otherwise (cited hereafter as NODWE). This work is also available as part of the New Oxford Style Manual, 3rd edn (2016). -->
+  <!-- Additional abbreviations are from:
+        1. Oxford Dictionary for Writers and Editors (2000), https://archive.org/details/oxfordstylemanua0000unse (cited hereafter as ODWE). NODWE is an abridged version of ODWE, meaning that the earlier edition still provides useful recommendations in some specialized fields, especially law. Periods must be removed from contractions to reflect current British English usage (a convention that the dictionary adopted with NODWE in 2005).
+        2. Oxford Dictionary of Abbreviations (2011), https://doi.org/10.1093/acref/9780199698295.001.0001 (cited hereafter as ODA).
+        3. The Chicago Manual of Style, 18th ed. (2024), sec. 10.48, https://www.chicagomanualofstyle.org (cited hereafter as CMOS), the foundational source for the en-US CSL locale.
+  -->
   <info>
-    <!-- This file follows the New Oxford Dictionary for Writers and Editors, 2nd edn (Oxford, 2014). The edition of this work from 2000 is available via <https://archive.org/details/isbn_0199690944> or <https://archive.org/details/oxfordstylemanua0000unse>, still a useful resource for more obscure abbreviations. This dictionary adopted the British English convention of rendering contractions without full stops in 2005: the earlier edition needs to be adapted for this. -->
     <translator>
       <name>Andrew Dunning</name>
       <uri>https://orcid.org/0000-0003-0464-5036</uri>
@@ -15,7 +20,7 @@
       <uri>https://orcid.org/0000-0003-1779-8883</uri>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2025-06-23T00:00:00+00:00</updated>
+    <updated>2025-06-24T00:00:00+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -29,26 +34,23 @@
     <date-part name="year"/>
   </date>
   <terms>
-    <!-- GENERAL TERMS -->
+    <!-- LONG GENERAL TERMS -->
     <term name="accessed">accessed</term>
     <term name="advance-online-publication">advance online publication</term>
     <term name="album">album</term>
     <term name="and">and</term>
     <term name="and others">and others</term>
     <term name="anonymous">anonymous</term>
-    <term name="anonymous" form="short">anon.</term>
     <term name="at">at</term>
     <term name="audio-recording">audio recording</term>
     <term name="available at">available at</term>
     <term name="by">by</term>
     <term name="circa">circa</term>
-    <term name="circa" form="short">c.</term> <!-- should be italicized -->
     <term name="cited">cited</term>
     <term name="et-al">et al.</term>
     <term name="film">film</term>
     <term name="forthcoming">forthcoming</term>
     <term name="from">from</term>
-    <term name="from" form="short">fr.</term>
     <term name="henceforth">henceforth</term>
     <term name="ibid">ibid.</term>
     <term name="in">in</term>
@@ -57,18 +59,13 @@
     <term name="letter">letter</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="no date">no date</term>
-    <term name="no date" form="short">n.d.</term>
     <term name="no-place">no place</term>
-    <term name="no-place" form="short">n.p.</term>
-    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
-    <term name="no-publisher" form="short">n.p.</term>
+    <term name="no-publisher">no publisher</term>
     <term name="on">on</term>
     <term name="online">online</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="original-work-published" form="short">orig. pub.</term>
     <term name="personal-communication">personal communication</term>
-    <term name="personal-communication" form="short">pers. comm.</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
@@ -80,13 +77,8 @@
       <single>reference</single>
       <multiple>references</multiple>
     </term>
-    <term name="reference" form="short">
-      <single>ref.</single>
-      <multiple>refs</multiple>
-    </term>
     <term name="retrieved">retrieved</term>
     <term name="review-of">review of</term>
-    <term name="review-of" form="short">rev. of</term>
     <term name="scale">scale</term>
     <term name="special-issue">special issue</term>
     <term name="special-section">special section</term>
@@ -95,6 +87,46 @@
     <term name="television-series-episode">television series episode</term>
     <term name="video">video</term>
     <term name="working-paper">working paper</term>
+
+    <!-- SHORT GENERAL TERMS -->
+    <!-- Omitted short forms: accessed, album, and (symbol), and others, at (symbol), forthcoming, henceforth, ibid, in, in press, internet, loc-cit, on, online, op-cit, podcast, preprint, presented at -->
+    <term name="advance-online-publication" form="short">adv. online pub.</term> <!-- ODA -->
+    <term name="anonymous" form="short">anon.</term>
+    <term name="audio-recording" form="short">au. rec.</term> <!-- ODA -->
+    <term name="available at" form="short">avail. at</term> <!-- ODA -->
+    <term name="circa" form="short">c.</term>
+    <term name="cited" form="short">cit.</term> <!-- ODA -->
+    <term name="et-al" form="short">et al.</term>
+    <term name="film" form="short">flm</term> <!-- ODA -->
+    <term name="from" form="short">fr.</term>
+    <term name="letter" form="short">let.</term> <!-- ODA -->
+    <term name="no date" form="short">n.d.</term>
+    <term name="no-place" form="short">n.p.</term>
+    <term name="no-publisher" form="short">n.p.</term>
+    <term name="original-work-published" form="short">orig. pub.</term> <!-- Oxford Guide to Style -->
+    <term name="personal-communication" form="short">pers. comm.</term>
+    <term name="podcast-episode" form="short">podcast ep.</term>
+    <term name="radio-broadcast" form="short">radio bdcst</term> <!-- ODA -->
+    <term name="radio-series" form="short">radio ser.</term> <!-- ODA -->
+    <term name="radio-series-episode" form="short">radio ser. ep.</term> <!-- ODA -->
+    <term name="reference" form="short">
+      <single>ref.</single>
+      <multiple>refs</multiple>
+    </term>
+    <term name="retrieved" form="short">rtvd</term> <!-- ODA -->
+    <term name="review-of" form="short">rev. of</term>
+    <term name="scale" form="short">sc.</term> <!-- ODA -->
+    <term name="special-issue" form="short">spec. iss.</term> <!-- ODA -->
+    <term name="special-section" form="short">spec. sec.</term> <!-- ODA/CMOS -->
+    <term name="television-broadcast" form="short">TV bdcst</term> <!-- ODA -->
+    <term name="television-series" form="short">TV ser.</term> <!-- ODA -->
+    <term name="television-series-episode" form="short">TV ser. ep.</term> <!-- ODA -->
+    <term name="video" form="short">vid.</term> <!-- ODA -->
+    <term name="working-paper" form="short">wkg paper</term> <!-- ODA -->
+
+    <!-- SYMBOLIC GENERAL FORMS -->
+    <term name="and" form="symbol">&amp;</term>
+    <term name="at" form="symbol">@</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">preprint</term>
@@ -107,7 +139,7 @@
     <!-- chapter is in the list of locator terms -->
     <term name="classic">classical work</term>
     <term name="collection">archival collection</term>
-    <term name="dataset">dataset</term>
+    <term name="dataset">data set</term>
     <term name="document">document</term>
     <term name="entry">entry</term>
     <term name="entry-dictionary">dictionary entry</term>
@@ -141,42 +173,58 @@
     <term name="standard">standard</term>
     <term name="thesis">thesis</term>
     <term name="treaty">treaty</term>
-    <term name="webpage">webpage</term>
+    <term name="webpage">web page</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <!-- Omitted short forms: article, bill, broadcast, entry, event, graphic, hearing, legal_case, legislation, map, performance, periodical, regulation, software, speech, standard, thesis, treaty, webpage -->
-    <term name="article-journal" form="short">jour. art.</term>
-    <term name="article-magazine" form="short">mag. art.</term>
+    <!-- Omitted short forms: article, bill, entry, event, hearing, map, periodical, speech, treaty -->
+    <term name="article-journal" form="short">jour. art.</term> <!-- ODWE -->
+    <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
     <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="broadcast" form="short">bdcst</term> <!-- ODA -->
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="classic" form="short">class. wk</term>
-    <term name="collection" form="short">archival coll.</term>
+    <term name="classic" form="short">class. wk</term> <!-- ODWE -->
+    <term name="collection" form="short">arch. coll.</term> <!-- ODA -->
     <term name="document" form="short">doc.</term>
     <term name="entry-dictionary" form="short">dict. entry</term>
     <term name="entry-encyclopedia" form="short">ency. entry</term>
     <!-- figure is in the list of locator terms -->
-    <term name="interview" form="short">intvw</term> <!-- Free Dictionary -->
+    <term name="graphic" form="short">gr.</term> <!-- ODA -->
+    <term name="interview" form="short">int.</term> <!-- ODA -->
+    <term name="legal_case" form="short">leg. case</term> <!-- ODA -->
+    <term name="legislation" form="short">legis.</term> <!-- ODA -->
     <term name="manuscript" form="short">
       <single>MS</single>
       <multiple>MSS</multiple>
     </term>
-    <term name="motion_picture" form="short">video rec.</term>
-    <term name="musical_score" form="short">mus. score</term>
-    <term name="pamphlet" form="short">pam.</term>
-    <term name="paper-conference" form="short">conf. paper</term>
-    <term name="patent" form="short">pat.</term>
+    <term name="motion_picture" form="short">vid. rec.</term> <!-- ODA -->
+    <term name="musical_score" form="short">mus. score</term> <!-- ODWE -->
+    <term name="pamphlet" form="short">pam.</term> <!-- ODWE -->
+    <term name="paper-conference" form="short">conf. paper</term> <!-- ODA -->
+    <term name="patent" form="short">pat.</term> <!-- ODWE -->
+    <term name="performance" form="short">prfm.</term> <!-- ODA -->
     <term name="personal_communication" form="short">pers. comm.</term>
-    <term name="report" form="short">rep.</term>
+    <term name="regulation" form="short">reg.</term> <!-- ODA -->
+    <term name="report" form="short">rep.</term> <!-- ODWE -->
     <term name="review" form="short">rev.</term>
     <term name="review-book" form="short">bk rev.</term>
-    <term name="song" form="short">audio rec.</term>
+    <term name="software" form="short">sftw.</term> <!-- ODA -->
+    <term name="song" form="short">au. rec.</term> <!-- ODA -->
+    <term name="standard" form="short">std</term> <!-- ODA -->
+    <term name="thesis" form="short">thes.</term> <!-- ODA -->
+    <term name="webpage" form="short">web pg.</term> <!-- ODA -->
 
-    <!-- VERB ITEM TYPE FORMS -->
+    <!-- LONG VERB ITEM TYPE FORMS -->
     <!-- Only where applicable -->
     <term name="hearing" form="verb">testimony of</term>
     <term name="review" form="verb">review of</term>
     <term name="review-book" form="verb">review of the book</term>
+
+    <!-- SHORT VERB ITEM TYPE FORMS -->
+    <!-- Only where applicable -->
+    <term name="hearing" form="verb-short">test. of</term> <!-- ODA -->
+    <term name="review" form="verb-short">rev. of</term>
+    <term name="review-book" form="verb-short">rev. of the bk</term>
 
     <!-- HISTORICAL ERA TERMS -->
     <term name="ad">AD</term>
@@ -346,6 +394,7 @@
       <multiple>bks</multiple>
     </term>
     <term name="canon" form="short">
+      <!-- Oxford Dictionary for Writers and Editors -->
       <single>can.</single>
       <multiple>cann.</multiple>
     </term>
@@ -362,7 +411,6 @@
       <multiple>locs</multiple>
     </term>
     <term name="equation" form="short">
-      <!-- from Chicago Manual of Style -->
       <single>eq.</single>
       <multiple>eqq.</multiple>
     </term>
@@ -403,6 +451,7 @@
       <multiple>pts</multiple>
     </term>
     <term name="rule" form="short">
+      <!-- legal abbreviations in the Oxford Guide to Style, sec. 13.2.1 -->
       <single>r.</single>
       <multiple>rr.</multiple>
     </term>
@@ -423,10 +472,12 @@
       <multiple>suppls</multiple>
     </term>
     <term name="table" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>tbl.</single>
       <multiple>tbls</multiple>
     </term>
     <term name="title-locator" form="short">
+      <!-- Oxford Dictionary for Writers and Editors -->
       <single>tit.</single>
       <multiple>titt.</multiple>
     </term>
@@ -440,7 +491,7 @@
       <multiple>vols</multiple>
     </term>
 
-    <!-- SYMBOL LOCATOR FORMS -->
+    <!-- SYMBOLIC LOCATOR FORMS -->
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>
@@ -636,12 +687,12 @@
       <multiple>comps</multiple>
     </term>
     <term name="contributor" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>contrib.</single>
       <multiple>contribs</multiple>
     </term>
     <term name="curator" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Art Online <https://www.oxfordartonline.com/page/1661> -->
       <single>cur.</single>
       <multiple>curs</multiple>
     </term>
@@ -666,40 +717,39 @@
       <multiple>eds</multiple>
     </term>
     <term name="executive-producer" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>exec. prod.</single>
       <multiple>exec. prods</multiple>
     </term>
     <term name="illustrator" form="short">illus.</term> <!-- no plural -->
     <term name="narrator" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>narr.</single>
       <multiple>narrs</multiple>
     </term>
     <term name="organizer" form="short">
-      <!-- source unknown -->
+      <!-- possibly misleading: Oxford Dictionary of Abbreviations only defines this as organization or organized -->
       <single>org.</single>
       <multiple>orgs</multiple>
     </term>
     <term name="performer" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>perf.</single>
       <multiple>perfs</multiple>
     </term>
     <term name="producer" form="short">
-      <!-- source unknown -->
+      <!-- Oxford Dictionary of Abbreviations -->
       <single>prod.</single>
       <multiple>prods</multiple>
     </term>
     <term name="script-writer" form="short">
-      <!-- source unknown -->
-      <single>writ.</single>
-      <multiple>writs</multiple>
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>wrtr</single>
+      <multiple>wrtrs</multiple>
     </term>
     <term name="series-creator" form="short">
-      <!-- source unknown -->
-      <single>cre.</single>
-      <multiple>cres</multiple>
+      <single>ser. creator</single>
+      <multiple>ser. creators</multiple>
     </term>
     <term name="translator" form="short">trans.</term> <!-- no plural -->
 
@@ -721,7 +771,7 @@
     <term name="host" form="verb">hosted by</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">interview by</term>
-    <term name="narrator" form="verb">narrated by</term>
+    <term name="narrator" form="verb">read by</term> <!-- verb role form in Oxford Style Manual, MHRA -->
     <term name="organizer" form="verb">organized by</term>
     <term name="original-author" form="verb">by</term>
     <term name="performer" form="verb">performed by</term>
@@ -734,25 +784,23 @@
 
     <!-- SHORT VERB ROLE FORMS -->
     <!-- Omitted roles:
-         author, chair, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author
+         author, chair, container-author, contributor, guest, host, interviewer, narrator, original-author, recipient, reviewed-author, series-creator
     -->
     <term name="collection-editor" form="verb-short">ed. by</term>
     <term name="compiler" form="verb-short">comp. by</term>
-    <term name="composer" form="verb-short">comp. by</term>
-    <term name="curator" form="verb-short">cur. by</term> <!-- source unknown -->
+    <term name="composer" form="verb-short">comp. by</term> <!-- ODWE -->
+    <term name="curator" form="verb-short">cur. by</term> <!-- Oxford Art Online -->
     <term name="director" form="verb-short">dir. by</term>
     <term name="editor" form="verb-short">ed. by</term>
     <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
     <term name="editorial-director" form="verb-short">ed. by</term>
-    <term name="executive-producer" form="verb-short">exec. prod. by</term>
+    <term name="executive-producer" form="verb-short">exec. prod. by</term> <!-- ODA -->
     <term name="illustrator" form="verb-short">illus. by</term>
-    <term name="narrator" form="verb-short">narr. by</term> <!-- source unknown -->
-    <term name="organizer" form="verb-short">org. by</term> <!-- source unknown -->
-    <term name="performer" form="verb-short">perf. by</term> <!-- source unknown -->
-    <term name="producer" form="verb-short">prod. by</term> <!-- source unknown -->
-    <term name="script-writer" form="verb-short">writ. by</term> <!-- source unknown -->
-    <term name="series-creator" form="verb-short">cre. by</term> <!-- source unknown -->
+    <term name="organizer" form="verb-short">org. by</term> <!-- ODA -->
+    <term name="performer" form="verb-short">perfd by</term> <!-- ODA -->
+    <term name="producer" form="verb-short">prod. by</term> <!-- ODA -->
+    <term name="script-writer" form="verb-short">writ. by</term> <!-- ODA -->
     <term name="translator" form="verb-short">trans. by</term>
 
     <!-- LONG MONTH FORMS -->
@@ -770,7 +818,7 @@
     <term name="month-12">December</term>
 
     <!-- SHORT MONTH FORMS -->
-    <!-- New Hart's Rules, 2nd edn, 10.2.6 (identical to Chicago Manual of Style, 18th edn, 10.44) -->
+    <!-- New Hart's Rules, 2nd ed., sec. 10.2.6 summarizes NODWE recommendations; identical to CMOS 10.44 -->
     <term name="month-01" form="short">Jan.</term>
     <term name="month-02" form="short">Feb.</term>
     <term name="month-03" form="short">Mar.</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -144,6 +144,7 @@
     <term name="webpage">webpage</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
+    <!-- Omitted short forms: article, bill, broadcast, entry, event, graphic, hearing, legal_case, legislation, map, performance, periodical, regulation, software, speech, standard, thesis, treaty, webpage -->
     <term name="article-journal" form="short">jour. art.</term>
     <term name="article-magazine" form="short">mag. art.</term>
     <term name="article-newspaper" form="short">newspaper art.</term>
@@ -769,6 +770,7 @@
     <term name="month-12">December</term>
 
     <!-- SHORT MONTH FORMS -->
+    <!-- New Hart's Rules, 2nd edn, 10.2.6 (identical to Chicago Manual of Style, 18th edn, 10.44) -->
     <term name="month-01" form="short">Jan.</term>
     <term name="month-02" form="short">Feb.</term>
     <term name="month-03" form="short">Mar.</term>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -260,8 +260,8 @@
       <multiple>folios</multiple>
     </term>
     <term name="issue">
-      <single>number</single>
-      <multiple>numbers</multiple>
+      <single>issue</single>
+      <multiple>issues</multiple>
     </term>
     <term name="line">
       <single>line</single>

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -143,7 +143,7 @@
     <term name="article-newspaper" form="short">newspaper art.</term>
     <!-- book is in the list of locator terms -->
     <!-- chapter is in the list of locator terms -->
-    <term name="classic">class. wk.</term>
+    <term name="classic">class. wk</term>
     <term name="document" form="short">doc.</term>
     <!-- figure is in the list of locator terms -->
     <term name="manuscript" form="short">MS</term>


### PR DESCRIPTION
- Synchronize the British English localization with the expanded `locales-en-US.xml` in #343.
- Update abbreviations using the latest edition of the *New Oxford Dictionary for Writers and Editors* (2014); with reference also to the earlier *Oxford Dictionary for Writers and Editors* (2000), available at <https://archive.org/details/isbn_0199690944>; and the MHRA Style Guide, <https://www.mhra.org.uk/style/>.
- Consistently render contractions without a full stop.