### PR TITLE
Update locales-en-GB.xml

### DIFF
--- a/locales-en-GB.xml
+++ b/locales-en-GB.xml
@@ -142,7 +142,7 @@
     <term name="document">document</term>
     <term name="entry">entry</term>
     <term name="entry-dictionary">dictionary entry</term>
-    <term name="entry-encyclopedia">encyclopedia entry</term>
+    <term name="entry-encyclopedia">encyclopaedia entry</term>
     <term name="event">event</term>
     <!-- figure is in the list of locator terms -->
     <term name="graphic">graphic</term>
@@ -655,8 +655,8 @@
       <multiple>narrators</multiple>
     </term>
     <term name="organizer">
-      <single>organizer</single>
-      <multiple>organizers</multiple>
+      <single>organiser</single>
+      <multiple>organisers</multiple>
     </term>
     <term name="original-author"/> <!-- generally blank -->
     <term name="performer">
@@ -783,7 +783,7 @@
     <term name="illustrator" form="verb">illustrated by</term>
     <term name="interviewer" form="verb">interview by</term>
     <term name="narrator" form="verb">read by</term> <!-- verb role form in Oxford Style Manual, MHRA -->
-    <term name="organizer" form="verb">organized by</term>
+    <term name="organizer" form="verb">organised by</term>
     <term name="original-author" form="verb">by</term>
     <term name="performer" form="verb">performed by</term>
     <term name="producer" form="verb">produced by</term>


### PR DESCRIPTION
Changed spelling of encyclopaedia and organiser. I understand that the NODWE uses -ize spelling, but this is en-GB, not en-GB-oxendict, so I maintain that a more standardised (albeit non-Oxford) spelling should be adopted. I also entirely support adding the en-GB-oxendict locale.

## CSL Locales Pull Request Template

You're about to create a pull request to the CSL locales repository.
If you haven't done so already, see <http://docs.citationstyles.org/en/stable/translating-locale-files.html> for instructions on how to translate CSL locale files, and <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> on how to submit your changes.
In addition, please fill out the pull request template below.

### Description

Briefly describe the changes you're proposing.

### Checklist

- [ ] Check that you're listed as a `<translator>` in the `<info>` block at the beginning of the file.
- [ ] Check that you've updated the date under `<updated>` in the `<info>` block. Be sure to preserve the original date-time formatting (for example, `2025-09-22T22:06:38+00:00`)
- [ ] If possible, please include references to dictionaries, style guides, or similar that inform your translations (see the en_US locale for examples). This helps us to keep locales up to date over time. 
