### PR TITLE
en: Add single-character `chapter` locator form; fix `version` category

### DIFF
--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -370,10 +370,6 @@
       <single>verse</single>
       <multiple>verses</multiple>
     </term>
-    <term name="version">
-      <single>version</single>
-      <multiple>versions</multiple>
-    </term>
     <term name="volume">
       <single>volume</single>
       <multiple>volumes</multiple>
@@ -485,7 +481,6 @@
       <single>v.</single>
       <multiple>vv.</multiple>
     </term>
-    <term name="version" form="short">v.</term> <!-- no plural -->
     <term name="volume" form="short">
       <single>vol.</single>
       <multiple>vols</multiple>
@@ -542,6 +537,10 @@
       <single>printing</single>
       <multiple>printings</multiple>
     </term>
+    <term name="version">
+      <single>version</single>
+      <multiple>versions</multiple>
+    </term>
 
     <!-- SHORT NUMBER VARIABLE FORMS -->
     <term name="chapter-number" form="short">
@@ -584,6 +583,7 @@
       <single>ptg</single>
       <multiple>ptgs</multiple>
     </term>
+    <term name="version" form="short">v.</term> <!-- no plural -->
 
     <!-- LONG ROLE FORMS -->
     <!-- Omitted roles:

--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -487,6 +487,11 @@
     </term>
 
     <!-- SYMBOLIC LOCATOR FORMS -->
+    <term name="chapter" form="symbol">
+      <!-- caput/capita, esp. in legal works -->
+      <single>c.</single>
+      <multiple>cc.</multiple>
+    </term>
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -494,6 +494,11 @@
     </term>
 
     <!-- SYMBOLIC LOCATOR FORMS -->
+    <term name="chapter" form="symbol">
+      <!-- caput/capita, esp. in legal works; cf. CMOS 14.196 -->
+      <single>c.</single>
+      <multiple>cc.</multiple>
+    </term>
     <term name="paragraph" form="symbol">
       <single>¶</single>
       <multiple>¶¶</multiple>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -377,10 +377,6 @@
       <single>verse</single>
       <multiple>verses</multiple>
     </term>
-    <term name="version">
-      <single>version</single>
-      <multiple>versions</multiple>
-    </term>
     <term name="volume">
       <single>volume</single>
       <multiple>volumes</multiple>
@@ -492,7 +488,6 @@
       <single>v.</single>
       <multiple>vv.</multiple>
     </term>
-    <term name="version" form="short">v.</term> <!-- no plural -->
     <term name="volume" form="short">
       <single>vol.</single>
       <multiple>vols.</multiple>
@@ -549,6 +544,10 @@
       <single>printing</single>
       <multiple>printings</multiple>
     </term>
+    <term name="version">
+      <single>version</single>
+      <multiple>versions</multiple>
+    </term>
 
     <!-- SHORT NUMBER VARIABLE FORMS -->
     <term name="chapter-number" form="short">
@@ -592,6 +591,7 @@
       <single>ptg.</single>
       <multiple>ptgs.</multiple>
     </term>
+    <term name="version" form="short">v.</term> <!-- no plural -->
 
     <!-- LONG ROLE FORMS -->
     <!-- Omitted roles:


### PR DESCRIPTION
- Add an alternative single-character `chapter` locator as a `symbol`, used in legal contexts; see _Chicago Manual of Style_, sec. 14.196.
- Categorize the `version` term as a number rather than a locator variable.