### PR TITLE
en: Fix ungrammatical 'with guest' as a verb

### DIFF
--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -772,7 +772,7 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
     <term name="editorial-director" form="verb">edited by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
-    <term name="guest" form="verb">with guest</term>
+    <term name="guest" form="verb">with</term>
     <term name="host" form="verb">hosted by</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">interview by</term>

--- a/locales-en-US.xml
+++ b/locales-en-US.xml
@@ -783,7 +783,7 @@
     <term name="editortranslator" form="verb">edited &amp; translated by</term>
     <term name="editorial-director" form="verb">edited by</term>
     <term name="executive-producer" form="verb">executive produced by</term>
-    <term name="guest" form="verb">with guest</term>
+    <term name="guest" form="verb">with</term>
     <term name="host" form="verb">hosted by</term>
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">interview by</term>


### PR DESCRIPTION
Since 'with guest' is not a verb, rendering the verbal form simply as 'with' ensures grammatical results with an item including more than one `guest`. I cannot find the source for the phrase 'with guest' (it does not occur in any of APA, Chicago, MHRA, MLA, or New Hart's Rules); 'with' is a safer default.