### PR TITLE
Update zh-CN terms

### DIFF
--- a/locales-zh-CN.xml
+++ b/locales-zh-CN.xml
@@ -16,11 +16,8 @@
     <translator>
       <name>韩小土</name>
     </translator>
-    <translator>
-      <name>韩敏义</name>
-    </translator>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <updated>2025-10-16T11:24:00+08:00</updated>
+    <updated>2026-01-25T15:03:03+08:00</updated>
   </info>
   <style-options punctuation-in-quote="false"/>
   <date form="text">
@@ -28,44 +25,44 @@
     <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
     <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
   </date>
-  <date form="numeric">
+  <date form="numeric"> <!-- GB/T 7408.1, ISO 8601 -->
     <date-part name="year" range-delimiter="/"/>
     <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
     <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
   </date>
   <terms>
     <!-- LONG GENERAL TERMS -->
-    <term name="accessed">见于</term>
-    <term name="advance-online-publication">网络首发</term>
+    <term name="accessed">访问</term> <!-- 法学引注手册 -->
+    <term name="advance-online-publication">在线出版</term> <!-- GB/T 7714 -->
     <term name="album">专辑</term>
     <term name="and">和</term>
-    <term name="and others">及其他</term>
-    <term name="anonymous">作者不详</term>
-    <term name="at">于</term>
+    <term name="and others">等人</term> <!-- 心理学报 -->
+    <term name="anonymous">佚名</term> <!-- GB/T 7714 -->
+    <term name="at">于</term> <!-- 法学引注手册 -->
     <term name="audio-recording">录音</term>
-    <term name="available at">载于</term>
+    <term name="available at">获取于</term>
     <term name="by">著</term>
-    <term name="circa">介于</term>
+    <term name="circa">约</term>
     <term name="cited">见引于</term>
     <term name="et-al">等</term>
     <term name="film">电影</term>
     <term name="forthcoming">即将出版</term>
-    <term name="from">从</term>
+    <term name="from">自</term> <!-- 心理学报 -->
     <term name="henceforth">从此以后</term>
-    <term name="ibid">同上</term>
-    <term name="in">收入</term>
-    <term name="in press">送印中</term>
-    <term name="internet">网际网络</term>
+    <term name="ibid">同上注</term> <!-- 法学引注手册 -->
+    <term name="in">载</term> <!-- 法学引注手册 -->
+    <term name="in press">印刷中</term> <!-- 心理学报 -->
+    <term name="internet">互联网</term>
     <term name="letter">信函</term>
-    <term name="loc-cit">同前注</term>
-    <term name="no date">日期不详</term>
-    <term name="no-place">出版地不详</term>
-    <term name="no-publisher">出版者不详</term> <!-- sine nomine -->
+    <term name="loc-cit">同前引处</term>
+    <term name="no date">出版时间不详</term> <!-- 中国社会科学  -->
+    <term name="no-place">出版地不详</term> <!-- GB/T 7714 -->
+    <term name="no-publisher">出版者不详</term> <!-- GB/T 7714 -->
     <term name="on">在</term>
     <term name="online">在线</term>
-    <term name="op-cit">同前注</term>
+    <term name="op-cit">同前引</term>
     <term name="original-work-published">原著出版于</term>
-    <term name="personal-communication">的私人交流</term>
+    <term name="personal-communication">私人通讯</term> <!-- 法学引注手册 -->
     <term name="podcast">播客</term>
     <term name="podcast-episode">播客集</term>
     <term name="preprint">预印本</term>
@@ -73,8 +70,8 @@
     <term name="radio-broadcast">电台广播</term>
     <term name="radio-series">广播剧</term>
     <term name="radio-series-episode">广播剧集</term>
-    <term name="reference">参考</term>
-    <term name="retrieved">取读于</term>
+    <term name="reference">文献</term>
+    <term name="retrieved">取</term> <!-- 心理学报 -->
     <term name="review-of">评论</term>
     <term name="scale">比例</term>
     <term name="special-issue">特刊</term>
@@ -86,15 +83,11 @@
     <term name="working-paper">工作论文</term>
 
     <!-- SHORT GENERAL TERMS -->
-    <term name="anonymous" form="short">无名氏</term>
-    <term name="circa" form="short">约</term>
-    <term name="no date" form="short">不详</term>
-    <term name="no-place" form="short">出版地不详</term>
-    <term name="no-publisher" form="short">出版者不详</term>
-    <term name="reference" form="short">参</term>
-    <term name="review-of" form="short">评</term>
+    <term name="no date" form="short">无日期</term> <!-- 心理学报 -->
 
     <!-- SYMBOLIC GENERAL FORMS -->
