### PR TITLE
Fix wrong entry for gl in locales.json

### DIFF
--- a/locales.json
+++ b/locales.json
@@ -18,7 +18,7 @@
         "fa":  "fa-IR",
         "fi":  "fi-FI",
         "fr":  "fr-FR",
-        "gl":  "gl-GL",
+        "gl":  "gl-ES",
         "he":  "he-IL",
         "hi":  "hi-IN",
         "hr":  "hr-HR",


### PR DESCRIPTION
There is no "gl-GL", it should be "gl-ES"