### PR TITLE
Update locales-pl-PL.xml

### DIFF
--- a/locales-pl-PL.xml
+++ b/locales-pl-PL.xml
@@ -35,13 +35,13 @@
     <term name="henceforth">henceforth</term>
     <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="no-place">brak miejsca wydania</term>
-    <term name="no-place" form="short">b.m.w.</term>
+    <term name="no-place" form="short">b.m.</term>
     <term name="no-publisher">brak wydawcy</term> <!-- sine nomine -->
     <term name="no-publisher" form="short">b.w.</term>
     <term name="on">on</term>
     <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
     <term name="original-work-published">original work published</term>
-    <term name="personal-communication">osobista komunikacja</term>
+    <term name="personal-communication">korespondencja prywatna</term>
     <term name="podcast">podcast</term>
     <term name="podcast-episode">podcast episode</term>
     <term name="preprint">preprint</term>
@@ -79,15 +79,15 @@
       <multiple>wydania</multiple>
     </term>
     <term name="first-reference-note-number" form="short">
-      <single>ref.</single>
-      <multiple>refs.</multiple>
+      <single>cyt.</single>
+      <multiple>cyt.</multiple>
     </term>
     <term name="number" form="short">
       <single>nr</single>
       <multiple>nr.</multiple>
     </term>
     <term name="edition" form="short">wyd.</term>
-    <term name="et-al">i in.</term>
+    <term name="et-al">et al.</term>
     <term name="forthcoming">w przygotowaniu</term>
     <term name="from">z</term>
     <term name="ibid">ibid.</term>
@@ -107,8 +107,8 @@
       <single>ref.</single>
       <multiple>ref.</multiple>
     </term>
-    <term name="review-of">review of</term>
-    <term name="review-of" form="short">rev. of</term>
+    <term name="review-of">recenzja</term>
+    <term name="review-of" form="short">rec.</term>
     <term name="retrieved">pobrano</term>
     <term name="scale">skala</term>
     <term name="version">wersja</term>


### PR DESCRIPTION
Added translations of:
- first-reference-note-number,
- review-of,

Proposed better translations of:
- personal-communication (komunikacja is more an act of speech, while korespondencja is an object that can be cited).
- no-place (see: "https://www.jezykowedylematy.pl/2023/08/bibliografia-co-zrobic-gdy-brakuje-roku-lub-miejsca-wydania/". This is a fix of my previous commit #351, turns out this last letter is not really used).

Now the most serious one. I would like to propose changing et-al from Polish "i in." back to Latin "et al.". While both Polish and Latin terms are used, from my experience, many publishers require using them consistently. Currently, both ibid and op-cit are in Latin, and only et-al is in Polish. We could either:
- Change all 3 of them to Polish, which would be extreme,
- Change et-al to Latin for consistency, considering Latin the norm, despite locale being Polish (proposed),
- Leave as is, which would be inconsistent.

See: 
- "https://fil.ug.edu.pl/sites/default/files/_nodes/strona-filologiczny/71884/files/kult._prace_standardy_redakcyjne_2.pdf" - page 3,
- "https://wydawnictwo.uwb.edu.pl/wymogi-edytorskie",
- "https://maska.psc.uj.edu.pl/documents/40768330/0/zalecenia+edytorskie.pdf/32ec2a26-8751-451e-8e2a-3d741710a2d3",
- "https://etnologia.amu.edu.pl/wp-content/uploads/2018/04/bibliografia-i-przypisy_zasady.pdf")