+    <term name="and" form="symbol">&amp;</term>
+    <term name="at" form="symbol">@</term>
 
     <!-- LONG ITEM TYPE FORMS -->
     <term name="article">预印本</term>
@@ -116,21 +109,21 @@
     <!-- figure is in the list of locator terms -->
     <term name="graphic">视觉作品</term>
     <term name="hearing">听证会</term>
-    <term name="interview">访谈</term>
+    <term name="interview">访谈</term>  <!-- 法学引注手册 -->
     <term name="legal_case">司法案例</term>
     <term name="legislation">法律</term>
     <term name="manuscript">手稿</term>
     <term name="map">地图</term>
-    <term name="motion_picture">录像</term>
+    <term name="motion_picture">视频</term>
     <term name="musical_score">乐谱</term>
     <term name="pamphlet">小册子</term>
     <term name="paper-conference">会议论文</term>
     <term name="patent">专利</term>
     <term name="performance">演出</term>
     <term name="periodical">期刊</term>
-    <term name="personal_communication">的私人交流</term>
-    <term name="post">帖子</term>
-    <term name="post-weblog">博客帖子</term>
+    <term name="personal_communication">私人通讯</term>  <!-- 法学引注手册 -->
+    <term name="post">帖文</term>
+    <term name="post-weblog">博客帖文</term>
     <term name="regulation">法规</term>
     <term name="report">报告</term>
     <term name="review">评论</term>
@@ -144,42 +137,28 @@
     <term name="webpage">网页</term>
 
     <!-- SHORT ITEM TYPE FORMS -->
-    <term name="article-journal" form="short">期刊文章</term>
-    <term name="article-magazine" form="short">杂志文章</term>
-    <term name="article-newspaper" form="short">报纸文章</term>
-    <!-- book is in the list of locator terms -->
-    <!-- chapter is in the list of locator terms -->
-    <term name="document" form="short">文档</term>
-    <!-- figure is in the list of locator terms -->
-    <term name="graphic" form="short">视觉作品</term>
-    <term name="interview" form="short">采访</term>
-    <term name="manuscript" form="short">手稿</term>
-    <term name="motion_picture" form="short">录像</term>
-    <term name="report" form="short">报告</term>
-    <term name="review" form="short">评论</term>
-    <term name="review-book" form="short">书评</term>
-    <term name="song" form="short">录音</term>
+    <term name="article-journal" form="short">文</term> <!-- 法学引注手册 -->
 
     <!-- LONG VERB ITEM TYPE FORMS -->
-    <!-- Only where applicable -->
-    <term name="hearing" form="verb">听证会</term>
-    <term name="review" form="verb">评论</term>
-    <term name="review-book" form="verb">书评</term>
 
     <!-- SHORT VERB ITEM TYPE FORMS -->
 
     <!-- HISTORICAL ERA TERMS -->
-    <term name="ad">公元</term>
-    <term name="bc">公元前</term>
-    <term name="bce">公元前</term>
-    <term name="ce">公元</term>
+    <!-- These terms are appended to years, but the corresponding Chinese
+      translations are conventionally placed before the years.
+      Therefore, the original forms are retained.
+    -->
+    <term name="ad"> AD</term>
+    <term name="bc"> BC</term>
+    <term name="bce"> BCE</term>
+    <term name="ce"> CE</term>
 
     <!-- PUNCTUATION -->
-    <term name="open-quote">《</term>
-    <term name="close-quote">》</term>
-    <term name="open-inner-quote">〈</term>
-    <term name="close-inner-quote">〉</term>
-    <term name="page-range-delimiter">～</term>
+    <term name="open-quote">“</term>
+    <term name="close-quote">”</term>
+    <term name="open-inner-quote">‘</term>
+    <term name="close-inner-quote">’</term>
+    <term name="page-range-delimiter">&#8212;</term>
     <term name="colon">：</term>
     <term name="comma">，</term>
     <term name="semicolon">；</term>
@@ -200,68 +179,45 @@
     <term name="long-ordinal-10">十</term>
 
     <!-- LONG LOCATOR FORMS -->
