### PR TITLE
Update `cs-CZ` and `lv-LV` locales with smart quotes

### DIFF
--- a/locales-cs-CZ.xml
+++ b/locales-cs-CZ.xml
@@ -6,6 +6,7 @@
     </translator>
     <translator>
       <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
     </translator>
     <translator>
       <name>libora</name>
@@ -14,7 +15,7 @@
       <name>Michal Hoftich</name>
     </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2025-10-16T03:08:07+00:00</updated>
+    <updated>2026-01-10T00:00:07+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -177,9 +178,9 @@
 
     <!-- PUNCTUATION -->
     <term name="open-quote">„</term>
-    <term name="close-quote">"</term>
+    <term name="close-quote">“</term>
     <term name="open-inner-quote">‚</term>
-    <term name="close-inner-quote">´</term>
+    <term name="close-inner-quote">‘</term>
     <term name="page-range-delimiter">–</term>
     <term name="colon">:</term>
     <term name="comma">,</term>

--- a/locales-lv-LV.xml
+++ b/locales-lv-LV.xml
@@ -7,8 +7,12 @@
     <translator>
       <name>Kristiāns Francis Cagulis</name>
     </translator>
+    <translator>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2025-10-16T03:24:00+00:00</updated>
+    <updated>2026-01-10T00:00:00+00:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text" delimiter=" ">
@@ -171,10 +175,10 @@
     <term name="ce">m.ē.</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">"</term>
-    <term name="close-quote">"</term>
-    <term name="open-inner-quote">"</term>
-    <term name="close-inner-quote">"</term>
+    <term name="open-quote">“</term>
+    <term name="close-quote">”</term>
+    <term name="open-inner-quote">“</term>
+    <term name="close-inner-quote">”</term>
     <term name="page-range-delimiter">–</term>
     <term name="colon">:</term>
     <term name="comma">,</term>


### PR DESCRIPTION
Updated quotes to use correct typographic marks for `cs-CZ` and `lv-LV`, following <https://op.europa.eu/en/web/eu-vocabularies/formex/physical-specifications/character-encoding/use-of-quotation-marks-in-the-different-languages>.

### Checklist

- [X] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
- [X] Check that you've updated the date under `<updated>` in the `<info>` block. Be sure to preserve the original date-time formatting (for example, `2025-09-22T22:06:38+00:00`)
- [X] If possible, please include references to dictionaries, style guides, or similar that inform your translations (see the en_US locale for examples). This helps us to keep locales up to date over time. 
