### PR TITLE
Update locales-sl-SI.xml

### DIFF
--- a/locales-sl-SI.xml
+++ b/locales-sl-SI.xml
@@ -7,6 +7,9 @@
     <translator>
       <name>ratek1</name>
     </translator>
+    <translator>
+      <name>Uroš Mikanovič</name>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2014-11-06T09:41:02+00:00</updated>
   </info>
@@ -184,10 +187,10 @@
     <term name="ce">CE</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">„</term>
-    <term name="close-quote">“</term>
-    <term name="open-inner-quote">‚</term>
-    <term name="close-inner-quote">‘</term>
+    <term name="open-quote">»</term>
+    <term name="close-quote">«</term>
+    <term name="open-inner-quote">„</term>
+    <term name="close-inner-quote">“</term>
     <term name="page-range-delimiter">–</term>
     <term name="colon">:</term>
     <term name="comma">,</term>


### PR DESCRIPTION
Fix quotes to conform to the suggested symbols in the Slovenian orthography reference (Pravopis).

### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