-    <term name="act">幕</term>
+    <term name="act">幕</term> <!-- 用于戏剧，如“《哈姆雷特》第三幕” -->
     <term name="appendix">附录</term>
     <term name="article-locator">条</term> <!-- 用于法律，如“《公司法》第 16 条” -->
-    <term name="book">册</term>
-    <term name="canon">准则</term>
+    <term name="book">编</term> <!-- 用于法律，如《民法典》第一编翻译为“Book One” -->
+    <term name="canon">准则</term> <!-- 宗教法典的“第……条” -->
     <term name="chapter">章</term>
     <term name="column">栏</term>
-    <term name="elocation">位置</term>
+    <term name="elocation">位置号</term> <!-- 电子书的位置号 -->
     <term name="equation">公式</term>
-    <term name="figure">图表</term>
-    <term name="folio">版</term>
+    <term name="figure">图</term>
+    <term name="folio">张</term> <!-- 档案手稿的张号 -->
     <term name="issue">期</term>
     <term name="line">行</term>
-    <term name="note">注脚</term>
-    <term name="opus">作品</term>
+    <term name="note">注释</term>
+    <term name="opus">作品编号</term> <!-- 音乐的作品编号 -->
     <term name="page">页</term>
-    <term name="paragraph">段落</term>
+    <term name="paragraph">段</term>
     <term name="part">部分</term>
     <term name="rule">规则</term>
-    <term name="scene">场</term>
+    <term name="scene">场</term> <!-- 用于戏剧，如“《哈姆雷特》第三幕第一场” -->
     <term name="section">节</term>
-    <term name="sub-verbo">另见</term>
-    <term name="supplement">补充</term>
-    <term name="table">表格</term>
-    <term name="timestamp"> <!-- generally blank -->
-      <single/>
-      <multiple/>
-    </term>
+    <term name="sub-verbo">参见</term> <!-- 用于字典，“参见……词条” -->
+    <term name="supplement">补充材料</term>
+    <term name="table">表</term>
+    <!-- A timestamp is a composite of hours, minutes, etc. and therefore has no default label. -->
+    <term name="timestamp"/>
     <term name="title-locator">编</term> <!-- 用于法律，如“《美国法典》第19编” -->
-    <term name="verse">篇</term>
+    <term name="verse">节</term> <!-- 用于宗教、诗歌，“第……节” -->
     <term name="volume">卷</term>
 
     <!-- SHORT LOCATOR FORMS -->
-    <term name="appendix" form="short">附录</term>
-    <term name="article-locator" form="short">条</term>
-    <term name="book" form="short">册</term>
-    <term name="chapter" form="short">章</term>
-    <term name="column" form="short">栏</term>
     <term name="elocation" form="short">位置</term>
     <term name="equation" form="short">式</term>
-    <term name="figure" form="short">图</term>
-    <term name="folio" form="short">版</term>
-    <term name="issue" form="short">期</term>
-    <term name="line" form="short">行</term>
     <term name="note" form="short">注</term>
-    <term name="opus" form="short">op.</term>
-    <term name="page" form="short">页</term>
-    <term name="paragraph" form="short">段</term>
-    <term name="part" form="short">部</term>
-    <term name="rule" form="short">规则</term>
-    <term name="scene" form="short">场</term>
-    <term name="section" form="short">节</term>
-    <term name="sub-verbo" form="short">另见</term>
-    <term name="supplement" form="short">补充</term>
-    <term name="table" form="short">表</term>
-    <term name="timestamp" form="short"> <!-- generally blank -->
-      <single/>
-      <multiple/>
+    <term name="opus" form="short">
+      <single>op.</single>
+      <multiple>opp.</multiple>
     </term>
-    <term name="title-locator" form="short">编</term>
-    <term name="verse" form="short">篇</term>
-    <term name="volume" form="short">卷</term>
+    <term name="sub-verbo" form="short">参</term>
 
     <!-- SYMBOLIC LOCATOR FORMS -->
     <term name="paragraph" form="symbol">
@@ -277,127 +233,68 @@
     <term name="chapter-number">章</term>
     <term name="citation-number">引用</term>
     <term name="collection-number">册</term>
-    <term name="edition">版本</term>
-    <term name="first-reference-note-number">前注</term>
+    <term name="edition">版</term>
+    <term name="first-reference-note-number">前注</term> <!-- 法学引注手册 -->
     <term name="number">编号</term>
-    <term name="number-of-pages"> 总页数</term>
+    <term name="number-of-pages">页</term>
     <term name="number-of-volumes">卷</term>
     <term name="page-first">页</term>
-    <term name="printing">编号</term>
-    <term name="version">版</term>
+    <term name="printing">印次</term>
+    <term name="version">版本</term>
 
     <!-- SHORT NUMBER VARIABLE FORMS -->
-    <term name="chapter-number" form="short">章</term>
-    <term name="citation-number" form="short">引用</term>
-    <term name="collection-number" form="short">册</term>
-    <term name="edition" form="short">版</term>
-    <term name="first-reference-note-number" form="short">前注</term>
     <term name="number" form="short">
       <single>no.</single>
       <multiple>nos.</multiple>
     </term>
-    <term name="number-of-pages" form="short">共</term>
-    <term name="number-of-volumes" form="short">卷</term>
-    <term name="page-first" form="short">页</term>
-    <term name="printing" form="short">编号</term>
+    <term name="version" form="short">v.</term> <!-- GB/T 7714—2025 -->
 
     <!-- LONG ROLE FORMS -->
     <term name="author"/> <!-- generally blank -->
     <term name="chair">主席</term>
-    <term name="collection-editor">总编辑</term>
-    <term name="compiler">编撰</term>
+    <term name="collection-editor">编辑</term> <!-- 丛书编辑 -->
+    <term name="compiler">汇编</term>
     <term name="composer"/> <!-- generally blank -->
     <term name="container-author"/> <!-- generally blank -->
-    <term name="contributor">贡献者</term>
+    <term name="contributor">贡献</term>
     <term name="curator">策展人</term>
     <term name="director">导演</term>
     <term name="editor">编辑</term>
     <term name="editor-translator">编译</term>
     <term name="editortranslator">编译</term>
-    <term name="editorial-director">主编</term>
+    <term name="editorial-director">总编辑</term>
     <term name="executive-producer">监制</term>
     <term name="guest">嘉宾</term>
     <term name="host">主持</term>
     <term name="illustrator">绘图</term>
     <term name="interviewer"/> <!-- generally blank -->
-    <term name="narrator">朗读者</term>
-    <term name="organizer">组织者</term>
+    <term name="narrator">朗读</term> <!-- 有声书的朗读者 -->
+    <term name="organizer">组织</term>
     <term name="original-author"/> <!-- generally blank -->
     <term name="performer">表演</term>
     <term name="producer">制片人</term>
     <term name="recipient"/> <!-- generally blank -->
     <term name="reviewed-author"/> <!-- generally blank -->
     <term name="script-writer">编剧</term>
-    <term name="series-creator">创作</term>
+    <term name="series-creator">剧集创作人</term>
     <term name="translator">翻译</term>
 
     <!-- SHORT ROLE FORMS -->
-    <term name="compiler" form="short">编</term>
-    <term name="contributor" form="short">贡献</term>
-    <term name="curator" form="short">策展</term>
-    <term name="director" form="short">导演</term>
+    <term name="collection-editor" form="short">编</term>
     <term name="editor" form="short">编</term>
-    <term name="editor-translator" form="short">编译</term>
-    <term name="editortranslator" form="short">编译</term>
-    <term name="editorial-director" form="short">主编</term>
-    <term name="executive-producer" form="short">监制</term>
-    <term name="illustrator" form="short">绘</term>
-    <term name="narrator" form="short">朗读</term>
-    <term name="organizer" form="short">组织</term>
-    <term name="performer" form="short">表演</term>
-    <term name="producer" form="short">制片人</term>
-    <term name="script-writer" form="short">编剧</term>
-    <term name="series-creator" form="short">创作</term>
+    <term name="editorial-director" form="short">总编</term>
     <term name="translator" form="short">译</term>
 
     <!-- VERB ROLE FORMS -->
-    <term name="chair" form="verb">主席</term>
-    <term name="collection-editor" form="verb">总编辑</term>
-    <term name="compiler" form="verb">编撰</term>
-    <term name="container-author" form="verb">著</term>
-    <term name="contributor" form="verb">贡献</term>
-    <term name="curator" form="verb">策展</term>
-    <term name="director" form="verb">指导</term>
-    <term name="editor" form="verb">编辑</term>
-    <term name="editor-translator" form="verb">编译</term>
-    <term name="editortranslator" form="verb">编译</term>
-    <term name="editorial-director" form="verb">主编</term>
-    <term name="executive-producer" form="verb">监制</term>
-    <term name="guest" form="verb">嘉宾</term>
-    <term name="host" form="verb">主持</term>
-    <term name="illustrator" form="verb">绘图</term>
-    <term name="interviewer" form="verb">采访</term>
-    <term name="narrator" form="verb">朗读</term>
-    <term name="organizer" form="verb">组织</term>
-    <term name="performer" form="verb">表演</term>
-    <term name="producer" form="verb">制片</term>
-    <term name="recipient" form="verb">受函</term>
-    <term name="reviewed-author" form="verb">校订</term>
-    <term name="script-writer" form="verb">编剧</term>
-    <term name="series-creator" form="verb">创作</term>
-    <term name="translator" form="verb">翻译</term>
+    <term name="composer" form="verb">作曲</term>
+    <term name="interviewer" form="verb">采访者</term>
+    <term name="original-author" form="verb">原作者</term>
+    <term name="recipient" form="verb">致</term>
 
     <!-- SHORT VERB ROLE FORMS -->
-    <term name="collection-editor" form="verb-short">总编</term>
-    <term name="compiler" form="verb-short">编</term>
-    <term name="contributor" form="verb-short">贡献</term>
-    <term name="curator" form="verb-short">策展</term>
-    <term name="director" form="verb-short">导</term>
+    <term name="collection-editor" form="verb-short">编</term>
     <term name="editor" form="verb-short">编</term>
-    <term name="editor-translator" form="verb-short">编译</term>
-    <term name="editortranslator" form="verb-short">编译</term>
-    <term name="editorial-director" form="verb-short">主编</term>
-    <term name="executive-producer" form="verb-short">监制</term>
-    <term name="guest" form="verb-short">嘉宾</term>
-    <term name="host" form="verb-short">主持</term>
-    <term name="illustrator" form="verb-short">绘</term>
-    <term name="narrator" form="verb-short">朗读</term>
-    <term name="organizer" form="verb-short">组织</term>
-    <term name="performer" form="verb-short">表演</term>
-    <term name="producer" form="verb-short">制片</term>
-    <term name="reviewed-author" form="verb-short">校</term>
-    <term name="script-writer" form="verb-short">编剧</term>
-    <term name="series-creator" form="verb-short">创作</term>
+    <term name="editorial-director" form="verb-short">总编</term>
     <term name="translator" form="verb-short">译</term>
 
     <!-- LONG MONTH FORMS -->


### PR DESCRIPTION
## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Notable changes:

1. Added references to style guides in comments.
    - GB/T 7714: The Chinese national standard [*Information and documentation—Rules for bibliographic references and citations to information resources*](https://std.samr.gov.cn/gb/search/gbDetailed?id=4507EFE13D37CB6AE06397BE0A0A601F)
    - Manual of Legal Citations 法学引注手册 (the Chinese Bluebook)
    - Social Sciences in China 中国社会科学 (periodical)
    - Acta Psychologica Sinica 心理学报 (periodical)
2. Most short forms of Chinese terms are identical to their long forms. Therefore, the duplicates have been removed.
3. In CSL, historical era terms are placed after the year (e.g., 221 BC), whereas in Chinese convention they are placed before the year (e.g., 公元前 221 年). Therefore, these terms have been reverted to Latin forms, which are also acceptable in Chinese.
4. In Chinese, there are two sets of punctuation marks: quotation marks (`“ ” ‘ ’`) and book title marks (`《 〈 〉 》`). They have different semantic meanings and cannot be used interchangeably. The locale currently uses book title marks but the drawback is that quotation marks in CSL titles are incorrectly converted to book title marks, even the CSL style does not specify `quotes="true"`. Considering quotation marks are more common in reference titles than book title marks, I've changed the quote terms to quotation marks.
5. Both em dashes and wave dashes are used in ranges, with the latter being preferable for numeric ones. However in the filed of citation styles, em dashes are more commonly used in page ranges.
6. The changes in the PR have been tested with Chinese styles <https://github.com/zotero-chinese/styles> so that they don't cause errors.
8. Both translator names "韩小土" and "韩敏义" belong to @redleafnew. He prefers to keep ther former one.


### Checklist

- [x] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
- [x] Check that you've updated the date under `<updated>` in the `<info>` block. Be sure to preserve the original date-time formatting (for example, `2025-09-22T22:06:38+00:00`)
- [x] If possible, please include references to dictionaries, style guides, or similar that inform your translations (see the en_US locale for examples). This helps us to keep locales up to date over time.
